### PR TITLE
Change the titles the news sitemap to the SEO titles, with a fallback to the post title. 

### DIFF
--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -201,7 +201,7 @@ class WPSEO_News_Sitemap_Item {
 		}
 
 		// Custom WPSEO post type title.
-		$title = WPSEO_Meta::get_value( 'title', $item->ID );
+		$title = WPSEO_Frontend::get_instance()->get_content_title( $item );
 		if ( $title !== '' && $title !== false ) {
 			return wpseo_replace_vars( $title, $item );
 		}

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -151,6 +151,7 @@ class WPSEO_News_Sitemap_Item {
 	 */
 	private function build_news_tag() {
 
+		$title         = $this->get_item_title( $this->item );
 		$genre         = $this->get_item_genre();
 		$stock_tickers = $this->get_item_stock_tickers( $this->item->ID );
 
@@ -164,7 +165,7 @@ class WPSEO_News_Sitemap_Item {
 		}
 
 		$this->output .= "\t\t<news:publication_date>" . $this->get_publication_date( $this->item ) . '</news:publication_date>' . "\n";
-		$this->output .= "\t\t<news:title><![CDATA[" . $this->item->post_title . ']]></news:title>' . "\n";
+		$this->output .= "\t\t<news:title><![CDATA[" . $title . ']]></news:title>' . "\n";
 
 		if ( ! empty( $stock_tickers ) ) {
 			$this->output .= "\t\t<news:stock_tickers><![CDATA[" . $stock_tickers . ']]></news:stock_tickers>' . "\n";
@@ -184,6 +185,35 @@ class WPSEO_News_Sitemap_Item {
 		$this->output .= "\t\t\t<news:name>" . $publication_name . '</news:name>' . "\n";
 		$this->output .= "\t\t\t<news:language>" . htmlspecialchars( $publication_lang ) . '</news:language>' . "\n";
 		$this->output .= "\t\t</news:publication>\n";
+	}
+
+	/**
+	 * Gets the SEO title of the item.
+	 *
+	 * @param   WP_Post $item The post object.
+	 *
+	 * @return  string	The formatted title or, if no formatted title can be created, the post_title.
+	 */
+	protected function get_item_title( $item = null ) {
+		// Exit early if the item is null.
+		if ( $item === null ) {
+			return '';
+		}
+
+		// Custom WPSEO post type title.
+		$title = WPSEO_Meta::get_value( 'title', $item->ID );
+		if ( $title !== '' && $title !== false ) {
+			return wpseo_replace_vars( $title, $item );
+		}
+
+		// Default WPSEO post type title.
+		$defaults = WPSEO_Option_Titles::get_instance()->get_defaults();
+		if ( array_key_exists( 'title-' . $item->post_type, $defaults ) && $defaults !== false ) {
+			return wpseo_replace_vars( str_replace( ' %%page%% ', ' ', $defaults[ 'title-' . $item->post_type ] ), $item );
+		}
+
+		// Fallback post title.
+		return $item->post_title;
 	}
 
 	/**

--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -222,7 +222,7 @@ class WPSEO_News_Sitemap {
 				"SELECT ID, post_content, post_name, post_author, post_parent, post_date_gmt, post_date, post_date_gmt, post_title, post_type
 				FROM {$wpdb->posts}
 				WHERE post_status='publish'
-					AND ( TIMESTAMPDIFF( MINUTE, post_date_gmt, NOW() ) <= ( 48 * 60 ) )
+					AND ( TIMESTAMPDIFF( MINUTE, post_date_gmt, UTC_TIMESTAMP() ) <= ( 48 * 60 ) )
 					AND post_type IN (" . implode( ',', array_fill( 0, count( $post_types ), '%s' ) ) . ')
 				ORDER BY post_date_gmt DESC
 				LIMIT 0, %d

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -101,7 +101,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output .= "\t\t\t<news:language>en</news:language>\n";
 		$expected_output .= "\t\t</news:publication>\n";
 		$expected_output .= "\t\t<news:publication_date>" . get_the_date( DATE_ATOM, $post_id ) . "</news:publication_date>\n";
-		$expected_output .= "\t\t<news:title><![CDATA[generate rss]]></news:title>\n";
+		$expected_output .= "\t\t<news:title><![CDATA[generate rss - " . get_bloginfo( "name" ) . "]]></news:title>\n";
 		$expected_output .= "\t</news:news>\n";
 		$expected_output .= '</url>';
 
@@ -259,7 +259,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap::build_sitemap
 	 */
 	public function test_sitemap_only_showing_recent_items() {
-		$base_time = time();
+		$base_time = (int) current_time( 'timestamp' );
 
 		$this->factory->post->create(
 			array(
@@ -292,10 +292,10 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$output = $this->instance->build_sitemap();
 
 		// Check if the $output contains the $expected_output.
-		$this->assertContains( "\t\t<news:title><![CDATA[Newest post]]></news:title>\n", $output );
-		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post]]></news:title>\n", $output );
+		$this->assertContains( "\t\t<news:title><![CDATA[Newest post - " . get_bloginfo( "name" ) . "]]></news:title>\n", $output );
+		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post - " . get_bloginfo( "name" ) . "]]></news:title>\n", $output );
 
-		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post]]></news:title>\n", $output );
+		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post - " . get_bloginfo( "name" ) . "]]></news:title>\n", $output );
 	}
 
 	public function restrict_featured_image( $options ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*  Changes the titles in the news sitemap to default to the SEO title, with a fallback to the post title. (props: @[timnolte](https://github.com/timnolte)) 

## Test instructions

This PR can be tested by following these steps:

* Open the news sitemap. See the titles of each post are the same as the post titles. Make sure to have a couple of posts with a SEO title. 
* Checkout this branch. See the posts with a SEO title now show this title in the news sitemap. 
* Remove the SEO title of a post, see the post in the news sitemap change back to the post title. 

Fixes #64
