### PR TITLE
Remove original source

### DIFF
--- a/classes/class-head.php
+++ b/classes/class-head.php
@@ -35,33 +35,7 @@ class WPSEO_News_Head {
 
 			$this->post = $post;
 
-			$this->display_original_source();
 			$this->display_noindex();
-		}
-	}
-
-	/**
-	 * Displays the original-source as link-tag in head.
-	 */
-	private function display_original_source() {
-		/**
-		 * Filter: 'wpseo_news_head_display_original' - Allow preventing of outputting original source tag.
-		 *
-		 * @api bool unsigned Whether or not to show the original source.
-		 *
-		 * @param object $post The post.
-		 */
-		if ( apply_filters( 'wpseo_news_head_display_original', true, $this->post ) ) {
-			$original_source = trim( WPSEO_Meta::get_value( 'newssitemap-original', $this->post->ID ) );
-			if ( empty( $original_source ) ) {
-				echo '<meta name="original-source" content="' . esc_url( get_permalink( $this->post->ID ) ) . '" />' . "\n";
-			}
-			else {
-				$sources = explode( '|', $original_source );
-				foreach ( $sources as $source ) {
-					echo '<meta name="original-source" content="' . esc_url( $source ) . '" />' . "\n";
-				}
-			}
 		}
 	}
 

--- a/classes/class-meta-box.php
+++ b/classes/class-meta-box.php
@@ -58,13 +58,6 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 				'options'     => WPSEO_News::list_genres(),
 				'serialized'  => true,
 			),
-			'newssitemap-original'     => array(
-				'name'        => 'newssitemap-original',
-				'std'         => '',
-				'type'        => 'text',
-				'title'       => __( 'Original Source', 'wordpress-seo-news' ),
-				'description' => __( 'Is this article the original source of this news? If not, please enter the URL of the original source here. If there are multiple sources, please separate them by a pipe symbol: | .', 'wordpress-seo-news' ),
-			),
 			'newssitemap-stocktickers' => array(
 				'name'        => 'newssitemap-stocktickers',
 				'std'         => '',

--- a/classes/class-upgrade-manager.php
+++ b/classes/class-upgrade-manager.php
@@ -24,13 +24,11 @@ class WPSEO_News_Upgrade_Manager {
 
 		// Check if update is required.
 		if ( version_compare( WPSEO_News::VERSION, $options['version'], '>' ) ) {
-
 			// Do update.
 			$this->do_update( $options['version'] );
 
 			// Update version code.
 			$this->update_current_version_code();
-
 		}
 
 	}
@@ -41,39 +39,20 @@ class WPSEO_News_Upgrade_Manager {
 	 * @param string $current_version The current version.
 	 */
 	private function do_update( $current_version ) {
+		// Update to version 2.0.
+		if ( version_compare( $current_version, '2.0', '<' ) ) {
+			$this->upgrade_20();
+		}
 
 		// Upgrade to version 2.0.4.
 		if ( version_compare( $current_version, '2.0.4', '<' ) ) {
-
-			// Remove unused option.
-			$news_options = WPSEO_News::get_options();
-			unset( $news_options['ep_image_title'] );
-
-			// Update options.
-			update_option( 'wpseo_news', $news_options );
-
-			// Reset variable.
-			$news_options = null;
-
+			$this->upgrade_204();
 		}
 
-		// Update to version 2.0.
-		if ( version_compare( $current_version, '2.0', '<' ) ) {
-
-			// Get current options.
-			$current_options = get_option( 'wpseo_news' );
-
-			// Set new options.
-			$new_options = array(
-				'name'             => ( ( isset( $current_options['newssitemapname'] ) ) ? $current_options['newssitemapname'] : '' ),
-				'default_genre'    => ( ( isset( $current_options['newssitemap_default_genre'] ) ) ? $current_options['newssitemap_default_genre'] : '' ),
-			);
-
-			// Save new options.
-			update_option( 'wpseo_news', $new_options );
-
+		// Upgrade to version 7.8.
+		if ( version_compare( $current_version, '7.8', '<' ) ) {
+			$this->upgrade_78();
 		}
-
 	}
 
 	/**
@@ -83,5 +62,52 @@ class WPSEO_News_Upgrade_Manager {
 		$options            = WPSEO_News::get_options();
 		$options['version'] = WPSEO_News::VERSION;
 		update_option( 'wpseo_news', $options );
+	}
+
+	/**
+	 * Perform the upgrade to 2.0.
+	 */
+	private function upgrade_20() {
+		// Get current options.
+		$current_options = get_option( 'wpseo_news' );
+
+		// Set new options.
+		$new_options = array(
+			'name'          => ( ( isset( $current_options['newssitemapname'] ) ) ? $current_options['newssitemapname'] : '' ),
+			'default_genre' => ( ( isset( $current_options['newssitemap_default_genre'] ) ) ? $current_options['newssitemap_default_genre'] : '' ),
+		);
+
+		// Save new options.
+		update_option( 'wpseo_news', $new_options );
+	}
+
+	/**
+	 * Perform the upgrade to 2.0.4.
+	 */
+	private function upgrade_204() {
+		// Remove unused option.
+		$news_options = WPSEO_News::get_options();
+		unset( $news_options['ep_image_title'] );
+
+		// Update options.
+		update_option( 'wpseo_news', $news_options );
+
+		// Reset variable.
+		$news_options = null;
+	}
+
+	/**
+	 * Perform the upgrade to 7.8.
+	 */
+	private function upgrade_78() {
+		global $wpdb;
+		// Delete all standout tags. Functionality was deleted in 7.7, data only deleted in 7.8.
+		$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_key = '_yoast_wpseo_newssitemap-standout'" );
+
+		// Delete all editors picks settings.
+		$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_key = '_yoast_wpseo_newssitemap-editors-pick'" );
+
+		// Delete all editors picks settings.
+		$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_key = '_yoast_wpseo_newssitemap-original'" );
 	}
 }

--- a/classes/class-upgrade-manager.php
+++ b/classes/class-upgrade-manager.php
@@ -100,14 +100,31 @@ class WPSEO_News_Upgrade_Manager {
 	 * Perform the upgrade to 7.8.
 	 */
 	private function upgrade_78() {
-		global $wpdb;
 		// Delete all standout tags. Functionality was deleted in 7.7, data only deleted in 7.8.
-		$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_key = '_yoast_wpseo_newssitemap-standout'" );
+		$this->delete_meta_by_key( '_yoast_wpseo_newssitemap-standout' );
 
 		// Delete all editors picks settings.
-		$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_key = '_yoast_wpseo_newssitemap-editors-pick'" );
+		$this->delete_meta_by_key( '_yoast_wpseo_newssitemap-editors-pick' );
 
-		// Delete all editors picks settings.
-		$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_key = '_yoast_wpseo_newssitemap-original'" );
+		// Delete all original source references.
+		$this->delete_meta_by_key( '_yoast_wpseo_newssitemap-original' );
+	}
+
+	/**
+	 * Deletes post meta fields by key.
+	 *
+	 * @param string $key The key to delete post meta fields for.
+	 *
+	 * @link https://codex.wordpress.org/Class_Reference/wpdb#DELETE_Rows
+	 */
+	private function delete_meta_by_key( $key ) {
+		global $wpdb;
+		$wpdb->delete(
+			$wpdb->postmeta,
+			array(
+				'meta_key' => $key,
+			),
+			array( '%s' )
+		);
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes functionality for original-source as Google has confirmed they're no longer using it.

## Relevant technical choices:

* Deleted all code that had to do with it, didn't deprecate because there's no need. There were no tests for this.
* Deleted the data that was no longer useful, also deleted the data for functionality that was removed in 7.7.
* Decided to _keep_ the meta news keywords fields, people might be using those for something else and it was editorially put in, so I don't really want to delete it without user consent.

## Test instructions

This PR can be tested by following these steps:

* Go to News SEO settings on a post, see original source is gone.
