### PR TITLE
Bugfix: changed attachment URL generation

### DIFF
--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -235,7 +235,7 @@ class WPSEO_News_Sitemap {
 			'caption'     => $attachment->post_excerpt,
 			'description' => $attachment->post_content,
 			'href'        => get_permalink( $attachment->ID ),
-			'src'         => $attachment->guid,
+			'src'         => wp_get_attachment_url( $attachment->ID ),
 			'title'       => $attachment->post_title,
 		);
 	}


### PR DESCRIPTION
$attachment->guid is not necessarily the actual image URL and should not
used to extract an attachment image URL.

I changed the code to use the function wp_get_attachment_url() which is
the documented way to get an URL for an attachment.

References:

http://pods.io/2013/07/17/dont-use-the-guid-field-ever-ever-ever/
http://codex.wordpress.org/Function_Reference/wp_get_attachment_url