### PR TITLE
Fixes issue where the default SEO title was not shown in news-sitemap. 

### DIFF
--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -214,7 +214,7 @@ class WPSEO_News_Sitemap_Item {
 	 * Gets the SEO title of an item, used for static home and posts pages as well as singular titles.
 	 *
 	 * @codeCoverageIgnore
-	 *                    
+	 *
 	 * @param WP_Post $item Item to get the title for.
 	 *
 	 * @return string The formatted title.

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -199,9 +199,8 @@ class WPSEO_News_Sitemap_Item {
 		if ( $item === null ) {
 			return '';
 		}
-
 		// Get the SEO title.
-		$title = WPSEO_Frontend::get_instance()->get_seo_title( $item );
+		$title = WPSEO_Frontend::get_instance()->get_content_title( $item );
 
 		if ( ! empty( $title ) ) {
 			return $title;

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -213,6 +213,8 @@ class WPSEO_News_Sitemap_Item {
 	/**
 	 * Gets the SEO title of an item, used for static home and posts pages as well as singular titles.
 	 *
+	 * @codeCoverageIgnore
+	 *                    
 	 * @param WP_Post $item Item to get the title for.
 	 *
 	 * @return string The formatted title.

--- a/classes/class-sitemap-item.php
+++ b/classes/class-sitemap-item.php
@@ -200,7 +200,7 @@ class WPSEO_News_Sitemap_Item {
 			return '';
 		}
 		// Get the SEO title.
-		$title = WPSEO_Frontend::get_instance()->get_content_title( $item );
+		$title = $this->get_frontend_title( $item );
 
 		if ( ! empty( $title ) ) {
 			return $title;
@@ -208,6 +208,17 @@ class WPSEO_News_Sitemap_Item {
 
 		// Fallback to the post title.
 		return $item->post_title;
+	}
+
+	/**
+	 * Gets the SEO title of an item, used for static home and posts pages as well as singular titles.
+	 *
+	 * @param WP_Post $item Item to get the title for.
+	 *
+	 * @return string The formatted title.
+	 */
+	protected function get_frontend_title( $item ) {
+		return WPSEO_Frontend::get_instance()->get_content_title( $item );
 	}
 
 	/**

--- a/tests/test-class-sitemap-item.php
+++ b/tests/test-class-sitemap-item.php
@@ -100,6 +100,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 
 	/**
 	 * Checks if the post title output for the sitemap defaults to the post title when no SEO title is present.
+	 * This defaults to the default SEO title settings which is 'post_title - sitename'
 	 *
 	 * @covers WPSEO_News_Sitemap_Item::get_item_title
 	 */
@@ -113,11 +114,11 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 
 		$test_options = WPSEO_News::get_options();
 		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
-
 		$title_output = $instance->get_item_title( $test_seo_title );
+		$blogname = get_bloginfo("name");
 
 		// Check if correct post_title is returned.
-		$this->assertEquals( 'Post without SEO title', $title_output );
+		$this->assertEquals( 'Post without SEO title' . " - " . $blogname, $title_output);
 	}
 
 	/**

--- a/tests/test-class-sitemap-item.php
+++ b/tests/test-class-sitemap-item.php
@@ -115,10 +115,10 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$test_options = WPSEO_News::get_options();
 		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
 		$title_output = $instance->get_item_title( $test_seo_title );
-		$blogname = get_bloginfo("name");
+		$blogname     = get_bloginfo("name");
 
 		// Check if correct post_title - blogname is returned.
-		$this->assertEquals( 'Post without SEO title' . " - " . $blogname, $title_output);
+		$this->assertEquals( 'Post without SEO title' . " - " . $blogname, $title_output );
 	}
 
 	/**
@@ -143,7 +143,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		WPSEO_Options::set( 'title-' . $test_seo_title->post_type, '' );
 
 		// Check if correct post_title is returned.
-		$this->assertEquals( 'Post without SEO title and no default set', $title_output);
+		$this->assertEquals( 'Post without SEO title and no default set', $title_output );
 	}
 
 	/**

--- a/tests/test-class-sitemap-item.php
+++ b/tests/test-class-sitemap-item.php
@@ -99,8 +99,8 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	}
 
 	/**
-	 * Checks if the post title output for the sitemap defaults to the post title when no SEO title is present.
-	 * This defaults to the default SEO title settings which is 'post_title - sitename'
+	 * Checks if the post title output for the sitemap defaults to the post title + separator + blogtitle
+	 * when no SEO title is present.
 	 *
 	 * @covers WPSEO_News_Sitemap_Item::get_item_title
 	 */
@@ -117,12 +117,37 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$title_output = $instance->get_item_title( $test_seo_title );
 		$blogname = get_bloginfo("name");
 
-		// Check if correct post_title is returned.
+		// Check if correct post_title - blogname is returned.
 		$this->assertEquals( 'Post without SEO title' . " - " . $blogname, $title_output);
 	}
 
 	/**
-	 * Checks if the post title output for the sitemap exits and returns an emptry string when given null as a value.
+	 * Checks if the post title output for the sitemap defaults to only the post title when no SEO title is present
+	 * and no SEO title defaults are set.
+	 *
+	 * @covers WPSEO_News_Sitemap_Item::get_item_title
+	 */
+	public function test_get_item_title_when_no_seo_title_set_and_no_default_is_set() {
+		$test_seo_title = self::factory()->post->create_and_get(
+			array(
+				'post_title'    => 'Post without SEO title and no default set',
+				'post_type'     => 'test_post_type',
+			)
+		);
+
+		$test_options = WPSEO_News::get_options();
+		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
+		$title_output = $instance->get_item_title( $test_seo_title );
+
+		// Set the default SEO title for this post type to empty, to force it to return just the post_title.
+		WPSEO_Options::set( 'title-' . $test_seo_title->post_type, '' );
+
+		// Check if correct post_title is returned.
+		$this->assertEquals( 'Post without SEO title and no default set', $title_output);
+	}
+
+	/**
+	 * Checks if the post title output for the sitemap exits and returns an empty string when given null as a value.
 	 *
 	 * @covers WPSEO_News_Sitemap_Item::get_item_title
 	 */

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -101,7 +101,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output .= "\t\t\t<news:language>en</news:language>\n";
 		$expected_output .= "\t\t</news:publication>\n";
 		$expected_output .= "\t\t<news:publication_date>" . get_the_date( DATE_ATOM, $post_id ) . "</news:publication_date>\n";
-		$expected_output .= "\t\t<news:title><![CDATA[generate rss]]></news:title>\n";
+		$expected_output .= "\t\t<news:title><![CDATA[generate rss - " . get_bloginfo( "name" ) . "]]></news:title>\n";
 		$expected_output .= "\t</news:news>\n";
 		$expected_output .= '</url>';
 
@@ -291,10 +291,10 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$output = $this->instance->build_sitemap();
 
 		// Check if the $output contains the $expected_output.
-		$this->assertContains( "\t\t<news:title><![CDATA[Newest post]]></news:title>\n", $output );
-		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post]]></news:title>\n", $output );
+		$this->assertContains( "\t\t<news:title><![CDATA[Newest post - " . get_bloginfo( "name" ) . "]]></news:title>\n", $output );
+		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post - " . get_bloginfo( "name" ) . "]]></news:title>\n", $output );
 
-		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post]]></news:title>\n", $output );
+		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post - " . get_bloginfo( "name" ) . "]]></news:title>\n", $output );
 	}
 
 	public function restrict_featured_image( $options ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Users might see the titles in their sitemap change because of this PR because it used to only show the post_title. Now it will show the SEO title, which when left untouched outputs the default settings for SEO title set under "Search Appearance", which in its turn defaults to post_title + site name when left untouched. 
* Added an extra test to cover the scenario where a default SEO title is set and where it is not. 

## Test instructions

This PR can be tested by following these steps:

* Reproduce the steps in issue #459 
* Check out this branch.
* See it is fixed :)
* You can set the SEO title for a post in the "SEO title" field in the metabox (under 'edit snippet').
* The hierarchy should now function as follows: 
1) If a specific SEO title for a post is set this should be the title in the sitemap. 
2) If the SEO title for a post is set to empty the title in the news sitemap should default to the default SEO title set under `search appearance` for this post type. 
3) If this is also set to empty (so both the post seo title as well as the default seo title are empty) the regular post title is shown. 

Fixes #459 
