### PR TITLE
Added grunt release alias

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -43,3 +43,7 @@ check:
 # Default task
 default:
   - build
+
+# Get the project ready for release
+release:
+  - 'build'


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Added `grunt release` alias for consistency across projects.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Run `grunt release`

Fixes #453 
