### PR TITLE
Set value later, when value is needed.

### DIFF
--- a/classes/class-meta-box.php
+++ b/classes/class-meta-box.php
@@ -154,14 +154,29 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	public function content() {
 		// Build tab content
 		$content = '';
+		
+		foreach ( $this->get_meta_boxes() as $meta_key => $meta_box ) {
+			$meta_box = $this->before_do_meta_box( $meta_key, $meta_box );
 
-		$metaboxes = $this->get_meta_boxes();
-		$metaboxes['newssitemap-standout']['description'] = $this->standout_description();
-
-		foreach ( $metaboxes as $meta_key => $meta_box ) {
 			$content .= $this->do_meta_box( $meta_box, $meta_key );
 		}
 		$this->do_tab( 'news', __( 'Google News', 'wordpress-seo-news' ), $content );
+	}
+
+	/**
+	 * Alters the metabox values if needed.
+	 *
+	 * @param string      $meta_key The key of the metabox field.
+	 * @param array|mixed $meta_box The values for the metabox.
+	 *
+	 * @return mixed The altered value.
+	 */
+	protected function before_do_meta_box( $meta_key, $meta_box ) {
+		if ( $meta_key === 'newssitemap-standout' ) {
+			$meta_box['description'] = $this->standout_description();
+		}
+
+		return $meta_box;
 	}
 
 	/**

--- a/classes/class-meta-box.php
+++ b/classes/class-meta-box.php
@@ -74,7 +74,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 				'type'        => 'checkbox',
 				'title'       => __( 'Standout', 'wordpress-seo-news' ),
 				'expl'        => __( 'Use the standout tag', 'wordpress-seo-news' ),
-				'description' => $this->standout_description(),
+				'description' => '', // This value is rendered when metabox will be displayed.
 			),
 			'newssitemap-editors-pick' => array(
 				'name'        => 'newssitemap-editors-pick',
@@ -154,7 +154,11 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	public function content() {
 		// Build tab content
 		$content = '';
-		foreach ( $this->get_meta_boxes() as $meta_key => $meta_box ) {
+
+		$metaboxes = $this->get_meta_boxes();
+		$metaboxes['newssitemap-standout']['description'] = $this->standout_description();
+
+		foreach ( $metaboxes as $meta_key => $meta_box ) {
 			$content .= $this->do_meta_box( $meta_box, $meta_key );
 		}
 		$this->do_tab( 'news', __( 'Google News', 'wordpress-seo-news' ), $content );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* [Bug][Compatibility] Fixes a incompatibility bug for Piklist, bbPress andLiveblog (Automattic)

## Relevant technical choices:

* The `WP_Query` was executed too early, so set the value that relies on it later.

## Test instructions

This PR can be tested by following these steps:
* The pull fixes some errors with the PikList #262, Liveblog #242 and bbPress #243 plugins
* Follow each step below for each plugin
* Checkout `trunk`
* Follow the steps to reproduce the issue in the mentioned issues
* Checkout this branch
* Follow the steps again and see it being solved

Fixes #262
Fixes #242
Fixes #243 