### PR TITLE
Fixed a bug where the Publication Date in the News sitemap would be wrong

### DIFF
--- a/assets/xml-news-sitemap.xsl
+++ b/assets/xml-news-sitemap.xsl
@@ -104,7 +104,7 @@
 										<xsl:value-of select="count(image:image)"/>
 									</td>
 									<td>
-										<xsl:value-of select="concat(substring(n:news/n:publication_date,0,11),concat(' ', substring(n:news/n:publication_date,12,5)))"/>
+										<xsl:value-of select="n:news/n:publication_date"/>
 									</td>
 								</tr>
 							</xsl:for-each>

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -260,7 +260,7 @@ class WPSEO_News_Sitemap_Item {
 			$timezone_string = $timezone_option->wp_get_timezone_string();
 
 			// Is there a usable timezone string and does it exist in the list of 'valid' timezones.
-			if ( $timezone_string !== '' && ( in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) || ( preg_match( '/[+-][0-9]{4}/', $timezone_string  === 1 ) ) ) {
+			if ( $timezone_string !== '' && ( in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) || ( preg_match( '/[+-][0-9]{4}/', $timezone_string ) === 1 ) ) ) {
 				$timezone_format = DateTime::W3C;
 			}
 		}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -214,10 +214,11 @@ class WPSEO_News_Sitemap_Item {
 	 *
 	 * @return string
 	 */
-	private function get_publication_date( $item ) {
+	protected function get_publication_date( $item ) {
 		if ( $this->is_valid_datetime( $item->post_date_gmt ) ) {
 			return $this->format_date_with_timezone( $item->post_date_gmt, 'UTC' );
 		}
+
 		// Fallback: post_date.
 		if ( $this->is_valid_datetime( $item->post_date ) ) {
 			return $this->format_date_with_timezone( $item->post_date, new WPSEO_News_Sitemap_Timezone() );
@@ -227,13 +228,12 @@ class WPSEO_News_Sitemap_Item {
 	}
 
 	/**
-	 * Format a datestring with a timezone.
+	 * Format a date string with a timezone.
 	 *
 	 * @param string $item_date Date to parse.
+	 * @param string || object $time_zone Timezone to parse.
 	 *
-	 * @param string $time_zone Timezone to parse.
-	 *
-	 * @return string
+	 * @return string The formatted date string.
 	 */
 	private function format_date_with_timezone( $item_date, $time_zone ) {
 
@@ -241,6 +241,26 @@ class WPSEO_News_Sitemap_Item {
 		$datetime = new DateTime( $item_date, new DateTimeZone( $time_zone ) );
 
 		return $datetime->format( $this->get_date_format() );
+	}
+
+	/**
+	 * Checks if a DateTimeZone string is usable, either as a known timezone or as a numeric entry.
+	 *
+	 * @param string $timezone_string DateTimeZone string to check.
+	 *
+	 * @return bool
+	 */
+	private function is_timezone_usable( $timezone_string ) {
+		if ( $timezone_string === '' ) {
+			return false;
+		}
+
+		if ( in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) ) {
+			return true;
+		}
+
+		// Checks if the string matches a valid numeric DateTimeZone, for example "+0200".
+		return ( preg_match( '/[+-][0-9]{4}/', $timezone_string ) === 1 );
 	}
 
 	/**
@@ -260,7 +280,7 @@ class WPSEO_News_Sitemap_Item {
 			$timezone_string = $timezone_option->wp_get_timezone_string();
 
 			// Is there a usable timezone string and does it exist in the list of 'valid' timezones.
-			if ( $timezone_string !== '' && ( in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) || ( preg_match( '/[+-][0-9]{4}/', $timezone_string ) === 1 ) ) ) {
+			if ( $this->is_timezone_usable( $timezone_string ) ) {
 				$timezone_format = DateTime::W3C;
 			}
 		}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -230,7 +230,7 @@ class WPSEO_News_Sitemap_Item {
 	/**
 	 * Format a date string with a timezone.
 	 *
-	 * @param string $item_date Date to parse.
+	 * @param string           $item_date Date to parse.
 	 * @param string || object $time_zone Timezone to parse.
 	 *
 	 * @return string The formatted date string.

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -260,7 +260,7 @@ class WPSEO_News_Sitemap_Item {
 			$timezone_string = $timezone_option->wp_get_timezone_string();
 
 			// Is there a usable timezone string and does it exist in the list of 'valid' timezones.
-			if ( $timezone_string !== '' && in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) || strlen($timezone_string) === 5) {
+			if ( $timezone_string !== '' && ( in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) || ( preg_match("/[+-][0-9]{4}/", $timezone_string) === 1 ) ) ) {
 				$timezone_format = DateTime::W3C;
 			}
 		}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -271,7 +271,7 @@ class WPSEO_News_Sitemap_Item {
 	private function get_date_format() {
 		static $timezone_format;
 
-		if ( ! isset( $timezone_format ) ) {
+		if ( $timezone_format === null ) {
 			// Set a default.
 			$timezone_format = 'Y-m-d';
 

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -216,20 +216,11 @@ class WPSEO_News_Sitemap_Item {
 	 */
 	private function get_publication_date( $item ) {
 		if ( $this->is_valid_datetime( $item->post_date_gmt ) ) {
-			// Create a DateTime object date in the correct timezone.
-			return $this->format_date_with_timezone( $item->post_date_gmt );
+			return $this->format_date_with_timezone( $item->post_date_gmt, 'UTC' );
 		}
-		if ( $this->is_valid_datetime( $item->post_modified_gmt ) ) {
-			// Fallback 1: post_modified_gmt.
-			return $this->format_date_with_timezone( $item->post_modified_gmt );
-		}
-		if ( $this->is_valid_datetime( $item->post_modified ) ) {
-			// Fallback 2: post_modified.
-			return $this->format_date_with_timezone( $item->post_modified );
-		}
+		// Fallback: post_date.
 		if ( $this->is_valid_datetime( $item->post_date ) ) {
-			// Fallback 3: post_date.
-			return $this->format_date_with_timezone( $item->post_date );
+			return $this->format_date_with_timezone( $item->post_date, new WPSEO_News_Sitemap_Timezone() );
 		}
 
 		return '';
@@ -240,18 +231,14 @@ class WPSEO_News_Sitemap_Item {
 	 *
 	 * @param string $item_date Date to parse.
 	 *
+	 * @param string $time_zone Timezone to parse.
+	 *
 	 * @return string
 	 */
-	private function format_date_with_timezone( $item_date ) {
-		static $timezone_string;
-
-		if ( $timezone_string === null ) {
-			// Get the timezone string.
-			$timezone_string = new WPSEO_News_Sitemap_Timezone();
-		}
+	private function format_date_with_timezone( $item_date, $time_zone ) {
 
 		// Create a DateTime object date in the correct timezone.
-		$datetime = new DateTime( $item_date, new DateTimeZone( $timezone_string ) );
+		$datetime = new DateTime( $item_date, new DateTimeZone( $time_zone ) );
 
 		return $datetime->format( $this->get_date_format() );
 	}
@@ -272,8 +259,8 @@ class WPSEO_News_Sitemap_Item {
 			$timezone_option = new WPSEO_News_Sitemap_Timezone();
 			$timezone_string = $timezone_option->wp_get_timezone_string();
 
-			// Is there a usable timezone string and does it exists in the list of 'valid' timezones.
-			if ( $timezone_string !== '' && in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) ) {
+			// Is there a usable timezone string and does it exist in the list of 'valid' timezones.
+			if ( $timezone_string !== '' && in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) || strlen($timezone_string) === 5) {
 				$timezone_format = DateTime::W3C;
 			}
 		}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -260,7 +260,7 @@ class WPSEO_News_Sitemap_Item {
 			$timezone_string = $timezone_option->wp_get_timezone_string();
 
 			// Is there a usable timezone string and does it exist in the list of 'valid' timezones.
-			if ( $timezone_string !== '' && ( in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) || ( preg_match("/[+-][0-9]{4}/", $timezone_string) === 1 ) ) ) {
+			if ( $timezone_string !== '' && ( in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) || ( preg_match( '/[+-][0-9]{4}/', $timezone_string  === 1 ) ) ) {
 				$timezone_format = DateTime::W3C;
 			}
 		}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -230,8 +230,8 @@ class WPSEO_News_Sitemap_Item {
 	/**
 	 * Format a date string with a timezone.
 	 *
-	 * @param string           $item_date Date to parse.
-	 * @param string || object $time_zone Timezone to parse.
+	 * @param string                                $item_date Date to parse.
+	 * @param string || WPSEO_News_Sitemap_Timezone $time_zone Timezone to parse.
 	 *
 	 * @return string The formatted date string.
 	 */

--- a/classes/class-sitemap-timezone.php
+++ b/classes/class-sitemap-timezone.php
@@ -35,29 +35,31 @@ class WPSEO_News_Sitemap_Timezone {
 			return $timezone;
 		}
 
+		$utc_offset = get_option( 'gmt_offset', 0 );
+
 		// Get UTC offset, if it isn't set then return UTC.
-		if ( 0 === ( $utc_offset = get_option( 'gmt_offset', 0 ) ) ) {
+		if ( $utc_offset === 0 ) {
 			return 'UTC';
 		}
 
-		// Adjust UTC offset from hours to seconds.
-		$utc_offset *= HOUR_IN_SECONDS;
+		// Format the UTC offset to a string readable by DateTimeZone()
 
-		// Attempt to guess the timezone string from the UTC offset.
-		$timezone = timezone_name_from_abbr( '', $utc_offset );
+		$offset_float = floatval( $utc_offset );
 
-		if ( false !== $timezone ) {
-			return $timezone;
+		if ( $utc_offset < 0 ) {
+			$offset_float *= -1;
 		}
 
-		// Last try, guess timezone string manually.
-		$timezone_id = $this->get_timezone_id( $utc_offset );
-		if ( $timezone_id ) {
-			return $timezone_id;
+		$offset_int = floor( $offset_float );
+		$offset_minutes_float = ( $offset_float - $offset_int ) * 60;
+		$offset_minutes = sprintf("%02d", $offset_minutes_float);
+		$offset_hours = sprintf("%02d", $offset_int);
+
+		if ( $utc_offset >= 0 ) {
+			return '+' . $offset_hours . $offset_minutes;
 		}
 
-		// Fallback to UTC.
-		return 'UTC';
+		return '-' . $offset_hours . $offset_minutes;
 	}
 
 

--- a/classes/class-sitemap-timezone.php
+++ b/classes/class-sitemap-timezone.php
@@ -43,43 +43,16 @@ class WPSEO_News_Sitemap_Timezone {
 		}
 
 		// Format the UTC offset to a string readable by DateTimeZone.
-		$offset_float = floatval( $utc_offset );
-
-		if ( $utc_offset < 0 ) {
-			$offset_float *= -1;
-		}
-
-		$offset_int = floor( $offset_float );
+		$offset_float         = abs( floatval( $utc_offset ) );
+		$offset_int           = floor( $offset_float );
 		$offset_minutes_float = ( ( $offset_float - $offset_int ) * 60 );
-		$offset_minutes = sprintf( '%02d' , $offset_minutes_float );
-		$offset_hours = sprintf( '%02d', $offset_int );
+		$offset_minutes       = sprintf( '%02d' , $offset_minutes_float );
+		$offset_hours         = sprintf( '%02d', $offset_int );
 
 		if ( $utc_offset >= 0 ) {
 			return '+' . $offset_hours . $offset_minutes;
 		}
 
 		return '-' . $offset_hours . $offset_minutes;
-	}
-
-
-	/**
-	 * Getting the timezone id.
-	 *
-	 * @param string $utc_offset Offset to use.
-	 *
-	 * @return mixed
-	 */
-	private function get_timezone_id( $utc_offset ) {
-		$is_dst = date( 'I' );
-
-		foreach ( timezone_abbreviations_list() as $abbr ) {
-			foreach ( $abbr as $city ) {
-				if ( $city['dst'] === $is_dst && $city['offset'] === $utc_offset ) {
-					return $city['timezone_id'];
-				}
-			}
-		}
-
-		return false;
 	}
 }

--- a/classes/class-sitemap-timezone.php
+++ b/classes/class-sitemap-timezone.php
@@ -42,8 +42,7 @@ class WPSEO_News_Sitemap_Timezone {
 			return 'UTC';
 		}
 
-		// Format the UTC offset to a string readable by DateTimeZone()
-
+		// Format the UTC offset to a string readable by DateTimeZone.
 		$offset_float = floatval( $utc_offset );
 
 		if ( $utc_offset < 0 ) {
@@ -51,9 +50,9 @@ class WPSEO_News_Sitemap_Timezone {
 		}
 
 		$offset_int = floor( $offset_float );
-		$offset_minutes_float = ( $offset_float - $offset_int ) * 60;
-		$offset_minutes = sprintf("%02d", $offset_minutes_float);
-		$offset_hours = sprintf("%02d", $offset_int);
+		$offset_minutes_float = ( ( $offset_float - $offset_int ) * 60 );
+		$offset_minutes = sprintf( '%02d' , $offset_minutes_float );
+		$offset_hours = sprintf( '%02d', $offset_int );
 
 		if ( $utc_offset >= 0 ) {
 			return '+' . $offset_hours . $offset_minutes;

--- a/tests/assets/wpseo-news-sitemap-item-double.php
+++ b/tests/assets/wpseo-news-sitemap-item-double.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Yoast SEO: News plugin test file.
+ *
+ * @package WPSEO_News\Tests
+ */
+
+/**
+ * Class WPSEO_News_Sitemap_Item.
+ */
+class WPSEO_News_Sitemap_Item_Double extends WPSEO_News_Sitemap_Item {
+
+	/**
+	 * @inheritdoc
+	 */
+	public function get_publication_date( $item ) {
+		return parent::get_publication_date( $item );
+	}
+}

--- a/tests/test-class-sitemap-item.php
+++ b/tests/test-class-sitemap-item.php
@@ -11,34 +11,29 @@
 class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 
 	/**
-	 * Instance of the WPSEO_News_Sitemap_Item class.
-	 *
-	 * @var \WPSEO_News_Sitemap_Item
-	 */
-	private $instance;
-
-	/**
 	 * Checks if the time output for the sitemap is correct when there is a post_date_gmt set.
 	 *
 	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
+	 * @covers WPSEO_News_Sitemap_Item::is_valid_datetime
+	 * @covers WPSEO_News_Sitemap_Item::format_date_with_timezone
 	 */
 	public function test_get_publication_date_returning_correct_UTC_time() {
 		$base_time = time();
 		$timezone_format = DateTime::W3C;
 
-		$test_post_date_gmt = $this->factory->post->create_and_get(
+		$test_post_date_gmt = self::factory()->post->create_and_get(
 			array(
 				'post_title'    => 'Newest post',
 				'post_date'     => date( $timezone_format, $base_time ),
-				'post_date_gmt' => date( $timezone_format, $base_time )
+				'post_date_gmt' => date( $timezone_format, $base_time ),
 			)
 		);
 
 		$test_options = WPSEO_News::get_options();
-		$this->instance = new WPSEO_News_Sitemap_Item_Double($test_post_date_gmt, $test_options);
+		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_post_date_gmt, $test_options );
 
 		$original_post_UTC_time      = date( $timezone_format, $base_time );
-		$get_publication_date_output = $this->instance->get_publication_date( $test_post_date_gmt );
+		$get_publication_date_output = $instance->get_publication_date( $test_post_date_gmt );
 
 		// Check if post_date_gmt is equal to output of get_publication_date().
 		$this->assertEquals( $original_post_UTC_time, $get_publication_date_output );
@@ -48,12 +43,14 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * Checks if the time output for the sitemap is correct when there is no post_date_gmt set.
 	 *
 	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
+	 * @covers WPSEO_News_Sitemap_Item::is_valid_datetime
+	 * @covers WPSEO_News_Sitemap_Item::format_date_with_timezone
 	 */
 	public function test_get_publication_date_returning_correct_post_date_when_no_gmt_set() {
 		$base_time = time();
 		$timezone_format = DateTime::W3C;
 
-		$test_post_date = $this->factory->post->create_and_get(
+		$test_post_date = self::factory()->post->create_and_get(
 			array(
 				'post_title'    => 'Newest post',
 				'post_date'     => date( $timezone_format, $base_time ),
@@ -61,16 +58,42 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		);
 
 		// Manually set post_date_gmt to an invalid string, because at creation WP forces a valid string.
-		$test_post_date->post_date_gmt = "This is an invalid string";
+		$test_post_date->post_date_gmt = 'This is an invalid string';
 
 		$test_options = WPSEO_News::get_options();
-		$this->instance = new WPSEO_News_Sitemap_Item_Double($test_post_date, $test_options);
+		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_post_date, $test_options );
 
 		$original_post_date          = date( $timezone_format, $base_time );
-		$get_publication_date_output = $this->instance->get_publication_date( $test_post_date );
+		$get_publication_date_output = $instance->get_publication_date( $test_post_date );
 
 		// Check if post_date is equal to output of get_publication_date().
 		$this->assertEquals( $original_post_date, $get_publication_date_output );
+	}
+
+
+	/**
+	 * Checks if the time output for the sitemap is an empty string when dates are
+	 * invalid.
+	 *
+	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
+	 */
+	public function test_get_publication_date_with_invalid_datetime() {
+		$test_post_date_gmt = self::factory()->post->create_and_get(
+			array(
+				'post_title'    => 'Newest post'
+			)
+		);
+
+		$test_post_date_gmt->post_date     = -10;
+		$test_post_date_gmt->post_date_gmt = -10;
+
+		$test_options = WPSEO_News::get_options();
+		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_post_date_gmt, $test_options );
+
+		$get_publication_date_output = $instance->get_publication_date( $test_post_date_gmt );
+
+		// Check if post_date_gmt is equal to output of get_publication_date().
+		$this->assertEquals( '', $get_publication_date_output );
 	}
 }
 

--- a/tests/test-class-sitemap-item.php
+++ b/tests/test-class-sitemap-item.php
@@ -70,7 +70,6 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$this->assertEquals( $original_post_date, $get_publication_date_output );
 	}
 
-
 	/**
 	 * Checks if the time output for the sitemap is an empty string when dates are
 	 * invalid.
@@ -80,7 +79,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	public function test_get_publication_date_with_invalid_datetime() {
 		$test_post_date_gmt = self::factory()->post->create_and_get(
 			array(
-				'post_title'    => 'Newest post'
+				'post_title'    => 'Newest post',
 			)
 		);
 

--- a/tests/test-class-sitemap-item.php
+++ b/tests/test-class-sitemap-item.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Yoast SEO: News plugin test file.
+ *
+ * @package WPSEO_News\Tests
+ */
+
+/**
+ * Class WPSEO_News_Sitemap_Item_Test.
+ */
+class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
+
+	/**
+	 * Instance of the WPSEO_News_Sitemap_Item class.
+	 *
+	 * @var \WPSEO_News_Sitemap_Item
+	 */
+	private $instance;
+
+	/**
+	 * Checks if the time output for the sitemap is correct when there is a post_date_gmt set.
+	 *
+	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
+	 */
+	public function test_get_publication_date_returning_correct_UTC_time() {
+		$base_time = time();
+		$timezone_format = DateTime::W3C;
+
+		$test_post_date_gmt = $this->factory->post->create_and_get(
+			array(
+				'post_title'    => 'Newest post',
+				'post_date'     => date( $timezone_format, $base_time ),
+				'post_date_gmt' => date( $timezone_format, $base_time )
+			)
+		);
+
+		$test_options = WPSEO_News::get_options();
+		$this->instance = new WPSEO_News_Sitemap_Item_Double($test_post_date_gmt, $test_options);
+
+		$original_post_UTC_time      = date( $timezone_format, $base_time );
+		$get_publication_date_output = $this->instance->get_publication_date( $test_post_date_gmt );
+
+		// Check if post_date_gmt is equal to output of get_publication_date().
+		$this->assertEquals( $original_post_UTC_time, $get_publication_date_output );
+	}
+
+	/**
+	 * Checks if the time output for the sitemap is correct when there is no post_date_gmt set.
+	 *
+	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
+	 */
+	public function test_get_publication_date_returning_correct_post_date_when_no_gmt_set() {
+		$base_time = time();
+		$timezone_format = DateTime::W3C;
+
+		$test_post_date = $this->factory->post->create_and_get(
+			array(
+				'post_title'    => 'Newest post',
+				'post_date'     => date( $timezone_format, $base_time ),
+			)
+		);
+
+		// Manually set post_date_gmt to an invalid string, because at creation WP forces a valid string.
+		$test_post_date->post_date_gmt = "This is an invalid string";
+
+		$test_options = WPSEO_News::get_options();
+		$this->instance = new WPSEO_News_Sitemap_Item_Double($test_post_date, $test_options);
+
+		$original_post_date          = date( $timezone_format, $base_time );
+		$get_publication_date_output = $this->instance->get_publication_date( $test_post_date );
+
+		// Check if post_date is equal to output of get_publication_date().
+		$this->assertEquals( $original_post_date, $get_publication_date_output );
+	}
+}
+


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the Publication Date in the News sitemap would be wrong when a hardcoded timezone was set (for example UTC + 2). 

## Relevant technical choices:

* Class-sitemap-item now returns the UTC time by default in the news sitemap, if `post_date_gmt` is for the post. If not, it defaults to 'post_date' and returns the local time + timezone modifier. 
* Removed fallbacks relying on `post_modified` data, as this data is not available there and this always threw an error. 
* Removed code from 'class-sitemap-item' that attempted to guess the timezone, and replaced this with a conversion into a usable hard coded time string.   

## Test instructions

This PR can be tested by following these steps:

**How to reproduce:** 
* Make sure the Yoast test helper is activated with 'Disable the XML sitemaps cache.' checked. 
* Now go to `Settings->General`, set timezone to **"Amsterdam"**.
* Create a new post, put the local UTC time in the title (just to make it easier to read). In this example let's say it's '14:19'. If you want to double check the current utc time,  type "current utc time" in google, to make sure you are comparing the news sitemap time with the correct time. 
* Go to `Yoast settings > News SEO > View news sitemap`. 
* The news sitemap should read:  "14:19:05+02:00", Which is incorrect. 

**How to test:** 
* Now checkout this branch and repeat the steps. 
* The time in the news sitemap should now be the correct UTC time without a modifier. For example. If the timezone setting for your website is on Amsterdam and your post is published at 11:00, the time in the sitemap should be 9:00. 

* timezone **"Amsterdam"**:
The news sitemap should read:  "14:19:05+00:00", Which is correct. 

* Timezone **"UTC+2"**.
The news sitemap should read:  "14:19:05+00:00", Which is correct. 

* Finally, The fallback for having no `post_date_gmt` set for your post is to my knowledge not testable, as this value seems to be always set to a valid value, even if you delete it from the database. 

Fixes #227.

This is only 1/2 of the fix of #227. This fixes the wrong time in the news sitemap, but not in the publication_date metadata. This will be fixed in wordpress-seo in a separate issue.  
