### PR TITLE
updated helpscout interface

### DIFF
--- a/classes/class-beacon-setting.php
+++ b/classes/class-beacon-setting.php
@@ -43,4 +43,15 @@ class WPSEO_News_Beacon_Setting implements Yoast_HelpScout_Beacon_Setting {
 
 		return array();
 	}
+
+	/**
+	 * Returns a list of config values for a a certain admin page.
+	 *
+	 * @param string $page The current admin page we are on.
+	 *
+	 * @return array A list with configuration for the beacon
+	 */
+	public function get_config( $page ){
+		return array();
+	}
 }

--- a/classes/class-beacon-setting.php
+++ b/classes/class-beacon-setting.php
@@ -51,7 +51,7 @@ class WPSEO_News_Beacon_Setting implements Yoast_HelpScout_Beacon_Setting {
 	 *
 	 * @return array A list with configuration for the beacon
 	 */
-	public function get_config( $page ){
+	public function get_config( $page ) {
 		return array();
 	}
 }


### PR DESCRIPTION
`get_config( $page  )` will be added to the `Yoast_HelpScout_Beacon_Setting` interface to alter the help scout beacon's configuration. This allows for all instances of the help scout beacon to be set up differently. ([possible values](http://developer.helpscout.net/beacons/customization/#config-configobject-))