### PR TITLE
Changed private method to public to determine timezone

### DIFF
--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -251,7 +251,7 @@ class WPSEO_News_Sitemap_Item {
 		}
 
 		// Is there a timezone option and does it exists in the list of 'valid' timezone.
-		if ( $timezone_option !== '' && in_array( $timezone_option, DateTimeZone::listIdentifiers(), true ) ) {
+		if ( $timezone_option !== '' && in_array( $timezone_option->wp_get_timezone_string(), DateTimeZone::listIdentifiers(), true ) ) {
 			return DateTime::W3C;
 		}
 

--- a/classes/class-sitemap-timezone.php
+++ b/classes/class-sitemap-timezone.php
@@ -24,7 +24,7 @@ class WPSEO_News_Sitemap_Timezone {
 	 *
 	 * @return string valid PHP timezone string
 	 */
-	private function wp_get_timezone_string() {
+	public function wp_get_timezone_string() {
 
 		// If site timezone string exists, return it.
 		if ( $timezone = get_option( 'timezone_string' ) ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an issue where an incorrect DateTime was returned due to strict checking being introduced on arrays. 

## Relevant technical choices:

* Because the class that determines what timezone to use in the sitemap leans heavily on the `__toString()` method, it resulted in a breakage when strict checking is used on `in_array`. Because of this, I altered the method that determines the timezone and made it public so we can properly check against the expected output.

## Test instructions

This PR can be tested by following these steps:

* See that Travis succeeds

_-OR-_

* While using the `trunk` branch, create a new post and go to your News Sitemap.
* Notice that there's no timestamp behind the newly created post, but just the date.
* Checkout this branch.
* Create a new post.
* Go back to the News Sitemap.
* Check that there's also a timestamp present in the sitemap.

Fixes #368 
