### PR TITLE
Exclude artifact folder from POT file generation

### DIFF
--- a/grunt/config/makepot.js
+++ b/grunt/config/makepot.js
@@ -4,6 +4,7 @@ module.exports = {
 		options: {
 			domainPath: '<%= paths.languages %>',
 			potFilename: '<%= pkg.plugin.textdomain %>.pot',
+			exclude: [ 'artifact/.*' ],
 			potHeaders: {
 				poedit: true,
 				'report-msgid-bugs-to': '<%= pkg.pot.reportmsgidbugsto %>',


### PR DESCRIPTION
## Summary

If an artifact was build previously, this will be taken into account when re-generating the language files. Resulting in double entries which are not relevant.

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Excluded the `optionally present` artifact folder from being parsed for translations.

## Test instructions

This PR can be tested by following these steps:

* `grunt copy:artifact` - This generates an `artifact` folder in your local directory
* `grunt build:i18n` - This rebuilds the `pot` file

Fixes https://github.com/Yoast/wpseo-news/issues/406
