### PR TITLE
CS/QA: use strict comparisons when comparing strings

### DIFF
--- a/classes/class-head.php
+++ b/classes/class-head.php
@@ -96,7 +96,7 @@ class WPSEO_News_Head {
 		 */
 		if ( apply_filters( 'wpseo_news_head_display_standout', true, $this->post ) ) {
 			$meta_standout = WPSEO_Meta::get_value( 'newssitemap-standout', $this->post->ID );
-			if ( 'on' == $meta_standout && strtotime( $this->post->post_date ) >= strtotime( '-7 days' ) ) {
+			if ( 'on' === $meta_standout && strtotime( $this->post->post_date ) >= strtotime( '-7 days' ) ) {
 				echo '<meta name="standout" content="' . get_permalink( $this->post->ID ) . '" />' . "\n";
 			}
 		}

--- a/classes/class-meta-keywords.php
+++ b/classes/class-meta-keywords.php
@@ -83,7 +83,7 @@ class WPSEO_News_Meta_Keywords {
 		$options = WPSEO_News::get_options();
 
 		// TODO: add suggested keywords to each post based on category, next to the entire.
-		if ( isset( $options['default_keywords'] ) && $options['default_keywords'] != '' ) {
+		if ( isset( $options['default_keywords'] ) && $options['default_keywords'] !== '' ) {
 			$this->add_keywords( $options['default_keywords'] );
 		}
 	}

--- a/classes/class-sitemap-editors-pick.php
+++ b/classes/class-sitemap-editors-pick.php
@@ -50,7 +50,7 @@ class WPSEO_News_Sitemap_Editors_Pick {
 		echo '<title>' . get_bloginfo( 'name' ) . '</title>' . PHP_EOL;
 
 		// Display the image tag if an image is set.
-		if ( isset( $options['ep_image_src'] ) && $options['ep_image_src'] != '' ) {
+		if ( isset( $options['ep_image_src'] ) && $options['ep_image_src'] !== '' ) {
 			$this->show_image( $options['ep_image_src'] );
 		}
 

--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -98,7 +98,7 @@ class WPSEO_News {
 		// Edit Post JS.
 		global $pagenow;
 
-		if ( 'post.php' == $pagenow || 'post-new.php' == $pagenow ) {
+		if ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_edit_post' ) );
 		}
 
@@ -193,7 +193,7 @@ class WPSEO_News {
 		if ( empty( $this_plugin ) ) {
 			$this_plugin = plugin_basename( __FILE__ );
 		}
-		if ( $file == $this_plugin ) {
+		if ( $file === $this_plugin ) {
 			$settings_link = '<a href="' . admin_url( 'admin.php?page=wpseo_news' ) . '">' . __( 'Settings', 'wordpress-seo-news' ) . '</a>';
 			array_unshift( $links, $settings_link );
 		}
@@ -344,7 +344,7 @@ class WPSEO_News {
 			// Get supported post types.
 			$post_types = array();
 			foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $post_type ) {
-				if ( isset( $options[ 'newssitemap_include_' . $post_type->name ] ) && ( 'on' == $options[ 'newssitemap_include_' . $post_type->name ] ) ) {
+				if ( isset( $options[ 'newssitemap_include_' . $post_type->name ] ) && ( 'on' === $options[ 'newssitemap_include_' . $post_type->name ] ) ) {
 					$post_types[] = $post_type->name;
 				}
 			}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:

Whenever a variable/function call output is compared to a string, one should *always* use a strict comparison as otherwise the results will become unpredictable.

If the value of the variable is a boolean, the hard-coded string will be cast to boolean before comparing, if the value of the variable is an integer, the string will be cast to integer, etc.

So when the variable is expected to be a string and a comparison is made against a hard-coded string, this should always be a strict comparison.


## Test instructions
_N/A_
