### PR TITLE
Add wpseo_news_set_item filter to set_item function

### DIFF
--- a/classes/class-sitemap-editors-pick.php
+++ b/classes/class-sitemap-editors-pick.php
@@ -117,13 +117,15 @@ class WPSEO_News_Sitemap_Editors_Pick {
 	 * Add a single item to $this->items
 	 */
 	private function set_item() {
-		$this->items[] = array(
+		$wpseo_news_item = apply_filters( 'wpseo_news_set_item', array(
 			'title'        => get_the_title(),
 			'link'         => get_permalink(),
 			'description'  => get_the_excerpt(),
 			'creator'      => get_the_author_meta( 'display_name' ),
 			'published_on' => get_the_date( DATE_RFC822 ),
-		);
+		) );
+
+		$this->items[] = $wpseo_news_item;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Add `wpseo_news_set_item` filter to `set_item` function

## Relevant technical choices:

* This filter allows modification of the feed item

## Test instructions

This PR can be tested by following these steps:

* Include `add_filter( 'wpseo_news_set_item', 'wpseo_news_set_item_textdomain' )` in theme's functions.php
* Include `wpseo_news_set_item_textdomain` function in theme's functions.php

```
function wpseo_news_set_item_textdomain( $item ) {
  if ( /* condition */ ) {
    $item['creator'] = 'condition';
  }

  return $item;
}
```

```
function wpseo_news_set_item_textdomain( $item ) {
  if ( $author_byline = get_post_meta( get_the_ID(), '_author_byline', true ) ) {
    $item['creator'] = $author_byline;
  }

  return $item;
}
```

## Fixes

Allows theme's with an author byline to filter the author's name in the `editors-pick.rss`