### PR TITLE
Added check to exclude no-index posts from news sitemap

### DIFF
--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -73,18 +73,16 @@ class WPSEO_News_Sitemap_Item {
 
 		$item_noindex = WPSEO_Meta::get_value( 'meta-robots-noindex', $this->item->ID );
 
-		if ( $item_noindex == 1 ) {
+		if ( $item_noindex === 1 ) {
 			return true;
 		}
 
-		if ( $item_noindex == 0 ) {
-			if ( WPSEO_Options::get( 'noindex-' . $this->item->post_type ) == 1 ) {
-				return true;
-			}
+		if ( $item_noindex === 0 && WPSEO_Options::get( 'noindex-' . $this->item->post_type ) === 1 ){
+			return true;
 		}
 
 		// Check the specific WordPress SEO News no-index value.
-		if ( WPSEO_Meta::get_value( 'newssitemap-robots-index', $this->item->ID ) == 1 ) {
+		if ( WPSEO_Meta::get_value( 'newssitemap-robots-index', $this->item->ID ) === 1 ) {
 			return true;
 		}
 

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -71,6 +71,23 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
+		$item_noindex = WPSEO_Meta::get_value( 'meta-robots-noindex', $this->item->ID );
+
+		if ( $item_noindex == 1 ) {
+			return true;
+		}
+
+		if ( $item_noindex == 0 ) {
+			if ( WPSEO_Options::get( 'noindex-' . $this->item->post_type ) == 1 ) {
+				return true;
+			}
+		}
+
+		// Check the specific WordPress SEO News no-index value.
+		if  ( WPSEO_Meta::get_value( 'newssitemap-robots-index', $this->item->ID ) == 1 ) {
+			return true;
+		}
+
 		if ( 'post' === $this->item->post_type && $this->exclude_item_terms() ) {
 			return true;
 		}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -67,7 +67,9 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
-		if ( false !== WPSEO_Meta::get_value( 'meta-robots', $this->item->ID ) && strpos( WPSEO_Meta::get_value( 'meta-robots', $this->item->ID ), 'noindex' ) !== false ) {
+		$meta_robots = WPSEO_Meta::get_value( 'meta-robots', $this->item->ID );
+		
+		if ( $meta_robots !== false && strpos( $meta_robots, 'noindex' ) !== false ) {
 			return true;
 		}
 

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -84,7 +84,7 @@ class WPSEO_News_Sitemap_Item {
 		}
 
 		// Check the specific WordPress SEO News no-index value.
-		if  ( WPSEO_Meta::get_value( 'newssitemap-robots-index', $this->item->ID ) == 1 ) {
+		if ( WPSEO_Meta::get_value( 'newssitemap-robots-index', $this->item->ID ) == 1 ) {
 			return true;
 		}
 

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -68,7 +68,7 @@ class WPSEO_News_Sitemap_Item {
 		}
 
 		$meta_robots = WPSEO_Meta::get_value( 'meta-robots', $this->item->ID );
-		
+
 		if ( $meta_robots !== false && strpos( $meta_robots, 'noindex' ) !== false ) {
 			return true;
 		}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -77,7 +77,7 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
-		if ( $item_noindex === 0 && WPSEO_Options::get( 'noindex-' . $this->item->post_type ) === 1 ){
+		if ( $item_noindex === 0 && WPSEO_Options::get( 'noindex-' . $this->item->post_type ) === 1 ) {
 			return true;
 		}
 

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -174,6 +174,8 @@ class WPSEO_News_Sitemap {
 
 	/**
 	 * Clear the sitemap and sitemap index every hour to make sure the sitemap is hidden or shown when it needs to be.
+	 *
+	 * @return void
 	 */
 	private function yoast_wpseo_news_schedule_clear() {
 		$schedule = wp_get_schedule( 'wpseo_news_schedule_sitemap_clear' );

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -173,7 +173,7 @@ class WPSEO_News_Sitemap {
 	}
 
 	/**
-	 * Clear the sitemap  and sitemap index every hour to make sure the sitemap is hidden or shown when it needs to be.
+	 * Clear the sitemap and sitemap index every hour to make sure the sitemap is hidden or shown when it needs to be.
 	 */
 	private function yoast_wpseo_news_schedule_clear() {
 		$schedule = wp_get_schedule( 'wpseo_news_schedule_sitemap_clear' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where news posts set to no-index would still appear in the XML News Sitemap. 

## Relevant technical choices:

* There are several settings to set a news post to no-index, in the database these are stored under `meta-robots-noindex'` for WPSEO and under `newssitemap-robots-index` for WPSEO News. The implementation is as such that if either of these two is set to no-index the post will not show in the news sitemap. 

## Test instructions

This PR can be tested by following these steps:

* Activate the WPSEO News plugin, create a new post and open the sitemap. See that the post is in the News Sitemap. Set the post to no-index in one of 3 ways: 
-Set the individual post to no-index (in the settings under the post)
-Set all posts to no-index (under "Search Appearance" --> "Content Types").
-Set the individual post to no-index under the News settings: Settings under the post, 4th (power plug) icon->Googlebot-News index.
* See that in all cases the post remains in the News Sitemap. 
* Check out this branch. See that if any of the above 3 options is set to no-index the post is removed from the News sitemap. 

Fixes #297 
