### PR TITLE
Uses readfile instead of include in build_news_sitemap_xsl

### DIFF
--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -168,7 +168,7 @@ class WPSEO_News_Sitemap {
 		header( 'Cache-Control: maxage=' . YEAR_IN_SECONDS );
 		header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', ( time() + YEAR_IN_SECONDS ) ) . ' GMT' );
 
-		include dirname( WPSEO_NEWS_FILE ) . '/assets/xml-news-sitemap.xsl';
+		readfile( dirname( WPSEO_NEWS_FILE ) . '/assets/xml-news-sitemap.xsl' );
 		die();
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Uses readfile instead of include in build_news_sitemap_xsl to prevent parsing xml file as PHP code.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Set `short_open_tag` to `on` in _php.ini_.
* Check _news-sitemap.xsl_ . It returns 500 error.
* Apply this PR and check _news-sitemap.xsl_ again. It should work without errors.

Fixes #247
