### PR TITLE
Use UTC for the sitemap index

### DIFF
--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -52,7 +52,7 @@ class WPSEO_News_Sitemap {
 			return $str;
 		}
 
-		$date = new DateTime( get_lastpostdate( 'gmt' ), new DateTimeZone( new WPSEO_News_Sitemap_Timezone() ) );
+		$date = new DateTime( get_lastpostdate( 'gmt' ), new DateTimeZone( 'UTC' ) );
 
 		$str .= '<sitemap>' . "\n";
 		$str .= '<loc>' . self::get_sitemap_name() . '</loc>' . "\n";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the last modified date for the sitemap index has been displayed with the wrong time zone 

## Relevant technical choices:

* I've chosen to use UTC, because we are relying on the GMT date for the last modified date.

## Test instructions

This PR can be tested by following these steps:

* Follow the steps from issue #435:
> Install Yoast News 8.3
> Set WordPress time zone to UTC
> Publish a post
> Compare the dates from the index and the newest post in the news sitemap. Correct UTC time on both index and news sitemap.
> Change WP time zone to something else.
> Disable/Enable the sitemap feature.
> Compare the dates from the index and the newest post in the news sitemap. Same date/time but the index still includes the time zone designator which makes it the wrong time.

* It should be solved now

Fixes #435
