### PR TITLE
Hooking on the right action to be sure the post is loaded at that point.

### DIFF
--- a/classes/class-meta-box.php
+++ b/classes/class-meta-box.php
@@ -13,7 +13,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 		$this->options = WPSEO_News::get_options();
 
 		add_filter( 'wpseo_save_metaboxes', array( $this, 'save' ), 10, 1 );
-		add_action( 'admin_init', array( $this, 'add_tab_hooks' ) );
+		add_action( 'add_meta_boxes', array( $this, 'add_tab_hooks' ) );
 		add_filter( 'add_extra_wpseo_meta_fields', array( $this, 'add_meta_fields_to_wpseo_meta' ) );
 	}
 


### PR DESCRIPTION
The post wasn't there because we hook to early. Please verify for side effects on this.

Fixes #164 