### PR TITLE
 Prevents post type 'post' from being always on

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -28,7 +28,6 @@ class WPSEO_News {
 			'default_genre'            => array(),
 			'ep_image_src'             => '',
 			'version'                  => '0',
-			'newssitemap_include_post' => 'on',
 		) ) );
 	}
 


### PR DESCRIPTION
Fixes #422 

## Summary

This PR can be summarized in the following changelog entry:

*  Prevents post type 'post' from being always on for News SEO.

## Test instructions

This PR can be tested by following these steps:

* See #422, repeat those steps with and without patch.
