### PR TITLE
CS/QA: Use strict comparisons with array functions

### DIFF
--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -173,7 +173,7 @@ class WPSEO_News_Admin_Page {
 	protected function is_news_page( $page ) {
 		$news_pages = array( 'wpseo_news' );
 
-		return in_array( $page, $news_pages );
+		return in_array( $page, $news_pages, true );
 	}
 
 	/**

--- a/classes/class-meta-box.php
+++ b/classes/class-meta-box.php
@@ -207,7 +207,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 				$post_types = WPSEO_News::get_included_post_types();
 
 				// Display content if post type is supported.
-				if ( ! empty( $post_types ) && in_array( $post->post_type, $post_types ) ) {
+				if ( ! empty( $post_types ) && in_array( $post->post_type, $post_types, true ) ) {
 					$is_supported = true;
 				}
 			}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -251,7 +251,7 @@ class WPSEO_News_Sitemap_Item {
 		}
 
 		// Is there a timezone option and does it exists in the list of 'valid' timezone.
-		if ( $timezone_option !== '' && in_array( $timezone_option, DateTimeZone::listIdentifiers() ) ) {
+		if ( $timezone_option !== '' && in_array( $timezone_option, DateTimeZone::listIdentifiers(), true ) ) {
 			return DateTime::W3C;
 		}
 

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -91,7 +91,7 @@ class WPSEO_News_Sitemap {
 		}
 
 		// Only invalidate when we are in a News Post Type object.
-		if ( ! in_array( get_post_type( $post_id ), WPSEO_News::get_included_post_types() ) ) {
+		if ( ! in_array( get_post_type( $post_id ), WPSEO_News::get_included_post_types(), true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance.

Strict type comparisons should be used as a rule, with loose type comparisons being the exception.
For array functions which do loose type comparisons, setting the third `$strict` parameter to `false` can be seen as a clear indication that this is a conscious, well thought out decision by the developer.
In all other cases, `$strict` `true` should be used.

For the ones addressed here, I've verified that they all do comparisons with strings, which is when it is most important to do a strict comparison (and also safe to change it to one).

## Test instructions
_N/A_