### PR TITLE
Add i18n module for News

### DIFF
--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -2,15 +2,21 @@
 
 class WPSEO_News_Admin_Page {
 
+	private $options;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->options = WPSEO_News::get_options();
+
+		$this->register_i18n_promo_class();
+	}
+
 	/**
 	 * Display admin page
 	 */
 	public function display() {
-		// Load options
-		$options = WPSEO_News::get_options();
-
-		$this->register_i18n_promo_class();
-
 		// Admin header
 		WPSEO_News_Wrappers::admin_header( true, 'yoast_wpseo_news_options', 'wpseo_news' );
 
@@ -49,6 +55,26 @@ class WPSEO_News_Admin_Page {
 	}
 
 	/**
+	 * Register the promotion class for our GlotPress instance.
+	 *
+	 * @link https://github.com/Yoast/i18n-module
+	 */
+	protected function register_i18n_promo_class() {
+		new yoast_i18n(
+			array(
+				'textdomain'     => 'yoast-video-seo',
+				'project_slug'   => 'yoast-video-seo',
+				'plugin_name'    => 'WordPress SEO News',
+				'hook'           => 'yoast_news_seo_admin_footer',
+				'glotpress_url'  => 'http://translate.yoast.com/gp/',
+				'glotpress_name' => 'Yoast Translate',
+				'glotpress_logo' => 'http://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',
+				'register_url'   => 'http://translate.yoast.com/gp/projects#utm_source=plugin&utm_medium=promo-box&utm_campaign=wpseo-news-i18n-promo',
+			)
+		);
+	}
+
+	/**
 	 * Generate HTML for the keywords which will be defaulted
 	 */
 	private function default_keywords() {
@@ -75,8 +101,7 @@ class WPSEO_News_Admin_Page {
 	 * Generate HTML for excluding post categories
 	 */
 	private function excluded_post_categories() {
-		$options = WPSEO_News::get_options();
-		if ( isset( $options['newssitemap_include_post'] ) ) {
+		if ( isset( $this->options['newssitemap_include_post'] ) ) {
 			echo '<h2>' . __( 'Post categories to exclude', 'wordpress-seo-news' ) . '</h2>';
 			foreach ( get_categories() as $cat ) {
 				echo WPSEO_News_Wrappers::checkbox( 'catexclude_' . $cat->slug, $cat->name . ' (' . $cat->count . ' posts)', false );
@@ -91,35 +116,14 @@ class WPSEO_News_Admin_Page {
 		echo '<h2>' . __( "Editors' Pick", 'wordpress-seo-news' ) . '</h2>';
 
 		$esc_form_key = 'ep_image_src';
-		$options      = WPSEO_News::get_options();
 
 		echo '<label class="select" for="' . $esc_form_key . '">' . __( "Editors' Pick Image", 'wordpress-seo-news' ) . ':</label>';
-		echo '<input id="' . $esc_form_key . '" type="text" size="36" name="wpseo_news[' . $esc_form_key . ']" value="' . esc_attr( $options[ $esc_form_key ] ) . '" />';
+		echo '<input id="' . $esc_form_key . '" type="text" size="36" name="wpseo_news[' . $esc_form_key . ']" value="' . esc_attr( $this->options[ $esc_form_key ] ) . '" />';
 		echo '<input id="' . $esc_form_key . '_button" class="wpseo_image_upload_button button" type="button" value="' . __( 'Upload Image', 'wordpress-seo-news' ) . '" />';
 		echo '<br class="clear"/>';
 
 		echo '<p>' . sprintf( __( 'You can find your Editors\' Pick RSS feed here: %1$sEditors\' Pick RSS Feed%2$s', 'wordpress-seo-news' ), "<a target='_blank' class='button-secondary' href='" . home_url( 'editors-pick.rss' ) . "'>", '</a>' ) . '</p>';
 		echo '<p>' . sprintf( __( 'You can submit your Editors\' Pick RSS feed here: %1$sSubmit Editors\' Pick RSS Feed%2$s', 'wordpress-seo-news' ), "<a class='button-secondary' href='https://support.google.com/news/publisher/contact/editors_picks' target='_blank'>", '</a>' ) . '</p>';
-	}
-
-	/**
-	 * Register the promotion class for our GlotPress instance.
-	 *
-	 * @link https://github.com/Yoast/i18n-module
-	 */
-	private function register_i18n_promo_class() {
-		new yoast_i18n(
-			array(
-				'textdomain'     => 'yoast-video-seo',
-				'project_slug'   => 'yoast-video-seo',
-				'plugin_name'    => 'WordPress SEO News',
-				'hook'           => 'yoast_news_seo_admin_footer',
-				'glotpress_url'  => 'http://translate.yoast.com/gp/',
-				'glotpress_name' => 'Yoast Translate',
-				'glotpress_logo' => 'http://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',
-				'register_url'   => 'http://translate.yoast.com/gp/projects#utm_source=plugin&utm_medium=promo-box&utm_campaign=wpseo-news-i18n-promo',
-			)
-		);
 	}
 }
 

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -62,8 +62,8 @@ class WPSEO_News_Admin_Page {
 	protected function register_i18n_promo_class() {
 		new yoast_i18n(
 			array(
-				'textdomain'     => 'yoast-video-seo',
-				'project_slug'   => 'yoast-video-seo',
+				'textdomain'     => 'wordpress_seo_news',
+				'project_slug'   => 'news-seo',
 				'plugin_name'    => 'WordPress SEO News',
 				'hook'           => 'yoast_news_seo_admin_footer',
 				'glotpress_url'  => 'http://translate.yoast.com/gp/',

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -38,13 +38,14 @@ class WPSEO_News_Admin_Page {
 		// Editors' Pick
 		$this->editors_pick();
 
+		// By removing the action 'wpseo_admin_footer' we make sure the Yoast SEO i18n module isn't loaded.
 		remove_all_actions( 'wpseo_admin_footer' );
 
+		// Load the i18n module for News SEO.
 		do_action( 'yoast_news_seo_admin_footer' );
 
 		// Admin footer
 		WPSEO_News_Wrappers::admin_footer( true, false );
-
 	}
 
 	/**
@@ -101,6 +102,11 @@ class WPSEO_News_Admin_Page {
 		echo '<p>' . sprintf( __( 'You can submit your Editors\' Pick RSS feed here: %1$sSubmit Editors\' Pick RSS Feed%2$s', 'wordpress-seo-news' ), "<a class='button-secondary' href='https://support.google.com/news/publisher/contact/editors_picks' target='_blank'>", '</a>' ) . '</p>';
 	}
 
+	/**
+	 * Register the promotion class for our GlotPress instance.
+	 *
+	 * @link https://github.com/Yoast/i18n-module
+	 */
 	private function register_i18n_promo_class() {
 		new yoast_i18n(
 			array(

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -9,6 +9,8 @@ class WPSEO_News_Admin_Page {
 		// Load options
 		$options = WPSEO_News::get_options();
 
+		$this->register_i18n_promo_class();
+
 		// Admin header
 		WPSEO_News_Wrappers::admin_header( true, 'yoast_wpseo_news_options', 'wpseo_news' );
 
@@ -35,6 +37,10 @@ class WPSEO_News_Admin_Page {
 
 		// Editors' Pick
 		$this->editors_pick();
+
+		remove_all_actions( 'wpseo_admin_footer' );
+
+		do_action( 'yoast_news_seo_admin_footer' );
 
 		// Admin footer
 		WPSEO_News_Wrappers::admin_footer( true, false );
@@ -93,6 +99,21 @@ class WPSEO_News_Admin_Page {
 
 		echo '<p>' . sprintf( __( 'You can find your Editors\' Pick RSS feed here: %1$sEditors\' Pick RSS Feed%2$s', 'wordpress-seo-news' ), "<a target='_blank' class='button-secondary' href='" . home_url( 'editors-pick.rss' ) . "'>", '</a>' ) . '</p>';
 		echo '<p>' . sprintf( __( 'You can submit your Editors\' Pick RSS feed here: %1$sSubmit Editors\' Pick RSS Feed%2$s', 'wordpress-seo-news' ), "<a class='button-secondary' href='https://support.google.com/news/publisher/contact/editors_picks' target='_blank'>", '</a>' ) . '</p>';
+	}
+
+	private function register_i18n_promo_class() {
+		new yoast_i18n(
+			array(
+				'textdomain'     => 'yoast-video-seo',
+				'project_slug'   => 'yoast-video-seo',
+				'plugin_name'    => 'WordPress SEO News',
+				'hook'           => 'yoast_news_seo_admin_footer',
+				'glotpress_url'  => 'http://translate.yoast.com/gp/',
+				'glotpress_name' => 'Yoast Translate',
+				'glotpress_logo' => 'http://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',
+				'register_url'   => 'http://translate.yoast.com/gp/projects#utm_source=plugin&utm_medium=promo-box&utm_campaign=wpseo-news-i18n-promo',
+			)
+		);
 	}
 }
 

--- a/tests/test-class-admin-page.php
+++ b/tests/test-class-admin-page.php
@@ -43,4 +43,19 @@ EOT;
 
 	}
 
+	/**
+	 * Make sure 'register_i18n_promo_class' function is called.
+	 *
+	 * @covers WPSEO_News_Admin_Page::__construct
+	 */
+	public function test_call_i18n_module() {
+		$class_instance = $this->getMock( 'WPSEO_News_Admin_Page', array( 'register_i18n_promo_class' ) );
+
+		$class_instance->expects( $this->once() )
+			->method( 'register_i18n_promo_class' );
+
+		$class_instance->__construct();
+
+	}
+
 }

--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -52,7 +52,6 @@ function __wpseo_news_main() {
 add_action( 'plugins_loaded', '__wpseo_news_main' );
 
 /**
-<<<<<<< HEAD
  * Clear the news sitemap.
  */
 function yoast_wpseo_news_clear_sitemap_cache() {


### PR DESCRIPTION
Fixes #191 

Currently the Translation box for the addons is always showing the Yoast SEO translation box, if Yoast SEO itself isn't fully translated yet in the language that is selected.

Ideally we want to show the News Translation box, as the translation box will not be shown if Yoast SEO is fully translated, even though News isn't yet (fully) translated, as shown below. This pull fixes that. 

<img width="683" alt="schermafbeelding 2016-03-03 om 17 34 28" src="https://cloud.githubusercontent.com/assets/8614579/13501165/e34c482c-e165-11e5-9629-f4fb739f7f94.png">

### For acceptance testing
Languages to test with:
Yoast SEO fully translated - News SEO partially/not: choose Catalan for language.
Yoast SEO not fully translated - News SEO not fully translated: choose for example Nederlands (Formeel)