### PR TITLE
Fixed tests throwing deprecated warning

### DIFF
--- a/tests/test-class-sitemap-editors-pick.php
+++ b/tests/test-class-sitemap-editors-pick.php
@@ -29,6 +29,7 @@ class WPSEO_News_Sitemap_Editors_Pick_Test extends WPSEO_News_UnitTestCase {
 
 	/**
 	 * @covers WPSEO_News_Sitemap_Editors_Pick::generate_rss
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_generate_rss() {
 		// The date in XML format

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -27,6 +27,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 
 	/**
 	 * @covers WPSEO_News_Sitemap::add_to_index
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_add_to_index() {
 
@@ -72,6 +73,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_NOT_empty() {
 		$post_id = $this->factory->post->create( array(
@@ -102,6 +104,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_post_excluded() {
 		// Create post
@@ -125,6 +128,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added with keywords
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITH_keywords() {
 		// Create post
@@ -146,6 +150,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added with only a single tag
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITH_tags() {
 		// Create post
@@ -168,6 +173,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added and there is are default keywords present
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITH_default_keywords() {
 
@@ -195,6 +201,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added with keywords and tags
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITH_keywords_AND_tags() {
 
@@ -221,6 +228,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added with keywords and tags
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITH_tags_AND_default_keywords() {
 		// Create post
@@ -246,6 +254,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added with tags, keywords and default keywords
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITH_keywords_and_default_keywords() {
 
@@ -272,6 +281,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added with keywords and default keywords
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITH_keywords_AND_tags_AND_default_keywords() {
 
@@ -301,6 +311,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if post added with some simular tags, keywords and default keywords
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITH_SIMULAR_keywords_AND_tags_AND_default_keywords() {
 
@@ -331,6 +342,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added with a image in its content
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITH_image() {
 
@@ -354,6 +366,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added with a image in its content
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITHOUT_featured_image_restricted() {
 
@@ -387,6 +400,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Check what happens if there is one post added with a image in its content
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 * @expectedDeprecated wpseo_invalidate_sitemap_cache
 	 */
 	public function test_sitemap_WITH_featured_image_restricted() {
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixes broken tests that throw a deprecated warning.

## Test instructions

This PR can be tested by following these steps:

* Run the tests in PHPUnit / Travis and ensure they pass.

