### PR TITLE
Don't enqueue jQuery autocomplete.

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -232,8 +232,6 @@ class WPSEO_News {
 		wp_enqueue_media(); // Enqueue files needed for upload functionality.
 		wp_enqueue_script( 'wpseo-news-admin-page', plugins_url( 'assets/admin-page' . $this->file_ext( '.js' ), WPSEO_NEWS_FILE ), array(
 			'jquery',
-			'jquery-ui-core',
-			'jquery-ui-autocomplete',
 		), self::VERSION, true );
 		wp_localize_script( 'wpseo-news-admin-page', 'wpseonews', WPSEO_News_Javascript_Strings::strings() );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

- Remove jQuery UI autocomplete from the enqueued scripts.

## Test instructions

- Verify autocomplete wasn't used in this add-on, see also https://github.com/Yoast/wordpress-seo/pull/8875

Fixes #341 
