### PR TITLE
Add filter for exclude_item_terms to allow custom exclusion

### DIFF
--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -422,7 +422,8 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
-		if ( 'post' === $this->item->post_type && $this->exclude_item_terms() ) {
+		$exclude_item = $this->exclude_item_terms() || apply_filters( 'wpseo_news_sitemap_exclude_item', false, $this->item->ID );
+		if ( 'post' === $this->item->post_type && $exclude_item ) {
 			return true;
 		}
 


### PR DESCRIPTION
In order to exclude/include posts by custom criteria (for example, tags), this
patch adds a filter named 'wpseo_news_sitemap_exclude_item' that can be used to
control exclusion.
Fixes #292 
