### PR TITLE
Use the SEO title instead of default WordPress title for News Items

### DIFF
--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -192,18 +192,23 @@ class WPSEO_News_Sitemap_Item {
 	 *
 	 * @param   WP_Post $item The post object.
 	 *
-	 * @return  string        The WPSEO formatted title or, if problems, the post_title.
+	 * @return  string	The formatted title or, if no formatted title can be created, the post_title.
 	 */
 	protected function get_item_title( $item = null ) {
-		// Custom WPSEO post type title.
+		// Exit early if the item is null.
+		if ( $item === null ) {
+			return '';
+		}
+
+    // Custom WPSEO post type title.
 		$title = WPSEO_Meta::get_value( 'title', $item->ID );
-		if ( $title != '' && false !== $title ) {
+		if ( $title !=== '' && $title !=== false ) {
 			return wpseo_replace_vars( $title, $item );
 		}
 
 		// Default WPSEO post type title.
 		$defaults = WPSEO_Option_Titles::get_instance()->get_defaults();
-		if ( array_key_exists( 'title-' . $item->post_type, $defaults ) && false !== $defaults ) {
+		if ( array_key_exists( 'title-' . $item->post_type, $defaults ) && $defaults !=== false ) {
 			return wpseo_replace_vars( str_replace( ' %%page%% ', ' ', $defaults[ 'title-' . $item->post_type ] ), $item );
 		}
 

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -200,7 +200,7 @@ class WPSEO_News_Sitemap_Item {
 			return '';
 		}
 
-    // Custom WPSEO post type title.
+		// Custom WPSEO post type title.
 		$title = WPSEO_Meta::get_value( 'title', $item->ID );
 		if ( $title !== '' && $title !== false ) {
 			return wpseo_replace_vars( $title, $item );

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -151,9 +151,9 @@ class WPSEO_News_Sitemap_Item {
 	 */
 	private function build_news_tag() {
 
-    $title         = $this->get_item_title();
-    $genre         = $this->get_item_genre();
-    $stock_tickers = $this->get_item_stock_tickers( $this->item->ID );
+		$title         = $this->get_item_title();
+		$genre         = $this->get_item_genre();
+		$stock_tickers = $this->get_item_stock_tickers( $this->item->ID );
 
 		$this->output .= "\t<news:news>\n";
 
@@ -187,27 +187,27 @@ class WPSEO_News_Sitemap_Item {
 		$this->output .= "\t\t</news:publication>\n";
 	}
 
-  /**
-   * Gets the SEO title of the item.
-   *
-   * @return string
-   */
-  private function get_item_title() {
-    $title = WPSEO_Meta::get_value( 'title', $this->item->ID, true );
-    
-    if ( empty( $title ) ) {
-      $default_from_options = WPSEO_Options::get_default( 'wpseo_titles', $this->item->post_type );
-      if ( false !== $default_from_options ) { 
-        $title = str_replace( ' %%page%% ', ' ', $default_from_options );
-      }
-    } else {
-      $title = '%%title%%';
-    }
+	/**
+	 * Gets the SEO title of the item.
+	 *
+	 * @return string The WPSEO formatted title or, if problems, the post_title.
+	 */
+	protected function get_item_title() {
+		$title = WPSEO_Meta::get_value( 'title', $this->item->ID );
 
-    return WPSEO_Replace_Vars::replace( $title, $this->item );
-  }
+		if ( $title !== '' && $title !== false ) {
+			return WPSEO_Replace_Vars::replace( $title, $this->item );
+		}
 
-  /**
+		$default_from_options = WPSEO_Options::get_default( 'wpseo_titles', $this->item->post_type );
+		if ( $default_from_options !== '' && false !== $default_from_options ) {
+			return WPSEO_Replace_Vars::replace( str_replace( ' %%page%% ', ' ', $default_from_options ), $this->item );
+		}
+
+		return $this->item->post_title;
+	}
+
+	/**
 	 * Getting the genre for given $item_id.
 	 *
 	 * @return string

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -196,12 +196,13 @@ class WPSEO_News_Sitemap_Item {
 		$title = WPSEO_Meta::get_value( 'title', $this->item->ID );
 
 		if ( $title !== '' && $title !== false ) {
-			return WPSEO_Replace_Vars::replace( $title, $this->item );
+      //$wpseo_replace_vars = new WPSEO_Replace_Vars();
+      return wpseo_replace_vars( $title, $this->item );
 		}
 
 		$default_from_options = WPSEO_Options::get_default( 'wpseo_titles', $this->item->post_type );
 		if ( $default_from_options !== '' && false !== $default_from_options ) {
-			return WPSEO_Replace_Vars::replace( str_replace( ' %%page%% ', ' ', $default_from_options ), $this->item );
+      return wpseo_replace_vars( str_replace( ' %%page%% ', ' ', $default_from_options ), $this->item );
 		}
 
 		return $this->item->post_title;

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -151,7 +151,7 @@ class WPSEO_News_Sitemap_Item {
 	 */
 	private function build_news_tag() {
 
-		$title         = $this->get_item_title();
+		$title         = $this->get_item_title( $this->item );
 		$genre         = $this->get_item_genre();
 		$stock_tickers = $this->get_item_stock_tickers( $this->item->ID );
 
@@ -190,22 +190,25 @@ class WPSEO_News_Sitemap_Item {
 	/**
 	 * Gets the SEO title of the item.
 	 *
-	 * @return string The WPSEO formatted title or, if problems, the post_title.
+	 * @param   WP_Post $item The post object.
+	 *
+	 * @return  string        The WPSEO formatted title or, if problems, the post_title.
 	 */
-	protected function get_item_title() {
-		$title = WPSEO_Meta::get_value( 'title', $this->item->ID );
-
-		if ( $title != '' && $title !== false ) {
-			return wpseo_replace_vars( $title, $this->item );
+	protected function get_item_title( $item = null ) {
+		// Custom WPSEO post type title.
+		$title = WPSEO_Meta::get_value( 'title', $item->ID );
+		if ( $title != '' && false !== $title ) {
+			return wpseo_replace_vars( $title, $item );
 		}
 
-		// TODO: This call to get the default title format is not working.
-		$default_from_options = WPSEO_Options::get_default( 'titles', $this->item->post_type );
-		if ( $default_from_options != '' && false !== $default_from_options ) {
-			return wpseo_replace_vars( str_replace( ' %%page%% ', ' ', $default_from_options ), $this->item );
+		// Default WPSEO post type title.
+		$defaults = WPSEO_Option_Titles::get_instance()->get_defaults();
+		if ( array_key_exists( 'title-' . $item->post_type, $defaults ) && false !== $defaults ) {
+			return wpseo_replace_vars( str_replace( ' %%page%% ', ' ', $defaults[ 'title-' . $item->post_type ] ), $item );
 		}
 
-		return $this->item->post_title;
+		// Fallback post title.
+		return $item->post_title;
 	}
 
 	/**

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -202,13 +202,13 @@ class WPSEO_News_Sitemap_Item {
 
     // Custom WPSEO post type title.
 		$title = WPSEO_Meta::get_value( 'title', $item->ID );
-		if ( $title !=== '' && $title !=== false ) {
+		if ( $title !== '' && $title !== false ) {
 			return wpseo_replace_vars( $title, $item );
 		}
 
 		// Default WPSEO post type title.
 		$defaults = WPSEO_Option_Titles::get_instance()->get_defaults();
-		if ( array_key_exists( 'title-' . $item->post_type, $defaults ) && $defaults !=== false ) {
+		if ( array_key_exists( 'title-' . $item->post_type, $defaults ) && $defaults !== false ) {
 			return wpseo_replace_vars( str_replace( ' %%page%% ', ' ', $defaults[ 'title-' . $item->post_type ] ), $item );
 		}
 

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -196,13 +196,13 @@ class WPSEO_News_Sitemap_Item {
 		$title = WPSEO_Meta::get_value( 'title', $this->item->ID );
 
 		if ( $title !== '' && $title !== false ) {
-      //$wpseo_replace_vars = new WPSEO_Replace_Vars();
-      return wpseo_replace_vars( $title, $this->item );
+			// $wpseo_replace_vars = new WPSEO_Replace_Vars();
+			return wpseo_replace_vars( $title, $this->item );
 		}
 
 		$default_from_options = WPSEO_Options::get_default( 'wpseo_titles', $this->item->post_type );
 		if ( $default_from_options !== '' && false !== $default_from_options ) {
-      return wpseo_replace_vars( str_replace( ' %%page%% ', ' ', $default_from_options ), $this->item );
+			return wpseo_replace_vars( str_replace( ' %%page%% ', ' ', $default_from_options ), $this->item );
 		}
 
 		return $this->item->post_title;

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -199,9 +199,9 @@ class WPSEO_News_Sitemap_Item {
 			return wpseo_replace_vars( $title, $this->item );
 		}
 
-    // TODO: This call to get the default title format is not working.
-    $default_from_options = WPSEO_Options::get_default( 'titles', $this->item->post_type );
-    if ( $default_from_options != '' && false !== $default_from_options ) {
+		// TODO: This call to get the default title format is not working.
+		$default_from_options = WPSEO_Options::get_default( 'titles', $this->item->post_type );
+		if ( $default_from_options != '' && false !== $default_from_options ) {
 			return wpseo_replace_vars( str_replace( ' %%page%% ', ' ', $default_from_options ), $this->item );
 		}
 

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -195,13 +195,13 @@ class WPSEO_News_Sitemap_Item {
 	protected function get_item_title() {
 		$title = WPSEO_Meta::get_value( 'title', $this->item->ID );
 
-		if ( $title !== '' && $title !== false ) {
-			// $wpseo_replace_vars = new WPSEO_Replace_Vars();
+		if ( $title != '' && $title !== false ) {
 			return wpseo_replace_vars( $title, $this->item );
 		}
 
-		$default_from_options = WPSEO_Options::get_default( 'wpseo_titles', $this->item->post_type );
-		if ( $default_from_options !== '' && false !== $default_from_options ) {
+    // TODO: This call to get the default title format is not working.
+    $default_from_options = WPSEO_Options::get_default( 'titles', $this->item->post_type );
+    if ( $default_from_options != '' && false !== $default_from_options ) {
 			return wpseo_replace_vars( str_replace( ' %%page%% ', ' ', $default_from_options ), $this->item );
 		}
 

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -151,8 +151,9 @@ class WPSEO_News_Sitemap_Item {
 	 */
 	private function build_news_tag() {
 
-		$genre         = $this->get_item_genre();
-		$stock_tickers = $this->get_item_stock_tickers( $this->item->ID );
+    $title         = $this->get_item_title();
+    $genre         = $this->get_item_genre();
+    $stock_tickers = $this->get_item_stock_tickers( $this->item->ID );
 
 		$this->output .= "\t<news:news>\n";
 
@@ -164,7 +165,7 @@ class WPSEO_News_Sitemap_Item {
 		}
 
 		$this->output .= "\t\t<news:publication_date>" . $this->get_publication_date( $this->item ) . '</news:publication_date>' . "\n";
-		$this->output .= "\t\t<news:title><![CDATA[" . $this->item->post_title . ']]></news:title>' . "\n";
+		$this->output .= "\t\t<news:title><![CDATA[" . $title . ']]></news:title>' . "\n";
 
 		if ( ! empty( $stock_tickers ) ) {
 			$this->output .= "\t\t<news:stock_tickers><![CDATA[" . $stock_tickers . ']]></news:stock_tickers>' . "\n";
@@ -186,7 +187,27 @@ class WPSEO_News_Sitemap_Item {
 		$this->output .= "\t\t</news:publication>\n";
 	}
 
-	/**
+  /**
+   * Gets the SEO title of the item.
+   *
+   * @return string
+   */
+  private function get_item_title() {
+    $title = WPSEO_Meta::get_value( 'title', $this->item->ID, true );
+    
+    if ( empty( $title ) ) {
+      $default_from_options = WPSEO_Options::get_default( 'wpseo_titles', $this->item->post_type );
+      if ( false !== $default_from_options ) { 
+        $title = str_replace( ' %%page%% ', ' ', $default_from_options );
+      }
+    } else {
+      $title = '%%title%%';
+    }
+
+    return WPSEO_Replace_Vars::replace( $title, $this->item );
+  }
+
+  /**
 	 * Getting the genre for given $item_id.
 	 *
 	 * @return string

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -222,7 +222,7 @@ class WPSEO_News_Sitemap {
 				"SELECT ID, post_content, post_name, post_author, post_parent, post_date_gmt, post_date, post_date_gmt, post_title, post_type
 				FROM {$wpdb->posts}
 				WHERE post_status='publish'
-					AND ( TIMESTAMPDIFF( MINUTE, post_date_gmt, NOW() ) <= ( 48 * 60 ) )
+					AND ( TIMESTAMPDIFF( MINUTE, post_date_gmt, UTC_TIMESTAMP() ) <= ( 48 * 60 ) )
 					AND post_type IN (" . implode( ',', array_fill( 0, count( $post_types ), '%s' ) ) . ')
 				ORDER BY post_date_gmt DESC
 				LIMIT 0, %d

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -101,7 +101,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output .= "\t\t\t<news:language>en</news:language>\n";
 		$expected_output .= "\t\t</news:publication>\n";
 		$expected_output .= "\t\t<news:publication_date>" . get_the_date( DATE_ATOM, $post_id ) . "</news:publication_date>\n";
-		$expected_output .= "\t\t<news:title><![CDATA[generate rss]]></news:title>\n";
+		$expected_output .= "\t\t<news:title><![CDATA[generate rss - " . get_bloginfo( "name" ) . "]]></news:title>\n";
 		$expected_output .= "\t</news:news>\n";
 		$expected_output .= '</url>';
 
@@ -259,7 +259,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap::build_sitemap
 	 */
 	public function test_sitemap_only_showing_recent_items() {
-		$base_time = time();
+		$base_time = (int) current_time( 'timestamp' );
 
 		$this->factory->post->create(
 			array(
@@ -292,10 +292,10 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$output = $this->instance->build_sitemap();
 
 		// Check if the $output contains the $expected_output.
-		$this->assertContains( "\t\t<news:title><![CDATA[Newest post]]></news:title>\n", $output );
-		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post]]></news:title>\n", $output );
+		$this->assertContains( "\t\t<news:title><![CDATA[Newest post - " . get_bloginfo( "name" ) . "]]></news:title>\n", $output );
+		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post - " . get_bloginfo( "name" ) . "]]></news:title>\n", $output );
 
-		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post]]></news:title>\n", $output );
+		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post - " . get_bloginfo( "name" ) . "]]></news:title>\n", $output );
 	}
 
 	public function restrict_featured_image( $options ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes news items to use the SEO title instead of default WordPress title.

## Relevant technical choices:

* Added a method that performs the same sort of treatment of using the default plugin options that is used when building the new items.

## Test instructions

This PR can be tested by following these steps:

* news-sitemap.xml should display either a post-types custom SEO title or the default plugin title format.

Fixes #64
