### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,37 @@
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for this plugin using Composer, use `--prefer-source`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+#
+.github export-ignore
+grunt export-ignore
+tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.gruntjshintrc export-ignore
+.jscsrc export-ignore
+.jshintrc export-ignore
+.phpcs.xml export-ignore
+.phpcs.xml.dist export-ignore
+.removeable-files export-ignore
+.travis.yml export-ignore
+Gruntfile.js export-ignore
+package.json export-ignore
+phpcs.xml export-ignore
+phpcs.xml.dist export-ignore
+phpunit.xml export-ignore
+phpunit.xml.dist export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text


### PR DESCRIPTION
This PR adds a `.gitattributes` file to keep the archives GH creates of the repo clean of development related files.
People using Composer can still get these files in their setup if they really want to, by using `--prefer-source`.

The commit already anticipated some files which may or may not be added in the future.

Refs:
* [Reddit: I don't need your tests in my production](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production)
* [Blog: I don't need your tests in my production](https://blog.madewithlove.be/post/gitattributes/)
