### PR TITLE
QA: skip test when minimum PHP version does not comply

### DIFF
--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -257,6 +257,8 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Checks that expired posts don't get included in the sitemap.
 	 *
 	 * @covers WPSEO_News_Sitemap::build_sitemap
+	 *
+	 * @requires PHP 5.5
 	 */
 	public function test_sitemap_only_showing_recent_items() {
 		$base_time = new DateTimeImmutable();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

The `DateTimeImmutable` class was only introduced in PHP 5.5.0.
The `DateInterval` class in PHP 5.3.0.

This test can therefore not be run on PHP < 5.5.0.

Adding the PHPUnit `@requires` annotation will ensure that the test suite will not break on this test.

Alternatively, if testing this functionality on PHP 5.2 - 5.4 is desired, the test will need to be refactored and the above mentioned classes removed from the test.

Ref:
* https://phpunit.de/manual/4.8/en/incomplete-and-skipped-tests.html#incomplete-and-skipped-tests.requires.tables.api

## Test instructions

This PR can be tested by following these steps:

* Locally switch to PHP 5.4 and the `trunk` branch, run the unit tests and see them fail with a fatal PHP error.
* Switch to this branch and see the unit test skip the test in question.

The Travis build should have alerted about this when the original unit test were pulled, but didn't due to  issue #402.
