### PR TITLE
wpseo_admin_pages is no longer being used in Yoast SEO. So it can be removed

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -63,8 +63,6 @@ class WPSEO_News {
 		// Add subitem to menu
 		add_filter( 'wpseo_submenu_pages', array( $this, 'add_submenu_pages' ) );
 
-		// Add Redirect page as admin page
-		add_filter( 'wpseo_admin_pages', array( $this, 'add_admin_pages' ) );
 
 		// Register settings
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
@@ -199,18 +197,6 @@ class WPSEO_News {
 		return $submenu_pages;
 	}
 
-	/**
-	 * Add admin page to admin_pages so the correct assets are loaded by WPSEO
-	 *
-	 * @param $admin_pages
-	 *
-	 * @return array
-	 */
-	public function add_admin_pages( $admin_pages ) {
-		$admin_pages[] = 'wpseo_news';
-
-		return $admin_pages;
-	}
 
 	/**
 	 * Enqueue admin page JS


### PR DESCRIPTION
related to https://github.com/Yoast/wordpress-seo-local/issues/458#issuecomment-188829155
Just like in Local SEO, this filter is no longer relevant.