### PR TITLE
Make xsl rewrite rule more specific

### DIFF
--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -71,7 +71,9 @@ class WPSEO_News_Sitemap {
 
 			$GLOBALS['wpseo_sitemaps']->register_sitemap( $this->basename, array( $this, 'build' ) );
 			if ( method_exists( $GLOBALS['wpseo_sitemaps'], 'register_xsl' ) ) {
-				$GLOBALS['wpseo_sitemaps']->register_xsl( $this->basename, array( $this, 'build_news_sitemap_xsl' ), $this->basename );
+				$xsl_rewrite_rule = sprintf( '^%s-sitemap.xsl$', $this->basename );
+
+				$GLOBALS['wpseo_sitemaps']->register_xsl( $this->basename, array( $this, 'build_news_sitemap_xsl' ), $xsl_rewrite_rule );
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where a page or post type with the slug `news` would be inaccessible.

## Relevant technical choices:

The rewrite rule would just be `news` or `yoast-news` which is far too broad for only targeting the news sitemap xsl. Improve this by adding `-sitemap.xml` after the basename and also surrounding with ^ and $.

## Test instructions

This PR can be tested by following these steps:

* Have a post that starts with `news`.
* Go to that post.
* Observe that it doesn't work.

Other test cases that should be tested because of full coverage

* Testing with a post type that has a slug of `news`. (Making sure that the sitemap is now at `yoast-news-sitemap.xml`)

## Known bugs

#251 is a known bug that is also introduced in 3.5 but has a lesser severity.

Fixes #248