### PR TITLE
Fixes old posts being queried for the News sitemap

### DIFF
--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -206,6 +206,7 @@ class WPSEO_News_Sitemap {
 
 		// Get supported post types.
 		$post_types = WPSEO_News::get_included_post_types();
+
 		if ( empty( $post_types ) ) {
 			return array();
 		}
@@ -219,7 +220,7 @@ class WPSEO_News_Sitemap {
 				"SELECT ID, post_content, post_name, post_author, post_parent, post_date_gmt, post_date, post_date_gmt, post_title, post_type
 				FROM {$wpdb->posts}
 				WHERE post_status='publish'
-					AND ( HOUR( TIMEDIFF( NOW(), post_date_gmt ) ) <= 48 )
+					AND ( TIMESTAMPDIFF( MINUTE, post_date_gmt, NOW() ) <= ( 48 * 60 ) )
 					AND post_type IN (" . implode( ',', array_fill( 0, count( $post_types ), '%s' ) ) . ')
 				ORDER BY post_date_gmt DESC
 				LIMIT 0, %d

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -219,7 +219,7 @@ class WPSEO_News_Sitemap {
 				"SELECT ID, post_content, post_name, post_author, post_parent, post_date_gmt, post_date, post_date_gmt, post_title, post_type
 				FROM {$wpdb->posts}
 				WHERE post_status='publish'
-					AND (DATEDIFF(CURDATE(), post_date_gmt)<=2)
+					AND ( HOUR( TIMEDIFF( NOW(), post_date_gmt ) ) <= 48 )
 					AND post_type IN (" . implode( ',', array_fill( 0, count( $post_types ), '%s' ) ) . ')
 				ORDER BY post_date_gmt DESC
 				LIMIT 0, %d

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -253,6 +253,39 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$this->assertEquals( 'unit-test-news', WPSEO_News_Sitemap::news_sitemap_basename() );
 	}
 
+	/**
+	 * Check what happens if there is one post added.
+	 *
+	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 */
+	public function test_sitemap_only_showing_recent_items() {
+		$base_time = new DateTimeImmutable();
+
+		$this->factory->post->create( array(
+				'post_title' 	=> 'Newest post',
+				'post_date'		=> $base_time->format( 'Y-m-d H:i:s' ),
+				'post_date_gmt' => $base_time->format( 'Y-m-d H:i:s' )
+			) );
+
+		$this->factory->post->create( array(
+				'post_title' 	=> 'New-ish post',
+				'post_date'		=> $base_time->sub( new DateInterval( 'PT48H' ) )->format( 'Y-m-d H:i:s' ),
+				'post_date_gmt' => $base_time->sub( new DateInterval( 'PT48H' ) )->format( 'Y-m-d H:i:s' )
+			) );
+
+		$this->factory->post->create( array(
+				'post_title' 	=> 'Too old Post',
+				'post_date'		=> $base_time->sub( new DateInterval( 'PT48H1M' ) )->format( 'Y-m-d H:i:s' ),
+				'post_date_gmt' => $base_time->sub( new DateInterval( 'PT48H1M' ) )->format( 'Y-m-d H:i:s' )
+			) );
+
+		$output = $this->instance->build_sitemap();
+
+		// Check if the $output contains the $expected_output.
+		$this->assertContains( "\t\t<news:title><![CDATA[Newest post]]></news:title>\n", $output );
+		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post]]></news:title>\n", $output );
+		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post]]></news:title>\n", $output );
+	}
 
 	public function restrict_featured_image( $options ) {
 		$options['restrict_sitemap_featured_img'] = true;

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -254,7 +254,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	}
 
 	/**
-	 * Check what happens if there is one post added.
+	 * Checks that expired posts don't get included in the sitemap.
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
 	 */
@@ -284,6 +284,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		// Check if the $output contains the $expected_output.
 		$this->assertContains( "\t\t<news:title><![CDATA[Newest post]]></news:title>\n", $output );
 		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post]]></news:title>\n", $output );
+
 		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post]]></news:title>\n", $output );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where older posts would be displayed in the sitemap despite them being older than 48 hours.

## Relevant technical choices:

* Altered the query that retrieves the posts by calculating the difference in minutes instead of days. Because MySQL rounds off days / hours, it was possible to run into a situation where a post was 48 hours and 1 minute old, but would remain being queried due to said rounding of numbers. Using minutes means that anything older than `2880` minutes (48 hours) won't be retrieved.

**Please note that you still have to manually clear the cache. A new issue has been created regarding dealing with caches and expiration of news posts that will need to be addressed. See https://github.com/Yoast/wpseo-news/issues/396 for more information.**

## Test instructions

This PR can be tested by following these steps:

* Add three posts.
* Clear the cache by going to `SEO -> General -> Features` and hit the Save button.
* Open up the News Sitemap.
* See that all three posts are present in the sitemap.
* Edit the second post you created and set its publication date to be something like 47 hours ago and save the post.
* Edit the third post you created and set its publication date to be 48+ hours ago. Setting it to _exactly_ 48 hours ago would mean the post will still be queried, so make sure you change it to at least be 48 hours and 1 minute.
* Clear the cache again.
* Open the News sitemap and notice that now there are only two posts present.

Fixes #395
