### PR TITLE
CS/QA: don't unnecessarily use `readfile()` function call

### DIFF
--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -160,7 +160,7 @@ class WPSEO_News_Sitemap {
 		header( 'Cache-Control: maxage=' . YEAR_IN_SECONDS );
 		header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', ( time() + YEAR_IN_SECONDS ) ) . ' GMT' );
 
-		readfile( dirname( WPSEO_NEWS_FILE ) . '/assets/xml-news-sitemap.xsl' );
+		include dirname( WPSEO_NEWS_FILE ) . '/assets/xml-news-sitemap.xsl';
 		die();
 	}
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.

No need to use a file system function when a simple language construct should have the same effect and will be more efficient.


## Test instructions
* Make sure that the xsl file is not reachable directly by the server - i.e. this can be done via an `.htaccess` entry to direct requests to `.xsl` files to WP.
* Clear out the sitemap cache
* Load the sitemap and verify that the XSL stylesheet is correctly served with it.