### PR TITLE
CS/QA: remove superfluous fall-back function

### DIFF
--- a/classes/class-meta-box.php
+++ b/classes/class-meta-box.php
@@ -281,26 +281,4 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 
 		return $standout_desc;
 	}
-
-	/**
-	 * Returns post in metabox context - fallback for Yoast SEO < 3.0 and News SEO > 2.2.5
-	 *
-	 * @returns WP_Post|array
-	 */
-	protected function get_metabox_post() {
-		if ( is_callable( 'parent:get_metabox_post' ) ) {
-			return parent::get_metabox_post();
-		}
-
-		if ( $post = filter_input( INPUT_GET, 'post' ) ) {
-			$post_id = (int) WPSEO_Utils::validate_int( $post );
-			return get_post( $post_id );
-		}
-
-		if ( isset( $GLOBALS['post'] ) ) {
-			return $GLOBALS['post'];
-		}
-
-		return array();
-	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

This method falls through to the parent method if the parent exists - which it does since WPSEO `3.0`.

As we are a good two years down the road, this fall-back can be safely removed.
The method does not need to be deprecated as any function calls to it will fall through to the parent method, which is exactly as intended.

As a side-note: up to now, this method would have never fallen through to the parent as there is a typo in the `is_callable()` - `:` vs `::`.


## Test instructions

This PR can be tested by following these steps:

* Verify that the metabox related functionality still works as expected. Most notably whether the metabox functionality shows up correctly on supported post types and does not on unsuppported post types.
