### PR TITLE
Remove query call on all pages except post edit

### DIFF
--- a/classes/class-meta-box.php
+++ b/classes/class-meta-box.php
@@ -10,11 +10,16 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	private $max_standouts = 7;
 
 	public function __construct() {
+		global $pagenow;
+
 		$this->options = WPSEO_News::get_options();
 
 		add_filter( 'wpseo_save_metaboxes', array( $this, 'save' ), 10, 1 );
 		add_action( 'add_meta_boxes', array( $this, 'add_tab_hooks' ) );
-		add_filter( 'add_extra_wpseo_meta_fields', array( $this, 'add_meta_fields_to_wpseo_meta' ) );
+
+		if ( $pagenow === 'post.php' || $pagenow === 'post-new.php' ) {
+			add_filter( 'add_extra_wpseo_meta_fields', array( $this, 'add_meta_fields_to_wpseo_meta' ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #145 

When the meta box got registered, it did a query for the description.
This is unnecessary on all pages except post edit page.

One concern with this solution is, if there would be default values in
the metabox registration, the defaults wouldn't be taken into account
when getting the values. But because News SEO doesn't have any defaults,
this is not an issue.