### PR TITLE
Compare time for news sitemap with UTC time instead of local server time. 

### DIFF
--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -222,7 +222,7 @@ class WPSEO_News_Sitemap {
 				"SELECT ID, post_content, post_name, post_author, post_parent, post_date_gmt, post_date, post_date_gmt, post_title, post_type
 				FROM {$wpdb->posts}
 				WHERE post_status='publish'
-					AND ( TIMESTAMPDIFF( MINUTE, post_date_gmt, NOW() ) <= ( 48 * 60 ) )
+					AND ( TIMESTAMPDIFF( MINUTE, post_date_gmt, UTC_TIMESTAMP() ) <= ( 48 * 60 ) )
 					AND post_type IN (" . implode( ',', array_fill( 0, count( $post_types ), '%s' ) ) . ')
 				ORDER BY post_date_gmt DESC
 				LIMIT 0, %d

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -259,7 +259,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap::build_sitemap
 	 */
 	public function test_sitemap_only_showing_recent_items() {
-		$base_time = time();
+		$base_time = (int) current_time( 'timestamp' );
 
 		$this->factory->post->create(
 			array(

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -259,8 +259,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap::build_sitemap
 	 */
 	public function test_sitemap_only_showing_recent_items() {
-		$base_time = (int) current_time( 'timestamp' );
-
+		$base_time = time();
 		$this->factory->post->create(
 			array(
 				'post_title' 	=> 'Newest post',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where it was possible the 48 hour selection range for posts in the news sitemap was slightly off.  

## Relevant technical choices:

* In the old scenario we checked posts comparing the post gmt time with NOW(), which returns the server time. This could result in errors when the server is not set to a GMT/UTC time zone. We now compare the post time zone with UTC_TIMESTAMP(). 

## Test instructions

This PR can be tested by following these steps:

* This issue is very hard to test. Probably your test environment is set to UTC, so the result of NOW() and UTC_TIMESTAMP() are the same. 

* Testing the issue without touching the code but with patience:
-To reproduce the issue: 
-Create a post. Wait for 41 hours (maybe go get a cup of tea). Go to the news sitemap. See that the post is still in the sitemap as it should be. This is probably because your server time is set to UTC.
-Go into your database, for example with Sequel Pro. In the query tab enter the following query:
`SET GLOBAL time_zone = '+08:00'` Press 'Run Current' to apply. 
-The post should disappear from your sitemap on reloading, despite being less than 48 hours old. 
-Now switch to this branch. The post should correctly appear again. 
-set your database time back with `SET GLOBAL time_zone = 'SYSTEM'`Do not forget this! 

* The easiest way to test which do not involve waiting for two days:
-Edit a line in the following file:
In `wpseo-news/classes/class-sitemap.php` line 225 there is the part where the amount of minutes specified from which posts are considered relevant for the news-sitemap: `( 48 * 60 )`. Which is 48 hours. You can set this to less to make testing easier. For example change it to `( 1 * 60 )`. to only include posts that are less than 1 hour old. Now you only have to wait for one hour.  
-Another option is to go into your database into the wp_posts table. Select a post and edit its 'post_date_gmt' to a date/time that you want to test. 

Fixes #
