### PR TITLE
Updated i18n module and references to the old version

### DIFF
--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -77,7 +77,7 @@ class WPSEO_News_Admin_Page {
 	 * @link https://github.com/Yoast/i18n-module
 	 */
 	protected function register_i18n_promo_class() {
-		new yoast_i18n(
+		new Yoast_I18n_v2(
 			array(
 				'textdomain'     => 'wordpress_seo_news',
 				'project_slug'   => 'news-seo',

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "xrstf/composer-php52": "^1.0.20",
         "yoast/wp-helpscout": "^1.0",
-        "yoast/i18n-module": "^1.2.1"
+        "yoast/i18n-module": "^2.0"
     },
     "require-dev": {
         "yoast/yoastcs": "0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "945e49490516f96006b8748832356dae",
+    "content-hash": "5aeff661298189f5ef38accff70588cd",
     "packages": [
         {
             "name": "xrstf/composer-php52",
@@ -39,22 +39,22 @@
         },
         {
             "name": "yoast/i18n-module",
-            "version": "1.2.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/i18n-module.git",
-                "reference": "3bf8ae3ee1bb1cb7d80a78291c6ad3cbd0ee0711"
+                "reference": "c08da78bba4747dff960e31dda2be46aae6b30e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/3bf8ae3ee1bb1cb7d80a78291c6ad3cbd0ee0711",
-                "reference": "3bf8ae3ee1bb1cb7d80a78291c6ad3cbd0ee0711",
+                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/c08da78bba4747dff960e31dda2be46aae6b30e8",
+                "reference": "c08da78bba4747dff960e31dda2be46aae6b30e8",
                 "shasum": ""
             },
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "i18n-module.php"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -73,7 +73,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2017-02-02T09:36:28+00:00"
+            "time": "2017-02-02T11:32:53+00:00"
         },
         {
             "name": "yoast/wp-helpscout",
@@ -171,7 +171,7 @@
                 "codeclimate",
                 "coverage"
             ],
-            "time": "2017-06-01T13:19:55+00:00"
+            "time": "2017-06-01 13:19:55"
         },
         {
             "name": "guzzle/guzzle",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Updates the `yoast/i18n-module` to the `^2.0` version and changed the reference to the old version.

## Test instructions

This PR can be tested by following these steps:

* Enable the News SEO plugin with this branch.
* Ensure you have a language selected that **isn't** `en_US` and determine that translations show up, assuming the selected language has them.

Replaces #288 
