### PR TITLE
Fixed Sitemap image URLs to use href instead of guid.

### DIFF
--- a/classes/class-sitemap-images.php
+++ b/classes/class-sitemap-images.php
@@ -214,11 +214,11 @@ class WPSEO_News_Sitemap_Images {
 			$image['alt'] = $attachment['alt'];
 		}
 
-		if ( ! empty( $attachment['src'] ) ) {
-			$this->images[ $attachment['src'] ] = $image;
-		}
-		elseif ( ! empty( $attachment['href'] ) ) {
+		if ( ! empty( $attachment['href'] ) ) {
 			$this->images[ $attachment['href'] ] = $image;
+		}
+		elseif ( ! empty( $attachment['src'] ) ) {
+			$this->images[ $attachment['src'] ] = $image;
 		}
 	}
 
@@ -242,7 +242,7 @@ class WPSEO_News_Sitemap_Images {
 		return array(
 			'title'       => $attachment->post_title,
 			'alt'         => get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ),
-			'href'        => get_permalink( $attachment->ID ),
+			'href'        => wp_get_attachment_url( $attachment->ID ),
 			'src'         => $attachment->guid,
 		);
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixed Sitemap image URLs to use href instead of guid to prevent relative URLs in the Sitemap.

## Relevant technical choices:

* Relative image URLs in the Sitemap which are not interpreted correctly by google. Besides not SEO friendly.

## Test instructions

This PR can be tested by following these steps:

* https://github.com/Yoast/wpseo-news/issues/438

Fixes #
