### PR TITLE
Add term exclusion for all taxonomies connected to enabled post types

### DIFF
--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -155,8 +155,9 @@ class WPSEO_News_Admin_Page {
 			}
 
 			$terms_per_taxonomy[] = array(
-				'taxonomy' => $taxonomy,
-				'terms'    => $terms,
+				'taxonomy'   => $taxonomy,
+				'terms'      => $terms,
+				'term_count' => 0,
 			);
 		}
 
@@ -174,11 +175,16 @@ class WPSEO_News_Admin_Page {
 		foreach ( $terms_per_taxonomy as $data ) {
 			$taxonomy = $data['taxonomy'];
 			$terms    = $data['terms'];
+			$count    = $data['term_count'];
 
 			echo '<h3>' . sprintf( esc_html__( '%1$s to exclude', 'wordpress-seo-news' ), $taxonomy->labels->name ) . '</h3>';
 
 			foreach ( $terms as $term ) {
-				echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type->name, $term->name, false );
+				echo WPSEO_News_Wrappers::checkbox(
+					'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type->name,
+					$term->name . ' (' . $count . ' ' . $post_type->label . ')',
+					false
+				);
 			}
 		}
 	}

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -125,7 +125,7 @@ class WPSEO_News_Admin_Page {
 	/**
 	 * Filter function used to determine what post times should be included in the new sitemap.
 	 *
-	 * @param $post_type WP_Post_Type The post type.
+	 * @param WP_Post_Type $post_type The post type.
 	 *
 	 * @return bool Whether or not the post type should be included in the sitemap.
 	 */

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -129,8 +129,6 @@ class WPSEO_News_Admin_Page {
 				continue;
 			}
 
-			echo '<h2>' . sprintf( esc_html__( 'Terms to exclude for %1$s', 'wordpress-seo-news' ), $post_type->labels->name ) . '</h2>';
-
 			$this->excluded_post_type_taxonomies_output( $terms_per_taxonomy, $post_type );
 		}
 	}
@@ -171,10 +169,15 @@ class WPSEO_News_Admin_Page {
 	 * @return void
 	 */
 	private function excluded_post_type_taxonomies_output( $terms_per_taxonomy, $post_type ) {
+
+		/* translators: %1%s expands to the post type name. */
+		echo '<h2>' . sprintf( esc_html__( 'Terms to exclude for %1$s', 'wordpress-seo-news' ), $post_type->labels->name ) . '</h2>';
+
 		foreach ( $terms_per_taxonomy as $data ) {
 			$taxonomy = $data['taxonomy'];
 			$terms    = $data['terms'];
 
+			/* translators: %1%s expands to the taxonomy name name. */
 			echo '<h3>' . sprintf( esc_html__( '%1$s to exclude', 'wordpress-seo-news' ), $taxonomy->labels->name ) . '</h3>';
 
 			foreach ( $terms as $term ) {

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -145,9 +145,8 @@ class WPSEO_News_Admin_Page {
 	 */
 	private function get_excluded_post_type_taxonomies( $post_type ) {
 		$terms_per_taxonomy = array();
-		$taxonomies = get_object_taxonomies( $post_type->name, 'objects' );
 
-		foreach ( $taxonomies as $taxonomy ) {
+		foreach ( get_object_taxonomies( $post_type->name, 'objects' ) as $taxonomy ) {
 			$terms = get_terms( array( 'taxonomy' => $taxonomy->name, 'hide_empty' => false ) );
 
 			if ( count( $terms ) === 0 ) {
@@ -157,7 +156,6 @@ class WPSEO_News_Admin_Page {
 			$terms_per_taxonomy[] = array(
 				'taxonomy'   => $taxonomy,
 				'terms'      => $terms,
-				'term_count' => 0,
 			);
 		}
 

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -112,13 +112,16 @@ class WPSEO_News_Admin_Page {
 	 * Generate HTML for excluding post categories.
 	 */
 	private function excluded_post_categories() {
-		if ( isset( $this->options['newssitemap_include_post'] ) ) {
-			echo '<h2>' . esc_html__( 'Post categories to exclude', 'wordpress-seo-news' ) . '</h2>';
-			echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'Post categories to exclude', 'wordpress-seo-news' ) . '</legend>';
-			foreach ( get_categories() as $cat ) {
-				echo WPSEO_News_Wrappers::checkbox( 'catexclude_' . $cat->slug, $cat->name . ' (' . $cat->count . ' posts)', false );
+		foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $post_type ) {
+			if ( isset( $this->options[ 'newssitemap_include_' . $post_type->name ] ) && ( 'on' === $this->options[ 'newssitemap_include_' . $post_type->name ] ) ) {
+				$taxonomies = get_object_taxonomies( $post_type->name, 'objects' );
+				foreach( $taxonomies as $taxonomy ) {
+					echo '<h2>' . sprintf( esc_html__( '%1$s %2$s to exclude', 'wordpress-seo-news' ), $post_type->labels->singular_name, $taxonomy->labels->name ) . '</h2>';
+					foreach( get_terms( array( 'taxonomy' => $taxonomy->name, 'hide_empty' => false ) ) as $term ) {
+						echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug, $term->name . ' (' . $term->count . ' posts)', false );
+					}
+				}
 			}
-			echo '</fieldset><br>';
 		}
 	}
 

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -96,27 +96,30 @@ class WPSEO_News_Admin_Page {
 	}
 
 	/**
-	 * Generate HTML for the post types which should be included in the sitemap.
+	 * Generates the HTML for the post types which should be included in the sitemap.
 	 */
 	private function include_post_types() {
 		// Post Types to include in News Sitemap.
 		echo '<h2>' . esc_html__( 'Post Types to include in News Sitemap', 'wordpress-seo-news' ) . '</h2>';
 		echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'Post Types to include:', 'wordpress-seo-news' ) . '</legend>';
+
 		foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $posttype ) {
 			echo WPSEO_News_Wrappers::checkbox( 'newssitemap_include_' . $posttype->name, $posttype->labels->name . ' (<code>' . $posttype->name . '</code>)', false );
 		}
+
 		echo '</fieldset><br>';
 	}
 
 	/**
-	 * Generate HTML for excluding post categories.
+	 * Generates the HTML for excluding post categories.
 	 *
 	 * @return void
 	 */
 	private function excluded_post_type_taxonomies() {
 		foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $post_type ) {
 			$option_key = 'newssitemap_include_' . $post_type->name;
-			if ( isset( $this->options[ $option_key ] ) && ( 'on' === $this->options[ $option_key ] ) ) {
+
+			if ( isset( $this->options[ $option_key ] ) && ( $this->options[ $option_key ] === 'on' ) ) {
 				$this->excluded_post_type_taxonomies_output( $post_type );
 			}
 		}
@@ -130,13 +133,15 @@ class WPSEO_News_Admin_Page {
 	 * @return void
 	 */
 	private function excluded_post_type_taxonomies_output( $post_type ) {
-		$taxonomies = get_object_taxonomies( $post_type->name, 'objects' );
-		foreach ( $taxonomies as $taxonomy ) {
+		foreach ( get_object_taxonomies( $post_type->name, 'objects' ) as $taxonomy ) {
 			$terms = get_terms( array( 'taxonomy' => $taxonomy->name, 'hide_empty' => false ) );
+
 			if ( count( $terms ) === 0 ) {
 				continue;
 			}
+
 			echo '<h2>' . sprintf( esc_html__( '%1$s %2$s to exclude', 'wordpress-seo-news' ), $post_type->labels->singular_name, $taxonomy->labels->name ) . '</h2>';
+
 			foreach ( $terms as $term ) {
 				echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug, $term->name . ' (' . $term->count . ' posts)', false );
 			}

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -165,6 +165,37 @@ class WPSEO_News_Admin_Page {
 	}
 
 	/**
+	 * Performs a query getting all term counts per specific post type, and returns
+	 * the results in an array with the key [post_type]_[term_id].
+	 *
+	 * Does takes trashed posts and revisions into account.
+	 *
+	 * @return array Term counts per post type.
+	 */
+	private function get_term_count_per_post_type() {
+		global $wpdb;
+		$posts_table              = $wpdb->prefix . 'posts';
+		$term_relationships_table = $wpdb->prefix . 'term_relationships';
+
+		$results = $wpdb->get_results(
+			"SELECT posts.post_type as post_type, tr.term_taxonomy_id as term_id, COUNT( tr.term_taxonomy_id ) as count FROM $posts_table as posts
+			INNER JOIN $term_relationships_table as tr
+			ON posts.ID=tr.object_id
+			WHERE posts.post_status!='trash' and posts.post_status!='inherit'
+			GROUP BY posts.post_type, tr.term_taxonomy_id"
+		);
+
+		$counts = array();
+
+		foreach ( $results as $query_row ) {
+			$id = $query_row->post_type . '_' . $query_row->term_id;
+			$counts[ $id ] = $query_row->count;
+		}
+
+		return $counts;
+	}
+
+	/**
 	 * Echoes the sub heading + checkboxes to exclude terms within each of the post type's taxonomies.
 	 *
 	 * @param array $terms_per_taxonomy Array containing arrays with 'taxonomy' and corresponding 'terms'.
@@ -172,14 +203,21 @@ class WPSEO_News_Admin_Page {
 	 * @return void
 	 */
 	private function excluded_post_type_taxonomies_output( $terms_per_taxonomy, $post_type ) {
+		$term_counts = $this->get_term_count_per_post_type();
+
 		foreach ( $terms_per_taxonomy as $data ) {
 			$taxonomy = $data['taxonomy'];
 			$terms    = $data['terms'];
-			$count    = $data['term_count'];
 
 			echo '<h3>' . sprintf( esc_html__( '%1$s to exclude', 'wordpress-seo-news' ), $taxonomy->labels->name ) . '</h3>';
 
 			foreach ( $terms as $term ) {
+				$count = $term_counts[ $post_type->name . '_' . $term->term_id ];
+
+				if ( empty( $count ) ) {
+					$count = '0';
+				}
+
 				echo WPSEO_News_Wrappers::checkbox(
 					'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type->name,
 					$term->name . ' (' . $count . ' ' . $post_type->label . ')',

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -167,9 +167,7 @@ class WPSEO_News_Admin_Page {
 	/**
 	 * Echoes the sub heading + checkboxes to exclude terms within each of the post type's taxonomies.
 	 *
-	 * @param array             $terms_per_taxonomy Post type for which to exclude taxonomies.
-	 * @param array['taxonomy'] WP_Taxonomy         The taxonomy.
-	 * @param array['terms']    array               The terms.
+	 * @param array $terms_per_taxonomy Array containing arrays with 'taxonomy' and corresponding 'terms'.
 	 *
 	 * @return void
 	 */

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -119,17 +119,19 @@ class WPSEO_News_Admin_Page {
 		foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $post_type ) {
 			$option_key = 'newssitemap_include_' . $post_type->name;
 
-			if ( isset( $this->options[ $option_key ] ) && ( $this->options[ $option_key ] === 'on' ) ) {
-				$terms_per_taxonomy = $this->get_excluded_post_type_taxonomies( $post_type );
-
-				if ( $terms_per_taxonomy === false ) {
-					continue;
-				}
-
-				echo '<h2>' . sprintf( esc_html__( 'Terms to exclude for %1$s', 'wordpress-seo-news' ), $post_type->labels->name ) . '</h2>';
-
-				$this->excluded_post_type_taxonomies_output( $terms_per_taxonomy );
+			if ( ! ( isset( $this->options[ $option_key ] ) && ( $this->options[ $option_key ] === 'on' ) ) ) {
+				continue;
 			}
+
+			$terms_per_taxonomy = $this->get_excluded_post_type_taxonomies( $post_type );
+
+			if ( $terms_per_taxonomy === array() ) {
+				continue;
+			}
+
+			echo '<h2>' . sprintf( esc_html__( 'Terms to exclude for %1$s', 'wordpress-seo-news' ), $post_type->labels->name ) . '</h2>';
+
+			$this->excluded_post_type_taxonomies_output( $terms_per_taxonomy );
 		}
 	}
 
@@ -139,12 +141,13 @@ class WPSEO_News_Admin_Page {
 	 *
 	 * @param WP_Post_Type $post_type Post type for which to exclude taxonomies.
 	 *
-	 * @return array|bool Returns an array containing terms and taxonomies.
+	 * @return array Returns an array containing terms and taxonomies. Can be empty.
 	 */
 	private function get_excluded_post_type_taxonomies( $post_type ) {
 		$terms_per_taxonomy = array();
+		$taxonomies = get_object_taxonomies( $post_type->name, 'objects' );
 
-		foreach ( get_object_taxonomies( $post_type->name, 'objects' ) as $taxonomy ) {
+		foreach ( $taxonomies as $taxonomy ) {
 			$terms = get_terms( array( 'taxonomy' => $taxonomy->name, 'hide_empty' => false ) );
 
 			if ( count( $terms ) === 0 ) {
@@ -155,10 +158,6 @@ class WPSEO_News_Admin_Page {
 				'taxonomy' => $taxonomy,
 				'terms'    => $terms,
 			);
-		}
-
-		if ( count( $terms_per_taxonomy ) === 0 ) {
-			return false;
 		}
 
 		return $terms_per_taxonomy;

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -178,7 +178,7 @@ class WPSEO_News_Admin_Page {
 			echo '<h3>' . sprintf( esc_html__( '%1$s to exclude', 'wordpress-seo-news' ), $taxonomy->labels->name ) . '</h3>';
 
 			foreach ( $terms as $term ) {
-				echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type->name, $term->name . ' (' . $term->count . ' posts)', false );
+				echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type->name, $term->name, false );
 			}
 		}
 	}

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -131,7 +131,7 @@ class WPSEO_News_Admin_Page {
 
 			echo '<h2>' . sprintf( esc_html__( 'Terms to exclude for %1$s', 'wordpress-seo-news' ), $post_type->labels->name ) . '</h2>';
 
-			$this->excluded_post_type_taxonomies_output( $terms_per_taxonomy );
+			$this->excluded_post_type_taxonomies_output( $terms_per_taxonomy, $post_type );
 		}
 	}
 
@@ -170,7 +170,7 @@ class WPSEO_News_Admin_Page {
 	 *
 	 * @return void
 	 */
-	private function excluded_post_type_taxonomies_output( $terms_per_taxonomy ) {
+	private function excluded_post_type_taxonomies_output( $terms_per_taxonomy, $post_type ) {
 		foreach ( $terms_per_taxonomy as $data ) {
 			$taxonomy = $data['taxonomy'];
 			$terms    = $data['terms'];

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -115,9 +115,9 @@ class WPSEO_News_Admin_Page {
 		foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $post_type ) {
 			if ( isset( $this->options[ 'newssitemap_include_' . $post_type->name ] ) && ( 'on' === $this->options[ 'newssitemap_include_' . $post_type->name ] ) ) {
 				$taxonomies = get_object_taxonomies( $post_type->name, 'objects' );
-				foreach( $taxonomies as $taxonomy ) {
+				foreach ( $taxonomies as $taxonomy ) {
 					echo '<h2>' . sprintf( esc_html__( '%1$s %2$s to exclude', 'wordpress-seo-news' ), $post_type->labels->singular_name, $taxonomy->labels->name ) . '</h2>';
-					foreach( get_terms( array( 'taxonomy' => $taxonomy->name, 'hide_empty' => false ) ) as $term ) {
+					foreach ( get_terms( array( 'taxonomy' => $taxonomy->name, 'hide_empty' => false ) ) as $term ) {
 						echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug, $term->name . ' (' . $term->count . ' posts)', false );
 					}
 				}

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -123,7 +123,7 @@ class WPSEO_News_Admin_Page {
 	/**
 	 * Echoes the heading + checkboxes to exclude terms within each of the post type's taxonomies.
 	 *
-	 * @param WP_Post_Type $post_type Post type for which to exclude taxonomies
+	 * @param WP_Post_Type $post_type Post type for which to exclude taxonomies.
 	 */
 	private function excluded_post_type_taxonomies_output( $post_type ) {
 		$taxonomies = get_object_taxonomies( $post_type->name, 'objects' );

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -69,7 +69,7 @@ class WPSEO_News_Admin_Page {
 		$this->include_post_types();
 
 		// Post categories to exclude.
-		$this->excluded_post_categories();
+		$this->excluded_post_type_taxonomies();
 
 		// Admin footer.
 		WPSEO_News_Wrappers::admin_footer( true, false );
@@ -111,16 +111,26 @@ class WPSEO_News_Admin_Page {
 	/**
 	 * Generate HTML for excluding post categories.
 	 */
-	private function excluded_post_categories() {
+	private function excluded_post_type_taxonomies() {
 		foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $post_type ) {
-			if ( isset( $this->options[ 'newssitemap_include_' . $post_type->name ] ) && ( 'on' === $this->options[ 'newssitemap_include_' . $post_type->name ] ) ) {
-				$taxonomies = get_object_taxonomies( $post_type->name, 'objects' );
-				foreach ( $taxonomies as $taxonomy ) {
-					echo '<h2>' . sprintf( esc_html__( '%1$s %2$s to exclude', 'wordpress-seo-news' ), $post_type->labels->singular_name, $taxonomy->labels->name ) . '</h2>';
-					foreach ( get_terms( array( 'taxonomy' => $taxonomy->name, 'hide_empty' => false ) ) as $term ) {
-						echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug, $term->name . ' (' . $term->count . ' posts)', false );
-					}
-				}
+			$option_key = 'newssitemap_include_' . $post_type->name;
+			if ( isset( $this->options[ $option_key ] ) && ( 'on' === $this->options[ $option_key ] ) ) {
+				$this->excluded_post_type_taxonomies_output( $post_type );
+			}
+		}
+	}
+
+	/**
+	 * Echoes the heading + checkboxes to exclude terms within each of the post type's taxonomies.
+	 *
+	 * @param WP_Post_Type $post_type Post type for which to exclude taxonomies
+	 */
+	private function excluded_post_type_taxonomies_output( $post_type ) {
+		$taxonomies = get_object_taxonomies( $post_type->name, 'objects' );
+		foreach ( $taxonomies as $taxonomy ) {
+			echo '<h2>' . sprintf( esc_html__( '%1$s %2$s to exclude', 'wordpress-seo-news' ), $post_type->labels->singular_name, $taxonomy->labels->name ) . '</h2>';
+			foreach ( get_terms( array( 'taxonomy' => $taxonomy->name, 'hide_empty' => false ) ) as $term ) {
+				echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug, $term->name . ' (' . $term->count . ' posts)', false );
 			}
 		}
 	}

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -128,8 +128,12 @@ class WPSEO_News_Admin_Page {
 	private function excluded_post_type_taxonomies_output( $post_type ) {
 		$taxonomies = get_object_taxonomies( $post_type->name, 'objects' );
 		foreach ( $taxonomies as $taxonomy ) {
+			$terms = get_terms( array( 'taxonomy' => $taxonomy->name, 'hide_empty' => false ) );
+			if ( count( $terms ) === 0 ) {
+				continue;
+			}
 			echo '<h2>' . sprintf( esc_html__( '%1$s %2$s to exclude', 'wordpress-seo-news' ), $post_type->labels->singular_name, $taxonomy->labels->name ) . '</h2>';
-			foreach ( get_terms( array( 'taxonomy' => $taxonomy->name, 'hide_empty' => false ) ) as $term ) {
+			foreach ( $terms as $term ) {
 				echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug, $term->name . ' (' . $term->count . ' posts)', false );
 			}
 		}

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -143,7 +143,7 @@ class WPSEO_News_Admin_Page {
 			echo '<h2>' . sprintf( esc_html__( '%1$s %2$s to exclude', 'wordpress-seo-news' ), $post_type->labels->singular_name, $taxonomy->labels->name ) . '</h2>';
 
 			foreach ( $terms as $term ) {
-				echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug, $term->name . ' (' . $term->count . ' posts)', false );
+				echo WPSEO_News_Wrappers::checkbox( 'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type->name, $term->name . ' (' . $term->count . ' posts)', false );
 			}
 		}
 	}

--- a/classes/class-admin-page.php
+++ b/classes/class-admin-page.php
@@ -198,7 +198,8 @@ class WPSEO_News_Admin_Page {
 	/**
 	 * Echoes the sub heading + checkboxes to exclude terms within each of the post type's taxonomies.
 	 *
-	 * @param array $terms_per_taxonomy Array containing arrays with 'taxonomy' and corresponding 'terms'.
+	 * @param array        $terms_per_taxonomy Array containing arrays with 'taxonomy' and corresponding 'terms'.
+	 * @param WP_Post_Type $post_type          The post type.
 	 *
 	 * @return void
 	 */

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -111,7 +111,7 @@ class WPSEO_News_Sitemap_Item {
 	 */
 	private function get_terms_for_item() {
 		$terms = array();
-		foreach( get_object_taxonomies( $this->item->post_type ) as $taxonomy ) {
+		foreach ( get_object_taxonomies( $this->item->post_type ) as $taxonomy ) {
 			$extra_terms = get_the_terms( $this->item->ID, $taxonomy );
 			if ( is_array( $extra_terms ) && count( $extra_terms ) > 0 ) {
 				$terms = array_merge( $terms, $extra_terms );

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -112,8 +112,10 @@ class WPSEO_News_Sitemap_Item {
 	 */
 	private function get_terms_for_item() {
 		$terms = array();
+
 		foreach ( get_object_taxonomies( $this->item->post_type ) as $taxonomy ) {
 			$extra_terms = get_the_terms( $this->item->ID, $taxonomy );
+
 			if ( ! is_array( $extra_terms ) || count( $extra_terms ) === 0 ) {
 				continue;
 			}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -82,7 +82,7 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
-		if ( 'post' === $this->item->post_type && $this->exclude_item_terms() ) {
+		if ( $this->exclude_item_terms() ) {
 			return true;
 		}
 
@@ -95,20 +95,30 @@ class WPSEO_News_Sitemap_Item {
 	 * @return bool
 	 */
 	private function exclude_item_terms() {
-		$cats    = get_the_terms( $this->item->ID, 'category' );
-		$exclude = 0;
-
-		if ( is_array( $cats ) ) {
-			foreach ( $cats as $cat ) {
-				if ( isset( $this->options[ 'catexclude_' . $cat->slug ] ) ) {
-					$exclude ++;
-				}
+		foreach ( $this->get_terms_for_item() as $term ) {
+			if ( isset( $this->options[ 'term_exclude_' . $term->taxonomy . '_' . $term->slug ] ) ) {
+				return true;
 			}
 		}
 
-		if ( $exclude >= count( $cats ) ) {
-			return true;
+		return false;
+	}
+
+	/**
+	 * Retrieve all the Term IDs for all the items.
+	 *
+	 * @return array
+	 */
+	private function get_terms_for_item() {
+		$terms = array();
+		foreach( get_object_taxonomies( $this->item->post_type ) as $taxonomy ) {
+			$extra_terms = get_the_terms( $this->item->ID, $taxonomy );
+			if ( is_array( $extra_terms ) && count( $extra_terms ) > 0 ) {
+				$terms = array_merge( $terms, $extra_terms );
+			}
 		}
+
+		return $terms;
 	}
 
 	/**

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -41,7 +41,6 @@ class WPSEO_News_Sitemap_Item {
 		$this->item    = $item;
 		$this->options = $options;
 
-
 		// Check if item should be skipped.
 		if ( ! $this->skip_build_item() ) {
 			$this->build_item();
@@ -96,7 +95,7 @@ class WPSEO_News_Sitemap_Item {
 	 */
 	private function exclude_item_terms() {
 		foreach ( $this->get_terms_for_item() as $term ) {
-			$term_exclude_option = 'term_exclude_' . $term->taxonomy . '_' . $term->slug;
+			$term_exclude_option = 'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $this->item->post_type->name;
 			if ( isset( $this->options[ $term_exclude_option ] ) ) {
 				return true;
 			}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -95,7 +95,8 @@ class WPSEO_News_Sitemap_Item {
 	 */
 	private function exclude_item_terms() {
 		foreach ( $this->get_terms_for_item() as $term ) {
-			$term_exclude_option = 'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $this->item->post_type->name;
+			$term_exclude_option = 'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $this->item->post_type;
+
 			if ( isset( $this->options[ $term_exclude_option ] ) ) {
 				return true;
 			}

--- a/classes/class-upgrade-manager.php
+++ b/classes/class-upgrade-manager.php
@@ -18,7 +18,6 @@ class WPSEO_News_Upgrade_Manager {
 	 * Check if there's a plugin update.
 	 */
 	public function check_update() {
-
 		// Get options.
 		$options = WPSEO_News::get_options();
 
@@ -30,7 +29,6 @@ class WPSEO_News_Upgrade_Manager {
 			// Update version code.
 			$this->update_current_version_code();
 		}
-
 	}
 
 	/**
@@ -52,6 +50,11 @@ class WPSEO_News_Upgrade_Manager {
 		// Upgrade to version 7.8.
 		if ( version_compare( $current_version, '7.8', '<' ) ) {
 			$this->upgrade_78();
+		}
+
+		// Upgrade to version 8.3
+		if ( version_compare( $current_version, '8.3', '<' ) ) {
+			$this->upgrade_83();
 		}
 	}
 
@@ -108,6 +111,24 @@ class WPSEO_News_Upgrade_Manager {
 
 		// Delete all original source references.
 		$this->delete_meta_by_key( '_yoast_wpseo_newssitemap-original' );
+	}
+
+	/**
+	 * Perform the upgrade to 8.3.
+	 */
+	private function upgrade_83() {
+		// Get current options.
+		$options = get_option( 'wpseo_news' );
+		foreach( $options as $key => $value ) {
+			if ( strpos( $key, 'catexclude_' ) === 0 ) {
+				$slug                                        = str_replace( 'catexclude_', '', $key );
+				$options[ 'term_exclude_category_' . $slug ] = $value;
+				unset( $options[ $key ] );
+			}
+		}
+
+		// Update options.
+		update_option( 'wpseo_news', $options );
 	}
 
 	/**

--- a/classes/class-upgrade-manager.php
+++ b/classes/class-upgrade-manager.php
@@ -52,7 +52,7 @@ class WPSEO_News_Upgrade_Manager {
 			$this->upgrade_78();
 		}
 
-		// Upgrade to version 8.3
+		// Upgrade to version 8.3.
 		if ( version_compare( $current_version, '8.3', '<' ) ) {
 			$this->upgrade_83();
 		}
@@ -119,7 +119,7 @@ class WPSEO_News_Upgrade_Manager {
 	private function upgrade_83() {
 		// Get current options.
 		$options = get_option( 'wpseo_news' );
-		foreach( $options as $key => $value ) {
+		foreach ( $options as $key => $value ) {
 			if ( strpos( $key, 'catexclude_' ) === 0 ) {
 				$slug                                        = str_replace( 'catexclude_', '', $key );
 				$options[ 'term_exclude_category_' . $slug ] = $value;

--- a/classes/class-upgrade-manager.php
+++ b/classes/class-upgrade-manager.php
@@ -120,11 +120,12 @@ class WPSEO_News_Upgrade_Manager {
 		// Get current options.
 		$options = get_option( 'wpseo_news' );
 		foreach ( $options as $key => $value ) {
-			if ( strpos( $key, 'catexclude_' ) === 0 ) {
-				$slug                                        = str_replace( 'catexclude_', '', $key );
-				$options[ 'term_exclude_category_' . $slug ] = $value;
-				unset( $options[ $key ] );
+			if ( strpos( $key, 'catexclude_' ) !== 0 ) {
+				continue;
 			}
+			$slug                                        = str_replace( 'catexclude_', '', $key );
+			$options[ 'term_exclude_category_' . $slug ] = $value;
+			unset( $options[ $key ] );
 		}
 
 		// Update options.

--- a/classes/class-upgrade-manager.php
+++ b/classes/class-upgrade-manager.php
@@ -114,15 +114,20 @@ class WPSEO_News_Upgrade_Manager {
 	}
 
 	/**
-	 * Perform the upgrade to 8.3.
+	 * Performs the upgrade to 8.3.
+	 *
+	 * @return void
 	 */
 	private function upgrade_83() {
 		// Get current options.
 		$options = get_option( 'wpseo_news' );
+
 		foreach ( $options as $key => $value ) {
+
 			if ( strpos( $key, 'catexclude_' ) !== 0 ) {
 				continue;
 			}
+
 			$slug                                        = str_replace( 'catexclude_', '', $key );
 			$options[ 'term_exclude_category_' . $slug ] = $value;
 			unset( $options[ $key ] );

--- a/tests/test-class-sitemap-item.php
+++ b/tests/test-class-sitemap-item.php
@@ -26,6 +26,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 				'post_title'    => 'Newest post',
 				'post_date'     => date( $timezone_format, $base_time ),
 				'post_date_gmt' => date( $timezone_format, $base_time ),
+				'post_type'     => 'post',
 			)
 		);
 
@@ -54,6 +55,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 			array(
 				'post_title'    => 'Newest post',
 				'post_date'     => date( $timezone_format, $base_time ),
+				'post_type'     => 'post',
 			)
 		);
 
@@ -80,6 +82,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$test_post_date_gmt = self::factory()->post->create_and_get(
 			array(
 				'post_title'    => 'Newest post',
+				'post_type'     => 'post',
 			)
 		);
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Allows term based exclusion in the news sitemap for all taxonomies connected to enabled post types.

## Relevant technical choices:

* Moved the `catexclude_` options to a `term_exclude_<taxonomy>_<slug>_for_<post_type>` option for better portability.

## Test instructions

This PR can be tested by following these steps:

* Make sure you have enabled at least one custom post type and one custom taxonomy. You can use the `Yoast Test Helper` for this.
* Go to the Yoast SEO News admin page.
* In the Yoast SEO News admin page enable at least one custom post type.
* Create a post and add one of those taxonomy terms you just selected.
* Create another post and do _not_ add one of those taxonomy terms you just selected.
* See only the second post in the XML news sitemap.

Be sure to also test the upgrade path for the old settings to the new settings.

Fixes #414 
Fixes #415 
