### PR TITLE
CS/QA: consistently use `WPSEO_NEWS_FILE` constant

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -191,7 +191,7 @@ class WPSEO_News {
 	public function plugin_links( $links, $file ) {
 		static $this_plugin;
 		if ( empty( $this_plugin ) ) {
-			$this_plugin = plugin_basename( __FILE__ );
+			$this_plugin = plugin_basename( WPSEO_NEWS_FILE );
 		}
 		if ( $file === $this_plugin ) {
 			$settings_link = '<a href="' . admin_url( 'admin.php?page=wpseo_news' ) . '">' . __( 'Settings', 'wordpress-seo-news' ) . '</a>';

--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -92,9 +92,9 @@ function wpseo_news_activate_license() {
 	$license_manager->activate_license();
 }
 
-register_activation_hook( __FILE__, 'yoast_wpseo_news_activate' );
+register_activation_hook( WPSEO_NEWS_FILE, 'yoast_wpseo_news_activate' );
 
-register_deactivation_hook( __FILE__, 'yoast_wpseo_news_deactivate' );
+register_deactivation_hook( WPSEO_NEWS_FILE, 'yoast_wpseo_news_deactivate' );
 
 /*
  * When the plugin is deactivated and activated again, the license has to be activated. This is mostly the case


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* Settings page link was missing on the plugins page.

## Relevant technical choices:

The `WPSEO_NEWS_FILE` constant is created for a reason: always having easy access to the filename of the "main" plugin file as registered with WP.

For the activation hooks, this is just a case of consistently using the constant.

For the second commit change - using `__FILE__` should cause WP not to recognize the plugin correctly and therefore not to display the settings link on the plugins page.
I haven't tested this, but I suspect this is currently not working and will start working again once this PR has been merged.


## Test instructions
* (De-)Activating the plugin should still work as expected.
* The settings link for this plugin should now show up on the plugins page.