### PR TITLE
Fix Shiny Update routine

### DIFF
--- a/classes/class-product.php
+++ b/classes/class-product.php
@@ -6,15 +6,19 @@
 class WPSEO_News_Product extends Yoast_Product {
 
 	public function __construct() {
+		$file = plugin_basename( WPSEO_NEWS_FILE );
+		$slug = dirname( $file );
+
 		parent::__construct(
 			'http://yoast.com/edd-sl-api',
 			'News SEO',
-			plugin_basename( WPSEO_NEWS_FILE ),
+			$slug,
 			WPSEO_News::VERSION,
 			'https://yoast.com/wordpress/plugins/news-seo/',
 			'admin.php?page=wpseo_licenses#top#licenses',
 			'wordpress-seo-news',
-			'Yoast'
+			'Yoast',
+			$file
 		);
 	}
 


### PR DESCRIPTION
Implemented slug and file parameters of the License Manager to facilitate Shiny Update routine to work.

See https://github.com/Yoast/wordpress-seo-premium/issues/274