### PR TITLE
CS/QA: remove superfluous `break` statements

### DIFF
--- a/classes/class-beacon-setting.php
+++ b/classes/class-beacon-setting.php
@@ -23,7 +23,6 @@ class WPSEO_News_Beacon_Setting implements Yoast_HelpScout_Beacon_Setting {
 					'5375e852e4b03c6512282d5a',
 					// See: http://kb.yoast.com/article/36-my-sitemap-is-blank-what-s-wrong.
 				);
-				break;
 		}
 
 		return array();
@@ -40,7 +39,6 @@ class WPSEO_News_Beacon_Setting implements Yoast_HelpScout_Beacon_Setting {
 		switch ( $page ) {
 			case 'wpseo_news':
 				return array( new WPSEO_News_Product() );
-				break;
 		}
 
 		return array();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

Code directly after a `return` cannot be executed.


## Test instructions

_N/A_