### PR TITLE
Change to new WPSEO Manage Options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_script:
 - sed -i "s/yourpasswordhere//" wp-tests-config.php
 - mysql -e "CREATE DATABASE wordpress_tests;" -uroot
 - cd "$WP_DEVELOP_DIR/src/wp-content/plugins/$PLUGIN_SLUG"
-- phpenv local 5.6
+- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.6.13; fi
 - composer install --no-interaction
 - composer config-yoastcs
 - phpenv local --unset

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
 #
 - git clone --depth=50 --branch="trunk" https://github.com/Yoast/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
 - cd /tmp/wordpress/src/wp-content/plugins/wordpress-seo
-- phpenv local 5.6
+- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.6.13; fi
 - composer selfupdate 1.0.0 --no-interaction
 - composer install --no-interaction
 - phpenv local --unset

--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -214,7 +214,7 @@ class WPSEO_News {
 			'wpseo_dashboard',
 			'Yoast SEO: News SEO',
 			'News SEO',
-			'manage_options',
+			'wpseo_manage_options',
 			'wpseo_news',
 			array( $admin_page, 'display' ),
 			array( array( $this, 'enqueue_admin_page' ) ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Use the capabilities introduced in Yoast SEO 5.5 for menu registration.

## Test instructions

This PR can be tested by following these steps:

* Apply patch and see the menu item being displayed when the current user has `wpseo_manage_options`
