### PR TITLE
CS/XSS: always escape output [4]

### DIFF
--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -33,17 +33,19 @@ class WPSEO_News_Admin_Page {
 		WPSEO_News_Wrappers::admin_header( true, 'yoast_wpseo_news_options', 'wpseo_news' );
 
 		// Introduction.
-		echo '<p>' . __( 'You will generally only need a News Sitemap when your website is included in Google News.', 'wordpress-seo-news' ) . '</p>';
-		echo '<p>' . sprintf(
+		echo '<p>' . esc_html__( 'You will generally only need a News Sitemap when your website is included in Google News.', 'wordpress-seo-news' ) . '</p>';
+		echo '<p>';
+		printf(
 			/* translators: %1$s opening tag of the link to the News Sitemap, %2$s closing tag for the link. */
-			__( '%1$sView your News Sitemap%2$s.', 'wordpress-seo-news' ),
-			'<a target="_blank" href="' . WPSEO_News_Sitemap::get_sitemap_name() . '">',
+			esc_html__( '%1$sView your News Sitemap%2$s.', 'wordpress-seo-news' ),
+			'<a target="_blank" href="' . esc_url( WPSEO_News_Sitemap::get_sitemap_name() ) . '">',
 			'</a>'
-		) . '</p>';
+		);
+		echo '</p>';
 
-		echo '<h2>' . __( 'General settings', 'wordpress-seo-news' ) . '</h2>';
+		echo '<h2>' . esc_html__( 'General settings', 'wordpress-seo-news' ) . '</h2>';
 
-		echo '<fieldset><legend class="screen-reader-text">' . __( 'News Sitemap settings', 'wordpress-seo-news' ) . '</legend>';
+		echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'News Sitemap settings', 'wordpress-seo-news' ) . '</legend>';
 
 		// Google News Publication Name.
 		echo WPSEO_News_Wrappers::textinput( 'name', __( 'Google News Publication Name', 'wordpress-seo-news' ) );
@@ -99,12 +101,14 @@ class WPSEO_News_Admin_Page {
 	private function default_keywords() {
 		// Default keywords.
 		echo WPSEO_News_Wrappers::textinput( 'default_keywords', __( 'Default Keywords', 'wordpress-seo-news' ) );
-		echo '<p class="desc label">' . sprintf(
+		echo '<p class="desc label">';
+		printf(
 			/* translators: %1$s opening tag of the link to the Google suggested keywords page, %2$s closing tag for the link. */
-			__( 'It might be wise to add some of the %1$sGoogle\'s suggested keywords%2$s to all of your posts. Add them as a comma separated list.', 'wordpress-seo-news' ),
+			esc_html__( 'It might be wise to add some of the %1$sGoogle\'s suggested keywords%2$s to all of your posts. Add them as a comma separated list.', 'wordpress-seo-news' ),
 			'<a target="_blank" href="http://www.google.com/support/news_pub/bin/answer.py?answer=116037">',
 			'</a>'
-		) . '</p>';
+		);
+		echo '</p>';
 
 		echo WPSEO_News_Wrappers::checkbox( 'restrict_sitemap_featured_img', __( 'Only use the featured image for your News Sitemap, ignore images in post.', 'wordpress-seo-news' ), false );
 		echo '<br>';
@@ -115,8 +119,8 @@ class WPSEO_News_Admin_Page {
 	 */
 	private function include_post_types() {
 		// Post Types to include in News Sitemap.
-		echo '<h2>' . __( 'Post Types to include in News Sitemap and Editors&#39; Picks RSS', 'wordpress-seo-news' ) . '</h2>';
-		echo '<fieldset><legend class="screen-reader-text">' . __( 'Post Types to include:', 'wordpress-seo-news' ) . '</legend>';
+		echo '<h2>' . esc_html__( 'Post Types to include in News Sitemap and Editors&#39; Picks RSS', 'wordpress-seo-news' ) . '</h2>';
+		echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'Post Types to include:', 'wordpress-seo-news' ) . '</legend>';
 		foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $posttype ) {
 			echo WPSEO_News_Wrappers::checkbox( 'newssitemap_include_' . $posttype->name, $posttype->labels->name . ' (<code>' . $posttype->name . '</code>)', false );
 		}
@@ -128,8 +132,8 @@ class WPSEO_News_Admin_Page {
 	 */
 	private function excluded_post_categories() {
 		if ( isset( $this->options['newssitemap_include_post'] ) ) {
-			echo '<h2>' . __( 'Post categories to exclude', 'wordpress-seo-news' ) . '</h2>';
-			echo '<fieldset><legend class="screen-reader-text">' . __( 'Post categories to exclude', 'wordpress-seo-news' ) . '</legend>';
+			echo '<h2>' . esc_html__( 'Post categories to exclude', 'wordpress-seo-news' ) . '</h2>';
+			echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'Post categories to exclude', 'wordpress-seo-news' ) . '</legend>';
 			foreach ( get_categories() as $cat ) {
 				echo WPSEO_News_Wrappers::checkbox( 'catexclude_' . $cat->slug, $cat->name . ' (' . $cat->count . ' posts)', false );
 			}
@@ -141,7 +145,7 @@ class WPSEO_News_Admin_Page {
 	 * Part with HTML for editors picks.
 	 */
 	private function editors_pick() {
-		echo '<h2>' . __( "Editors' Picks", 'wordpress-seo-news' ) . '</h2>';
+		echo '<h2>' . esc_html__( "Editors' Picks", 'wordpress-seo-news' ) . '</h2>';
 
 		$esc_form_key = 'ep_image_src';
 
@@ -150,19 +154,23 @@ class WPSEO_News_Admin_Page {
 		echo '<input id="' . $esc_form_key . '_button" class="wpseo_image_upload_button button" type="button" value="' . __( 'Upload Image', 'wordpress-seo-news' ) . '" />';
 		echo '<br class="clear"/>';
 
-		echo '<p>' . sprintf(
+		echo '<p>';
+		printf(
 			/* translators: %1$s opening tag of the link to the Editors Picks RSS, %2$s closing tag for the link. */
-			__( '%1$sView your Editors\' Picks RSS Feed%2$s.', 'wordpress-seo-news' ),
-			'<a target="_blank" href="' . home_url( 'editors-pick.rss' ) . '">',
+			esc_html__( '%1$sView your Editors\' Picks RSS Feed%2$s.', 'wordpress-seo-news' ),
+			'<a target="_blank" href="' . esc_url( home_url( 'editors-pick.rss' ) ) . '">',
 			'</a>'
-		) . '</p>';
+		);
+		echo '</p>';
 
-		echo '<p>' . sprintf(
+		echo '<p>';
+		printf(
 			/* translators: %1$s opening tag of the link to the Google Editors Picks submit page, %2$s closing tag for the link. */
-			__( '%1$sSubmit your Editors\' Picks RSS Feed to Google News%2$s.', 'wordpress-seo-news' ),
+			esc_html__( '%1$sSubmit your Editors\' Picks RSS Feed to Google News%2$s.', 'wordpress-seo-news' ),
 			'<a href="https://support.google.com/news/publisher/contact/editors_picks" target="_blank">',
 			'</a>'
-		) . '</p>';
+		);
+		echo '</p>';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Includes minor code build up/layout changes.

## Test instructions

Testing recommended, but no problems expected.

* Open the NewsSEO admin page and verify that all elements on the admin page still display correctly.
