### PR TITLE
Make sure the artifact matches the release zip

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,6 +22,7 @@ module.exports = function( grunt ) {
 			logs: "logs/"
 		},
 		files: {
+			artifact: "artifact",
 			js: [
 				"assets/**/*.js",
 				"!assets/**/*.min.js"

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -4,6 +4,7 @@
 build:
   - 'build:js'
   - 'build:i18n'
+
 # Build JavaScript from assets to production
 'build:js':
   - 'uglify'
@@ -28,18 +29,16 @@ check:
   - 'phpcs'
 'check:i18n':
   - 'checktextdomain'
+
 # Create a zipped artifact from a fresh build
-'create:artifact':
+'artifact':
   - 'update-version'
+  - 'shell:production-composer-install'
   - 'build'
+  - 'clean:artifact'
   - 'copy:artifact'
   - 'compress:artifact'
-# Copy the needed files to the ./artifact folder
-'copy:artifact':
-  - 'copy:artifactFiles'
-# Create a compressed zip from the ./artifact folder
-'compress:artifact':
-  - 'compress:artifactFiles'
+
 # Default task
 default:
   - build

--- a/grunt/config/clean.js
+++ b/grunt/config/clean.js
@@ -1,0 +1,10 @@
+// See https://github.com/gruntjs/grunt-contrib-clean for details.
+module.exports = {
+	"language-files": [
+		"<%= paths.languages %>*",
+		"!<%= paths.languages %>index.php",
+	],
+	artifact: [
+		"<%= files.artifact %>",
+	],
+};

--- a/grunt/config/compress.js
+++ b/grunt/config/compress.js
@@ -1,15 +1,15 @@
 module.exports = {
-	artifactFiles: {
+	artifact: {
 		options: {
 			archive: "artifact.zip",
+			level: 9,
 		},
 		files: [
 			{
-				expand: true,
-				cwd: "artifact/",
+				cwd: "<%= files.artifact %>/",
 				src: ["**"],
-				dest: "./",
+				dest: "wpseo-news",
 			},
 		],
 	},
-}
+};

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -1,20 +1,21 @@
 module.exports = {
-	artifactFiles: {
+	artifact: {
 		files: [
 			{
 				expand: true,
 				cwd: ".",
 				src: [
-					// Folders to copy.
-					"vendor/**",
-					"languages/**",
 					// Files to copy.
-					"/assets/xml-news-sitemap.xsl",
-					"/assets/*.min.js",
+					"assets/xml-news-sitemap.xsl",
+					"assets/*.min.js",
+					"classes/**",
+					"languages/*.mo",
+					"vendor/**",
+					"license.txt",
 					"*.php"
 				],
-				dest: "artifact",
+				dest: "<%= files.artifact %>",
 			},
 		],
 	},
-}
+};

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -1,0 +1,8 @@
+// See https://github.com/sindresorhus/grunt-shell
+module.exports = function( grunt ) {
+	return {
+		"production-composer-install": {
+			command: "composer install --prefer-dist --optimize-autoloader --no-dev",
+		},
+	};
+};


### PR DESCRIPTION
This fixes the grunt tasks to build a zip file that matches the release zip
Removes abundant grunt commands
Uses the general "artifact" for consistency and Wiki build script compatibility

**After this is merged, the release and beta script need to be updated** - when the release branch is made that includes this change! (Suspected to be 8.4)
For instructions, see issue.

## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Download the latest zip of News SEO (from the releases on this repo)
* Run `grunt artifact` in the branch
* Verify that all files and folders you expect to be there are actually in the `artifact.zip`
* Verify that the zip size closely matches the release zip (it is slightly bigger because certain files in the `vendor` folder are not specifically removed)

Fixes #426 
