### PR TITLE
Clean up: Remove outdated comment/merge artifact

### DIFF
--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -131,7 +131,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$this->assertContains( $expected_output, $output );
 	}
 
-		// Check if the $output contains the $expected_output.
+
 	/**
 	 * Check what happens if there is one post added with a image in its content.
 	 *


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
*  _N/A_

## Relevant technical choices:

Looks like one old/removed comment still made it back into the code base with the documentation fixes merge (vs the removal of the news keywords merge).

This removes it again.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
