### PR TITLE
Invalides only on supported Post Types

### DIFF
--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -88,6 +88,11 @@ class WPSEO_News_Sitemap {
 		if ( wp_is_post_revision( $post_id ) ) {
 			return;
 		}
+		
+		// Only invalidate when we are in a News Post Type object.
+		if ( ! in_array( get_post_type( $post_id ), WPSEO_News::get_included_post_types() ) ) {
+			return;
+		}
 
 		wpseo_invalidate_sitemap_cache( $this->basename );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Only invalidate sitemap cache when an object in a Post Type that is marked as News is updated.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Before this patch 'Pages' triggered News sitemap invalidations, with the patch applied they should not (unless manually configured in the News SEO options)

Fixes https://github.com/Yoast/wpseo-news/issues/271
