### PR TITLE
Cleanup: Removed deprecated functions from before 4.0.

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -31,19 +31,6 @@ class WPSEO_News {
 	}
 
 	/**
-	 * Get plugin file.
-	 *
-	 * @deprecated since 3.1. Use WPSEO_NEWS_FILE instead.
-	 *
-	 * @return string
-	 */
-	public static function get_file() {
-		_deprecated_function( __FUNCTION__, '3.1', 'WPSEO_NEWS_FILE' );
-
-		return WPSEO_NEWS_FILE;
-	}
-
-	/**
 	 * Initializes the plugin.
 	 */
 	public function __construct() {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*Checked for all functions that have been deprecated since before 4.0. Found one and removed it.  

## Test instructions

This PR can be tested by following these steps:

* This PR cannot be tested specifically. It's a code cleanup and it should have no effect on the plugin. The only difference is that developers will not see warning messages anymore from functions that have been deprecated since before 4.0. The only way of testing is checking that the plugin still works. 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
--> I have run the existing unittests and they don't throw any errors. 

Related [#8783](https://github.com/Yoast/wordpress-seo/issues/8783)