### PR TITLE
Removing the options property

### DIFF
--- a/classes/class-meta-box.php
+++ b/classes/class-meta-box.php
@@ -2,13 +2,14 @@
 
 class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 
-	private $options;
-
 	/**
 	 * @var int    The maximum number of standout tags allowed.
 	 */
 	private $max_standouts = 7;
 
+	/**
+	 * Constructing the object.
+	 */
 	public function __construct() {
 		$this->options = WPSEO_News::get_options();
 


### PR DESCRIPTION
Just because the parent has already one.

Edit: 
Fixes #165 