### PR TITLE
Add WordPress SEO version requirement

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -125,25 +125,44 @@ class WPSEO_News {
 	 *
 	 * @return bool True whether the dependencies are okay.
 	 */
-	private function check_dependencies( $wp_version ) {
+	protected function check_dependencies( $wp_version ) {
+		// When WordPress function is too low.
 		if ( ! version_compare( $wp_version, '3.5', '>=' ) ) {
 			add_action( 'all_admin_notices', array( $this, 'error_upgrade_wp' ) );
-		}
-		else {
-			if ( defined( 'WPSEO_VERSION' ) ) {
-				if ( version_compare( WPSEO_VERSION, '1.5', '>=' ) ) {
-					return true;
-				}
-				else {
-					add_action( 'all_admin_notices', array( $this, 'error_upgrade_wpseo' ) );
-				}
-			}
-			else {
-				add_action( 'all_admin_notices', array( $this, 'error_missing_wpseo' ) );
-			}
+
+			return false;
 		}
 
-		return false;
+		$wordpress_seo_version = $this->get_wordpress_seo_version();
+
+		// When WPSEO_VERSION isn't defined.
+		if ( $wordpress_seo_version === false ) {
+			add_action( 'all_admin_notices', array( $this, 'error_missing_wpseo' ) );
+
+			return false;
+		}
+
+		// When version is below 7.0.
+		if ( ! version_compare( $wordpress_seo_version, '7.0', '>=' ) ) {
+			add_action( 'all_admin_notices', array( $this, 'error_upgrade_wpseo' ) );
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the WordPress SEO version when set.
+	 *
+	 * @return bool|string The version whether it is set.
+	 */
+	protected function get_wordpress_seo_version() {
+		if ( ! defined( 'WPSEO_VERSION' ) ) {
+			return false;
+		}
+
+		return WPSEO_VERSION;
 	}
 
 	/**

--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -127,7 +127,7 @@ class WPSEO_News {
 	 */
 	protected function check_dependencies( $wp_version ) {
 		// When WordPress function is too low.
-		if ( ! version_compare( $wp_version, '4.8', '>=' ) ) {
+		if ( version_compare( $wp_version, '4.8', '<' ) ) {
 			add_action( 'all_admin_notices', array( $this, 'error_upgrade_wp' ) );
 
 			return false;
@@ -142,8 +142,8 @@ class WPSEO_News {
 			return false;
 		}
 
-		// When version is below 7.0.
-		if ( ! version_compare( $wordpress_seo_version, '7.0', '>=' ) ) {
+		// Make sure Yoast SEO is installed on version 7.0 or an RC candidate of that version.
+		if ( version_compare( $wordpress_seo_version, '6.9', '<' ) ) {
 			add_action( 'all_admin_notices', array( $this, 'error_upgrade_wpseo' ) );
 
 			return false;

--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -48,8 +48,9 @@ class WPSEO_News {
 	 */
 	public function __construct() {
 		// Check if module can work.
-		if ( false === $this->check_dependencies() ) {
-			return false;
+		global $wp_version;
+		if ( false === $this->check_dependencies( $wp_version ) ) {
+			return;
 		}
 
 		$this->set_hooks();
@@ -119,10 +120,12 @@ class WPSEO_News {
 
 	/**
 	 * Check the dependencies.
+	 *
+	 * @param string $wp_version The current version of WordPress.
+	 *
+	 * @return bool True whether the dependencies are okay.
 	 */
-	private function check_dependencies() {
-		global $wp_version;
-
+	private function check_dependencies( $wp_version ) {
 		if ( ! version_compare( $wp_version, '3.5', '>=' ) ) {
 			add_action( 'all_admin_notices', array( $this, 'error_upgrade_wp' ) );
 		}

--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -127,7 +127,7 @@ class WPSEO_News {
 	 */
 	protected function check_dependencies( $wp_version ) {
 		// When WordPress function is too low.
-		if ( ! version_compare( $wp_version, '3.5', '>=' ) ) {
+		if ( ! version_compare( $wp_version, '4.8', '>=' ) ) {
 			add_action( 'all_admin_notices', array( $this, 'error_upgrade_wp' ) );
 
 			return false;

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,11 @@
             "classes/"
         ]
     },
+    "autoload-dev": {
+        "classmap": [
+            "tests/"
+        ]
+    },
     "scripts": {
         "config-yoastcs": [
             "\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs",

--- a/tests/assets/wpseo-news-double.php
+++ b/tests/assets/wpseo-news-double.php
@@ -7,12 +7,10 @@
  * Class WPSEO_News_Test
  */
 class WPSEO_News_Double extends WPSEO_News {
-
 	/**
 	 *v @inheritdoc
 	 */
 	public function check_dependencies( $wp_version ) {
 		return parent::check_dependencies( $wp_version );
 	}
-
 }

--- a/tests/assets/wpseo-news-double.php
+++ b/tests/assets/wpseo-news-double.php
@@ -8,7 +8,7 @@
  */
 class WPSEO_News_Double extends WPSEO_News {
 	/**
-	 *v @inheritdoc
+	 * @inheritdoc
 	 */
 	public function check_dependencies( $wp_version ) {
 		return parent::check_dependencies( $wp_version );

--- a/tests/assets/wpseo-news-double.php
+++ b/tests/assets/wpseo-news-double.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @package WPSEO\Tests
+ */
+
+/**
+ * Class WPSEO_News_Test
+ */
+class WPSEO_News_Double extends WPSEO_News {
+
+	/**
+	 *v @inheritdoc
+	 */
+	public function check_dependencies( $wp_version ) {
+		return parent::check_dependencies( $wp_version );
+	}
+
+}

--- a/tests/test-class-wpseo-news.php
+++ b/tests/test-class-wpseo-news.php
@@ -9,68 +9,49 @@
 class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 
 	/**
-	 * Tests the situation where WordPress version is below the minimal required version.
+	 * Tests the check dependencies function.
+	 *
+	 * @dataProvider check_dependencies_data
+	 *
+	 * @param bool   $expected              The expected value.
+	 * @param string $wordpress_seo_version The WordPress SEO version to check.
+	 * @param string $wordpress_version     The WordPress version to check.
+	 * @param string $message               Message given by PHPUnit after assertion.
 	 *
 	 * @covers WPSEO_News::check_dependencies()
 	 */
-	public function test_with_required_depencendies_with_older_wordpress_version() {
-		$class_instance = new WPSEO_News_Double();
-
-		$this->assertFalse( $class_instance->check_dependencies( 3.0 ) );
-	}
-
-	/**
-	 * * Tests the situation where WordPress SEO version isn't installed.
-	 * @covers WPSEO_News::check_dependencies()
-	 */
-	public function test_with_required_depencendies_with_no_wordpress_seo_version() {
-		$class_instance = $this->getMockBuilder( 'WPSEO_News_Double' )
+	public function test_check_dependencies( $expected, $wordpress_seo_version, $wordpress_version, $message ) {
+		$class_instance = $this
+			->getMockBuilder( 'WPSEO_News_Double' )
+			->disableOriginalConstructor()
 			->setMethods( array( 'get_wordpress_seo_version' ) )
 			->getMock();
 
 		$class_instance
-			->expects( $this->once() )
 			->method( 'get_wordpress_seo_version' )
-			->will( $this->returnValue( false ) );
+			->will( $this->returnValue( $wordpress_seo_version ) );
 
-		$this->assertFalse( $class_instance->check_dependencies( '5.0' ) );
+
+		$this->assertEquals( $expected, $class_instance->check_dependencies( $wordpress_version ), $message );
 	}
 
 	/**
-	 * Tests the situation where WordPress SEO version is below the minimal required version.
+	 * Data provider for the check dependencies test.
 	 *
-	 * @covers WPSEO_News::check_dependencies()
-	 */
-	public function test_with_required_depencendies_with_old_wordpress_seo_version() {
-		$class_instance = $this->getMockBuilder( 'WPSEO_News_Double' )
-			->setMethods( array( 'get_wordpress_seo_version' ) )
-			->getMock();
-
-		$class_instance
-			->expects( $this->once() )
-			->method( 'get_wordpress_seo_version' )
-			->will( $this->returnValue( '6.9' ) );
-
-		$this->assertFalse( $class_instance->check_dependencies( '5.0' ) );
-	}
-
-	/**
-	 * Tests the situation where WordPress and WordPress SEO have the minimal required versions.
+	 * [0]: Expected
+	 * [1]: WordPress SEO Version
+	 * [2]: WordPress Version
+	 * [3]: Message for PHPUnit.
 	 *
-	 * @covers WPSEO_News::check_dependencies()
+	 * @return array
 	 */
-	public function test_with_all_required_depencendies_ok() {
-		$class_instance = $this->getMockBuilder( 'WPSEO_News_Double' )
-			->setMethods( array( 'get_wordpress_seo_version' ) )
-			->getMock();
-
-		$class_instance
-			->expects( $this->once() )
-			->method( 'get_wordpress_seo_version' )
-			->will( $this->returnValue( '7.0' ) );
-
-		$this->assertTrue( $class_instance->check_dependencies( '5.0' ) );
+	public function check_dependencies_data() {
+		return array(
+			array( false, '7.0', '3.0', 'WordPress is below the minimal required version.' ),
+			array( false, false, '5.0', 'WordPress SEO is not installed.' ),
+			array( false, '6.0', '5.0', 'WordPress SEO is below the minimal required version.' ),
+			array( true, '7.0', '5.0', 'WordPress and WordPress SEO have the minimal required versions.' ),
+			array( true, '8.0', '3.5', 'WordPress and WordPress SEO have the minimal required versions.' ),
+		);
 	}
-
-
 }

--- a/tests/test-class-wpseo-news.php
+++ b/tests/test-class-wpseo-news.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @package WPSEO\Tests
+ */
+
+/**
+ * Class WPSEO_News_Test
+ */
+class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
+
+	/**
+	 * Tests the situation where WordPress version is below the minimal required version.
+	 *
+	 * @covers WPSEO_News::check_dependencies()
+	 */
+	public function test_with_required_depencendies_with_older_wordpress_version() {
+		$class_instance = new WPSEO_News_Double();
+
+		$this->assertFalse( $class_instance->check_dependencies( 3.0 ) );
+	}
+
+	/**
+	 * * Tests the situation where WordPress SEO version isn't installed.
+	 * @covers WPSEO_News::check_dependencies()
+	 */
+	public function test_with_required_depencendies_with_no_wordpress_seo_version() {
+		$class_instance = $this->getMockBuilder( 'WPSEO_News_Double' )
+			->setMethods( array( 'get_wordpress_seo_version' ) )
+			->getMock();
+
+		$class_instance
+			->expects( $this->once() )
+			->method( 'get_wordpress_seo_version' )
+			->will( $this->returnValue( false ) );
+
+		$this->assertFalse( $class_instance->check_dependencies( '5.0' ) );
+	}
+
+	/**
+	 * Tests the situation where WordPress SEO version is below the minimal required version.
+	 *
+	 * @covers WPSEO_News::check_dependencies()
+	 */
+	public function test_with_required_depencendies_with_old_wordpress_seo_version() {
+		$class_instance = $this->getMockBuilder( 'WPSEO_News_Double' )
+			->setMethods( array( 'get_wordpress_seo_version' ) )
+			->getMock();
+
+		$class_instance
+			->expects( $this->once() )
+			->method( 'get_wordpress_seo_version' )
+			->will( $this->returnValue( '6.9' ) );
+
+		$this->assertFalse( $class_instance->check_dependencies( '5.0' ) );
+	}
+
+	/**
+	 * Tests the situation where WordPress and WordPress SEO have the minimal required versions.
+	 *
+	 * @covers WPSEO_News::check_dependencies()
+	 */
+	public function test_with_all_required_depencendies_ok() {
+		$class_instance = $this->getMockBuilder( 'WPSEO_News_Double' )
+			->setMethods( array( 'get_wordpress_seo_version' ) )
+			->getMock();
+
+		$class_instance
+			->expects( $this->once() )
+			->method( 'get_wordpress_seo_version' )
+			->will( $this->returnValue( '7.0' ) );
+
+		$this->assertTrue( $class_instance->check_dependencies( '5.0' ) );
+	}
+
+
+}

--- a/tests/test-class-wpseo-news.php
+++ b/tests/test-class-wpseo-news.php
@@ -49,10 +49,11 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 	public function check_dependencies_data() {
 		return array(
 			array( false, '7.0', '3.0', 'WordPress is below the minimal required version.' ),
+			array( false, '7.0', '3.5', 'WordPress is below the minimal required version.' ),
 			array( false, false, '5.0', 'WordPress SEO is not installed.' ),
 			array( false, '6.0', '5.0', 'WordPress SEO is below the minimal required version.' ),
-			array( true, '7.0', '5.0', 'WordPress and WordPress SEO have the minimal required versions.' ),
-			array( true, '8.0', '3.5', 'WordPress and WordPress SEO have the minimal required versions.' ),
+			array( true, '7.0', '5.0', 'WordPress (5.0) and WordPress SEO have the minimal required versions.' ),
+			array( true, '8.0', '4.8', 'WordPress (4.8) and WordPress SEO have the minimal required versions.' ),
 		);
 	}
 }

--- a/tests/test-class-wpseo-news.php
+++ b/tests/test-class-wpseo-news.php
@@ -28,6 +28,7 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 			->getMock();
 
 		$class_instance
+			->expects( $this->any() )
 			->method( 'get_wordpress_seo_version' )
 			->will( $this->returnValue( $wordpress_seo_version ) );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Show a notice when a WordPress SEO version below 7.0 is installed.

## Test instructions

This PR can be tested by following these steps:

* Have this branch and WordPress SEO active. Change in WordPress SEO the value of constant `WPSEO_VERSION` in a value below 7.0
* A notice should be shown. 
* Change the value of the constant to 7.0 or 7.1 and see the notice being gone.

* Add this somewhere in `wpseo-news.php` to test the minimal required WordPress notification.
```
add_action( 'admin_init', function() {
	global $wp_version;

	$wp_version = 4.7;
} );
```

Fixes #339 
Fixes #346 