### PR TITLE
Main file: add missing `Domain Path` tag

### DIFF
--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -11,6 +11,7 @@ Description: Google News plugin for the Yoast SEO plugin
 Author: Team Yoast
 Author URI: http://yoast.com/
 Text Domain: wpseo_news
+Domain Path: /languages/
 License: GPL v3
 
 Yoast SEO Plugin


### PR DESCRIPTION
As this is a premium plugin and not on GlotPress, the `Domain Path` tag should be set.