### PR TITLE
Revert "Upgrade yoast/wp-helpscout to 2.0.4 in composer.lock"

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "9dc72b4d4943ca660df4c0d15b3baa24",
@@ -77,16 +77,16 @@
         },
         {
             "name": "yoast/wp-helpscout",
-            "version": "2.0.4",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wp-helpscout.git",
-                "reference": "15549e900f67d62dbd0dd0b7fb72b7d064b65204"
+                "reference": "00c6d777497c935af76ba1b4962823165139bbbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-helpscout/zipball/15549e900f67d62dbd0dd0b7fb72b7d064b65204",
-                "reference": "15549e900f67d62dbd0dd0b7fb72b7d064b65204",
+                "url": "https://api.github.com/repos/Yoast/wp-helpscout/zipball/00c6d777497c935af76ba1b4962823165139bbbc",
+                "reference": "00c6d777497c935af76ba1b4962823165139bbbc",
                 "shasum": ""
             },
             "type": "library",
@@ -110,7 +110,7 @@
                 }
             ],
             "description": "A package to integrate the helpscout beacon into WordPress",
-            "time": "2018-10-31T09:37:07+00:00"
+            "time": "2017-08-03T07:48:33+00:00"
         }
     ],
     "packages-dev": [
@@ -272,6 +272,17 @@
         {
             "name": "roave/security-advisories",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/SecurityAdvisories.git",
+                "reference": "664836e89c7ecad3dbaabc1572ea752c0d532d80"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/664836e89c7ecad3dbaabc1572ea752c0d532d80",
+                "reference": "664836e89c7ecad3dbaabc1572ea752c0d532d80",
+                "shasum": ""
+            },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adodb/adodb-php": "<5.20.6",


### PR DESCRIPTION
Reverts Yoast/wpseo-news#443
This commit was created with an incorrect PHP version