### PR TITLE
Do strict checks

### DIFF
--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -67,24 +67,18 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
-		$meta_robots = WPSEO_Meta::get_value( 'meta-robots', $this->item->ID );
-
-		if ( $meta_robots !== false && strpos( $meta_robots, 'noindex' ) !== false ) {
-			return true;
-		}
-
 		$item_noindex = WPSEO_Meta::get_value( 'meta-robots-noindex', $this->item->ID );
 
-		if ( $item_noindex === 1 ) {
+		if ( $item_noindex === '1' ) {
 			return true;
 		}
 
-		if ( $item_noindex === 0 && WPSEO_Options::get( 'noindex-' . $this->item->post_type ) === 1 ) {
+		if ( $item_noindex === '0' && WPSEO_Options::get( 'noindex-' . $this->item->post_type ) === true ) {
 			return true;
 		}
 
 		// Check the specific WordPress SEO News no-index value.
-		if ( WPSEO_Meta::get_value( 'newssitemap-robots-index', $this->item->ID ) === 1 ) {
+		if ( WPSEO_Meta::get_value( 'newssitemap-robots-index', $this->item->ID ) === '1' ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where no-indexed items are shown in the sitemap
 
## Test instructions

This PR can be tested by following these steps:

The next posts shouldn't visible on the news sitemap: 
* Create a post with `Exclude from News Sitemap` being checked. 
* Create a post with `Allow search engines to show this Post in search results?` set to `No`
* Set the default `Show Posts in search results?` for the content type `post` in SEO - Search Appearance - Post Types to `no` and create a post where you set `Allow search engines to show this Post in search results?` to default.
* Create  a post with `Googlebot-News index` set to `no-index`

Fixes #297
