### PR TITLE
Load xsl stylesheet inline

### DIFF
--- a/assets/xml-news-sitemap-xsl.php
+++ b/assets/xml-news-sitemap-xsl.php
@@ -14,14 +14,6 @@
 			<head>
 				<title>XML News Sitemap</title>
 				<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-				<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-
-				<script type="text/javascript" src="<?php echo plugins_url( 'js/dist/jquery.tablesorter.min.js', WPSEO_FILE ) ?>"></script>
-				<script	type="text/javascript"><![CDATA[
-					jQuery(document).ready(function() {
-				        jQuery("#sitemap").tablesorter( { widgets: ['zebra'] } );
-					});
-				]]></script>
 				<style type="text/css">
 					body {
 						font-family: Helvetica, Arial, sans-serif;
@@ -32,7 +24,7 @@
 						border: none;
 						border-collapse: collapse;
 					}
-					#sitemap tr.odd {
+					#sitemap tbody tr:nth-child( odd ) {
 						background-color: #eee;
 					}
 					#sitemap tbody tr:hover {
@@ -73,7 +65,6 @@
 					}
 					thead th {
 						border-bottom: 1px solid #000;
-						cursor: pointer;
 					}
 				</style>
 			</head>

--- a/assets/xml-news-sitemap.xsl
+++ b/assets/xml-news-sitemap.xsl
@@ -1,7 +1,4 @@
-<?php
-// @codingStandardsIgnoreFile
-?>
-<?php echo '<?xml version="1.0" encoding="UTF-8"?>'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="2.0"
 	xmlns:html="http://www.w3.org/TR/REC-html40"
 	xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -181,7 +181,7 @@ class WPSEO_News_Sitemap {
 	 * @return string
 	 */
 	private function get_stylesheet_line() {
-		$stylesheet_url = "\n" . '<?xml-stylesheet type="text/xsl" href="' . $this->get_xsl_url() . '"?>';
+		$stylesheet_url = "\n" . '<?xml-stylesheet type="text/xsl" href="' . esc_url( $this->get_xsl_url() ) . '"?>';
 
 		return $stylesheet_url;
 	}
@@ -310,7 +310,7 @@ class WPSEO_News_Sitemap {
 			return home_url( $this->basename . '-sitemap.xsl' );
 		}
 
-		return esc_url( plugin_dir_url( WPSEO_NEWS_FILE ) . 'assets/xml-news-sitemap.xsl' );
+		return plugin_dir_url( WPSEO_NEWS_FILE ) . 'assets/xml-news-sitemap.xsl';
 	}
 }
 

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -69,6 +69,7 @@ class WPSEO_News_Sitemap {
 
 			$this->yoast_wpseo_news_schedule_clear();
 
+			// We might consider deprecating/removing this, because we are using a static xsl file.
 			$GLOBALS['wpseo_sitemaps']->register_sitemap( $this->basename, array( $this, 'build' ) );
 			if ( method_exists( $GLOBALS['wpseo_sitemaps'], 'register_xsl' ) ) {
 				$xsl_rewrite_rule = sprintf( '^%s-sitemap.xsl$', $this->basename );
@@ -158,7 +159,8 @@ class WPSEO_News_Sitemap {
 		header( 'Pragma: public' );
 		header( 'Cache-Control: maxage=' . YEAR_IN_SECONDS );
 		header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', ( time() + YEAR_IN_SECONDS ) ) . ' GMT' );
-		require dirname( WPSEO_NEWS_FILE ) . '/assets/xml-news-sitemap-xsl.php';
+
+		echo file_get_contents( dirname( WPSEO_NEWS_FILE ) . '/assets/xml-news-sitemap.xsl' );
 		die();
 	}
 
@@ -179,7 +181,7 @@ class WPSEO_News_Sitemap {
 	 * @return string
 	 */
 	private function get_stylesheet_line() {
-		$stylesheet_url = "\n" . '<?xml-stylesheet type="text/xsl" href="' . home_url( $this->basename . '-sitemap.xsl' ) . '"?>';
+		$stylesheet_url = "\n" . '<?xml-stylesheet type="text/xsl" href="' . esc_url( plugin_dir_url( WPSEO_NEWS_FILE ) . 'assets/xml-news-sitemap.xsl' ) . '"?>';
 
 		return $stylesheet_url;
 	}

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -181,7 +181,7 @@ class WPSEO_News_Sitemap {
 	 * @return string
 	 */
 	private function get_stylesheet_line() {
-		$stylesheet_url = "\n" . '<?xml-stylesheet type="text/xsl" href="' . esc_url( plugin_dir_url( WPSEO_NEWS_FILE ) . 'assets/xml-news-sitemap.xsl' ) . '"?>';
+		$stylesheet_url = "\n" . '<?xml-stylesheet type="text/xsl" href="' . $this->get_xsl_url() . '"?>';
 
 		return $stylesheet_url;
 	}
@@ -294,6 +294,23 @@ class WPSEO_News_Sitemap {
 		}
 
 		return $basename;
+	}
+
+	/**
+	 * Retrieves the XSL URL that should be used in the current environment
+	 *
+	 * When home_url and site_url are not the same, the home_url should be used.
+	 * This is because the XSL needs to be served from the same domain, protocol and port
+	 * as the XML file that is loading it.
+	 *
+	 * @return string The XSL URL that needs to be used.
+	 */
+	protected function get_xsl_url() {
+		if ( home_url() !== site_url() ) {
+			return home_url( $this->basename . '-sitemap.xsl' );
+		}
+
+		return esc_url( plugin_dir_url( WPSEO_NEWS_FILE ) . 'assets/xml-news-sitemap.xsl' );
 	}
 }
 

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -160,7 +160,7 @@ class WPSEO_News_Sitemap {
 		header( 'Cache-Control: maxage=' . YEAR_IN_SECONDS );
 		header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', ( time() + YEAR_IN_SECONDS ) ) . ' GMT' );
 
-		echo file_get_contents( dirname( WPSEO_NEWS_FILE ) . '/assets/xml-news-sitemap.xsl' );
+		readfile( dirname( WPSEO_NEWS_FILE ) . '/assets/xml-news-sitemap.xsl' );
 		die();
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

## Relevant technical choices:

* Load the XSL stylesheet from a static file. This resulted in removing the tablesorter dependency.

## Test instructions

This PR can be tested by following these steps:

* First of all: remove all transients, to make sure no cache has been loaded.
* Checkout trunk
* Open the news sitemap (you might have to add a post to have 'news') and see tablesorting is working
* Remove all transients again
* Checkout this branch and see the table sorting not working.

Whenever the home URL and site URL are set to different values (local.wordpress.test/local.wordpress-home.test) the XSL needs to be loaded via the previously implemented method.
Otherwise the domain, protocol or port will mismatch and the XSL cannot be loaded.
* Configure home URL to be different from site URL and see the XSL being loaded from the home URL base (`{home_url}/news-sitemap.xsl`)

Fixes #334
