### PR TITLE
Prevents post type 'post' from being always on for news seo

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -28,7 +28,6 @@ class WPSEO_News {
 			'default_genre'            => array(),
 			'ep_image_src'             => '',
 			'version'                  => '0',
-			'newssitemap_include_post' => 'on',
 		) ) );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* See #428 
