### PR TITLE
Disable Newrelic Monitoring script injection

### DIFF
--- a/assets/xml-news-sitemap-xsl.php
+++ b/assets/xml-news-sitemap-xsl.php
@@ -1,7 +1,7 @@
-<?php if ( extension_loaded('newrelic') ) {
+<?php if ( extension_loaded( 'newrelic' ) ) {
 	newrelic_disable_autorum();
 	newrelic_ignore_transaction();
-	}
+}
 echo '<?xml version="1.0" encoding="UTF-8"?>'?>
 <xsl:stylesheet version="2.0"
 	xmlns:html="http://www.w3.org/TR/REC-html40"

--- a/assets/xml-news-sitemap-xsl.php
+++ b/assets/xml-news-sitemap-xsl.php
@@ -1,8 +1,8 @@
-<?php if (extension_loaded('newrelic')) {
+<?php if ( extension_loaded('newrelic') ) {
 	newrelic_disable_autorum();
 	newrelic_ignore_transaction();
-}?>
-<?php echo '<?xml version="1.0" encoding="UTF-8"?>'?>
+	}
+echo '<?xml version="1.0" encoding="UTF-8"?>'?>
 <xsl:stylesheet version="2.0"
 	xmlns:html="http://www.w3.org/TR/REC-html40"
 	xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"

--- a/assets/xml-news-sitemap-xsl.php
+++ b/assets/xml-news-sitemap-xsl.php
@@ -1,3 +1,7 @@
+<?php if (extension_loaded('newrelic')) {
+	newrelic_disable_autorum();
+	newrelic_ignore_transaction();
+}?>
 <?php echo '<?xml version="1.0" encoding="UTF-8"?>'?>
 <xsl:stylesheet version="2.0"
 	xmlns:html="http://www.w3.org/TR/REC-html40"


### PR DESCRIPTION
Disable Newrelic PHP Agent to inject a script in the news-sitemap.xsl file breaking it. If the newrelic phpagent is installed it will be disabled for this file, if it is not installed it will not do anything.

This code is based on this documentation:

https://docs.newrelic.com/docs/browser/new-relic-browser/troubleshooting/google-amp-validator-fails-due-3rd-party-script