### PR TITLE
solve dep conflict with yoast/wordpress-seo 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "xrstf/composer-php52": "^1.0.20",
         "yoast/wp-helpscout": "^1.0",
-        "yoast/i18n-module": "^1.2.1"
+        "yoast/i18n-module": "^2.0.1"
     },
     "require-dev": {
         "yoast/yoastcs": "0.3",


### PR DESCRIPTION
Can only install one of: yoast/i18n-module[2.0.1, 1.2.1]

## Summary

This PR can be summarized in the following changelog entry:
solve i18n-module dependency conflict with yoast/wordpress-seo 4.4

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

Fixes #
