### PR TITLE
Ignore the sticky posts

### DIFF
--- a/classes/class-sitemap-editors-pick.php
+++ b/classes/class-sitemap-editors-pick.php
@@ -88,6 +88,7 @@ class WPSEO_News_Sitemap_Editors_Pick {
 			array(
 				'post_type'   => WPSEO_News::get_included_post_types(),
 				'post_status' => 'publish',
+				'ignore_sticky_posts' => 1,
 				'meta_query'  => array(
 					array(
 						'key'   => '_yoast_wpseo_newssitemap-editors-pick',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* [Bugfix] Fixes a bug where sticky posts show up in the editors pick

## Relevant technical choices:

* Ignore the sticky posts

## Test instructions

This PR can be tested by following these steps:

* Follow the steps in the issue and see this pull fixes the issue.

Fixes #296 
