### PR TITLE
WPSEO_News_Sitemap_Images::parse_image_source(): fix handling of protocol relative URLs

### DIFF
--- a/classes/class-sitemap-images.php
+++ b/classes/class-sitemap-images.php
@@ -122,7 +122,7 @@ class WPSEO_News_Sitemap_Images {
 			$home_url = home_url();
 		}
 
-		if ( strpos( $src, 'http' ) !== 0 ) {
+		if ( strpos( $src, 'http' ) !== 0 && strpos( $src, '//' ) !== 0 ) {
 			if ( $src[0] !== '/' ) {
 				return null;
 			}

--- a/tests/framework/class-wpseo-news-unit-test-case.php
+++ b/tests/framework/class-wpseo-news-unit-test-case.php
@@ -46,4 +46,22 @@ class WPSEO_News_UnitTestCase extends WP_UnitTestCase {
 		ob_clean();
 		$this->assertEquals( $output, $string );
 	}
+
+	/**
+	 * Call protected/private method of a class.
+	 *
+	 * @param object $object      Instantiated object that we will run method on.
+	 * @param string $method_name Method name to call.
+	 * @param array  $parameters  Array of parameters to pass into method.
+	 *
+	 * @return mixed Method return.
+	 */
+	public function invoke_method( &$object, $method_name, array $parameters = array() ) {
+		$reflection = new ReflectionClass( get_class( $object ) );
+		$method     = $reflection->getMethod( $method_name );
+
+		$method->setAccessible( true ); // PHP 5.3.2.
+
+		return $method->invokeArgs( $object, $parameters );
+	}
 }

--- a/tests/test-class-sitemap-images.php
+++ b/tests/test-class-sitemap-images.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Yoast SEO: News plugin test file.
+ *
+ * @package WPSEO_News\Tests
+ */
+
+/**
+ * Class WPSEO_News_Sitemap_Images_Test.
+ *
+ * @group news_sitemap_images
+ */
+class WPSEO_News_Sitemap_Images_Test extends WPSEO_News_UnitTestCase {
+
+	/**
+	 * Instance of the WPSEO_News_Sitemap_Images class.
+	 *
+	 * @var \WPSEO_News_Sitemap_Images
+	 */
+	protected $instance;
+
+	/**
+	 * Setting up the instance of WPSEO_News_Sitemap_Images.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Create a post and retrieve options so the new object can actually be created.
+		// Neither is actually used for the current unit tests.
+		$post_id = $this->factory->post->create();
+		$post    = get_post( $post_id );
+		$options = WPSEO_News::get_options();
+
+		$this->instance = new WPSEO_News_Sitemap_Images( $post, $options );
+	}
+
+	/**
+	 * Clean up after all tests in this class have run.
+	 */
+	public function tearDown() {
+		$this->instance = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests parsing of the image source attribute value.
+	 *
+	 * @covers WPSEO_News_Sitemap_Images::parse_image_source()
+	 *
+	 * @dataProvider provider_parse_image_source
+	 *
+	 * @requires PHP 5.3.2
+	 *
+	 * @param string $src      HTML image tag.
+	 * @param string $expected Expected result.
+	 */
+	public function test_parse_image_source( $src, $expected ) {
+		$url = $this->invoke_method( $this->instance, 'parse_image_source', array( $src ) );
+		$this->assertSame( $expected, $url );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see WPSEO_News_Sitemap_Images_Test::parse_image_source()
+	 */
+	public function provider_parse_image_source() {
+		return array(
+			// HTTP.
+			array(
+				'http://example.org/wp-content/uploads/2018/01/image1.jpg',
+				'http://example.org/wp-content/uploads/2018/01/image1.jpg',
+			),
+			// HTTPS.
+			array(
+				'https://example.org/wp-content/uploads/2018/01/image1.jpg',
+				'https://example.org/wp-content/uploads/2018/01/image1.jpg',
+			),
+			// Relative URL.
+			array(
+				'/wp-content/uploads/2018/01/image1.jpg',
+				'http://example.org/wp-content/uploads/2018/01/image1.jpg',
+			),
+			array(
+				'wp-content/uploads/2018/01/image1.jpg',
+				null,
+			),
+			// Protocol relative URL.
+			array(
+				'//example.org/wp-content/uploads/2018/01/image1.jpg',
+				'//example.org/wp-content/uploads/2018/01/image1.jpg',
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the news image sitemap did not correctly handle protocol relative URLs.

## Relevant technical choices:

Commit summary:

### WPSEO_News_UnitTestCase: add helper method to test private methods

If there is no functional reason to change the visibility of `private` methods to `protected`, it shouldn't be changed just to make the methods testable.

To still be able to test those methods in isolation, this helper method can be used.

Note: the helper method needs PHP 5.3.2+, which means that those methods can *not* be tested on PHP 5.2.

### WPSEO_News_Sitemap_Images::parse_image_source(): add unit tests 

There were no unit tests yet at all for the `WPSEO_News_Sitemap_Images` class. This is a minimal start to add them. Related to #362.

The unit tests include a test for protocol relative URLs which will fail until the next commit is added.

### WPSEO_News_Sitemap_Images::parse_image_source(): fix handling of protocol relative URLs

With only a small code change relative URLs are now supported.


## Test instructions

This PR can be tested by following these steps:

* Start with the latest WPSEO release + NewsSEO trunk
* Create a blog post with a a protocol relative image in it, such as `<img src="//yoast.com/app/uploads/2015/09/Avatar_Marieke_500x500.png" alt="something" title="something"/>`
* Go to the news sitemap, take note: it has correctly identified 1 image.
* View the news sitemap source - for the image location it will have something along the lines of : `<image:loc>http://localhost/wp/4.9_nl//yoast.com/app/uploads/2015/09/Avatar_Marieke_500x500.png</image:loc>` which is clearly incorrect.
* Now switch NewsSEO to this branch.
* In General/Features, turn the sitemap off & save, turn the sitemap back on & save to clear the previous sitemap.
* View the news sitemap source - for the image location it will have something along the lines of : `<image:loc>//yoast.com/app/uploads/2015/09/Avatar_Marieke_500x500.png</image:loc>` which is as should be.
