### PR TITLE
CS/XSS: always escape output [3]

### DIFF
--- a/classes/class-meta-box.php
+++ b/classes/class-meta-box.php
@@ -154,7 +154,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	 * The tab header.
 	 */
 	public function header() {
-		echo '<li class="news"><a class="wpseo_tablink" href="#wpseo_news">' . __( 'Google News', 'wordpress-seo-news' ) . '</a></li>';
+		echo '<li class="news"><a class="wpseo_tablink" href="#wpseo_news">' . esc_html__( 'Google News', 'wordpress-seo-news' ) . '</a></li>';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Simple non-controversial one. Use `esc_html()`, `esc_attr()` or `esc_url()` where appropriate.
This should not give any problems.

## Test instructions

Testing recommended, but no problems expected.

Test this by checking that the meta box header for `Google News` still displays correctly.
