### PR TITLE
Publishdate w3c format

### DIFF
--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -15,7 +15,7 @@ class WPSEO_News_Admin_Page {
 		}
 
 		// When the timezone is an empty string.
-		if( get_option( 'timezone_string' ) === '' ) {
+		if ( get_option( 'timezone_string' ) === '' ) {
 			$this->add_timezone_notice();
 		}
 
@@ -157,7 +157,6 @@ class WPSEO_News_Admin_Page {
 		$notification_center = Yoast_Notification_Center::get();
 		$notification_center->add_notification( $timezone_notification );
 	}
-
 }
 
 class WPSEO_News_Wrappers {

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -13,6 +13,12 @@ class WPSEO_News_Admin_Page {
 		if ( $this->is_news_page( filter_input( INPUT_GET, 'page' ) ) ) {
 			$this->register_i18n_promo_class();
 		}
+
+		// When the timezone is an empty string.
+		if( get_option( 'timezone_string' ) === '' ) {
+			$this->add_timezone_notice();
+		}
+
 	}
 
 	/**
@@ -134,6 +140,24 @@ class WPSEO_News_Admin_Page {
 
 		return in_array( $page, $news_pages );
 	}
+
+	/**
+	 * Shows a notice when the timezone is in UTC format.
+	 */
+	private function add_timezone_notice() {
+		$notification         = __( 'Your timezone settings should reflect your real timezone, not a UTC offset, please change this.', 'wpseo-news' );
+		$notification_options = array(
+			'type'         => Yoast_Notification::ERROR,
+			'id'           => 'wpseo-dismiss-news_timezone-notice',
+			'capabilities' => 'manage_options',
+		);
+
+		$timezone_notification = new Yoast_Notification( $notification, $notification_options );
+
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->add_notification( $timezone_notification );
+	}
+
 }
 
 class WPSEO_News_Wrappers {

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -560,7 +560,7 @@ class WPSEO_News_Sitemap_Item {
 	private function get_date_format() {
 		static $timezone_option;
 
-		if( $timezone_option === null ) {
+		if ( $timezone_option === null ) {
 			// When there isn't a timezone set
 			$timezone_option = get_option( 'timezone_string' );
 		}

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -539,7 +539,6 @@ class WPSEO_News_Sitemap_Item {
 	 * @return string
 	 */
 	private function format_date_with_timezone( $item_date ) {
-
 		static $timezone_string;
 
 		if ( $timezone_string === null ) {
@@ -550,7 +549,28 @@ class WPSEO_News_Sitemap_Item {
 		// Create a DateTime object date in the correct timezone.
 		$datetime = new DateTime( $item_date, new DateTimeZone( $timezone_string ) );
 
-		return $datetime->format( 'c' );
+		return $datetime->format( $this->get_date_format() );
+	}
+
+	/**
+	 * When the timezone string option in WordPress is empty, just return YYYY-MM-DD as format.
+	 *
+	 * @return string
+	 */
+	private function get_date_format() {
+		static $timezone_option;
+
+		if( $timezone_option === null ) {
+			// When there isn't a timezone set
+			$timezone_option = get_option( 'timezone_string' );
+		}
+
+		// Is there a timezone option and does it exists in the list of 'valid' timezone.
+		if ( $timezone_option !== '' && in_array( $timezone_option, DateTimeZone::listIdentifiers() ) ) {
+			return DateTime::W3C;
+		}
+
+		return 'Y-m-d';
 	}
 
 	/**

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -89,7 +89,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output .= "\t\t\t<news:name><![CDATA[Test Blog]]></news:name>\n";
 		$expected_output .= "\t\t\t<news:language>en</news:language>\n";
 		$expected_output .= "\t\t</news:publication>\n";
-		$expected_output .= "\t\t<news:publication_date>" . get_the_date( 'c', $post_id ) . "</news:publication_date>\n";
+		$expected_output .= "\t\t<news:publication_date>" . get_the_date( 'Y-m-d', $post_id ) . "</news:publication_date>\n";
 		$expected_output .= "\t\t<news:title><![CDATA[generate rss]]></news:title>\n";
 		$expected_output .= "\t\t<news:keywords><![CDATA[]]></news:keywords>\n";
 		$expected_output .= "\t</news:news>\n";


### PR DESCRIPTION
The publishdate should be in W3C format when the timezone is set in UTC-format. When the timezone is set in UTC format, give the user a notice.

Fixes #112