### PR TITLE
Deprecate method for getting the sitemap name.

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -347,20 +347,16 @@ class WPSEO_News {
 	/**
 	 * Getting the name for the sitemap, if $full_path is true, it will return the full path
 	 *
+	 * @deprecated 5.2
+	 *
 	 * @param bool $full_path
 	 *
 	 * @return string mixed
 	 */
 	public static function get_sitemap_name( $full_path = true ) {
-		// This filter is documented in classes/class-sitemap.php
-		$sitemap_name = apply_filters( 'wpseo_news_sitemap_name', 'news' );
+		_deprecated_function( 'WPSEO_News::get_sitemap_name', '5.2', 'WPSEO_News_Sitemap::get_sitemap_name' );
 
-		// When $full_path is true, it will generate a full path
-		if ( $full_path ) {
-			return wpseo_xml_sitemaps_base_url( $sitemap_name . '-sitemap.xml' );
-		}
-
-		return $sitemap_name;
+		return WPSEO_News_Sitemap::get_sitemap_name( $full_path );
 	}
 
 	/**

--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -345,21 +345,6 @@ class WPSEO_News {
 	}
 
 	/**
-	 * Getting the name for the sitemap, if $full_path is true, it will return the full path
-	 *
-	 * @deprecated 5.2
-	 *
-	 * @param bool $full_path
-	 *
-	 * @return string mixed
-	 */
-	public static function get_sitemap_name( $full_path = true ) {
-		_deprecated_function( 'WPSEO_News::get_sitemap_name', '5.2', 'WPSEO_News_Sitemap::get_sitemap_name' );
-
-		return WPSEO_News_Sitemap::get_sitemap_name( $full_path );
-	}
-
-	/**
 	 * Get the newest License Manager available
 	 *
 	 * @return Yoast_Plugin_License_Manager
@@ -374,5 +359,20 @@ class WPSEO_News {
 		$license_manager->setup_hooks();
 
 		return $license_manager;
+	}
+
+	/**
+	 * Getting the name for the sitemap, if $full_path is true, it will return the full path
+	 *
+	 * @deprecated 5.2
+	 *
+	 * @param bool $full_path
+	 *
+	 * @return string mixed
+	 */
+	public static function get_sitemap_name( $full_path = true ) {
+		_deprecated_function( 'WPSEO_News::get_sitemap_name', '5.2', 'WPSEO_News_Sitemap::get_sitemap_name' );
+
+		return WPSEO_News_Sitemap::get_sitemap_name( $full_path );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Deprecated `WPSEO_News::get_sitemap_name` because we have `WPSEO_News_Sitemap::get_sitemap_name` that does the same magic.

## Relevant technical choices:

* This method  `WPSEO_News::get_sitemap_name` was calling a deprecated function. I was replacing the deprecated call by the one that replaces it, but found out there is a similar method (`WPSEO_News_Sitemap::get_sitemap_name`) that does the same. Because of there are no calls to `WPSEO_News::get_sitemap_name` I deprecated it.

## Test instructions

This PR can be tested by following these steps:

* Check if everything stil works.
