### PR TITLE
CS/XSS: remove need to escape output [5]

### DIFF
--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -143,11 +143,9 @@ class WPSEO_News_Admin_Page {
 	private function editors_pick() {
 		echo '<h2>' . __( "Editors' Picks", 'wordpress-seo-news' ) . '</h2>';
 
-		$esc_form_key = 'ep_image_src';
-
-		echo '<label class="select" for="' . $esc_form_key . '">' . __( "Editors' Picks Image", 'wordpress-seo-news' ) . ':</label>';
-		echo '<input id="' . $esc_form_key . '" type="text" size="36" name="wpseo_news[' . $esc_form_key . ']" value="' . esc_attr( $this->options[ $esc_form_key ] ) . '" />';
-		echo '<input id="' . $esc_form_key . '_button" class="wpseo_image_upload_button button" type="button" value="' . __( 'Upload Image', 'wordpress-seo-news' ) . '" />';
+		echo '<label class="select" for="ep_image_src">' . esc_html__( "Editors' Picks Image", 'wordpress-seo-news' ) . ':</label>';
+		echo '<input id="ep_image_src" type="text" size="36" name="wpseo_news[ep_image_src]" value="' . esc_attr( $this->options['ep_image_src'] ) . '" />';
+		echo '<input id="ep_image_src_button" class="wpseo_image_upload_button button" type="button" value="' . esc_attr__( 'Upload Image', 'wordpress-seo-news' ) . '" />';
 		echo '<br class="clear"/>';
 
 		echo '<p>' . sprintf(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

While I understand that having this string in a variable is useful, there isn't any real need. It's not as if the variable is used in a lot of places throughout the code. Just few times directly following the old variable definition, so removing the variable was simplest.

Alternatively this block could be whitelisted, but that would open it up to new issues being introduced at a later stage.

## Test instructions

Testing recommended, but no problems expected.

Test this by checking that the `editors pick` section of the admin page still displays correctly as expected.
