### PR TITLE
Set minimum required WP version to 5.0 and minumum yoast seo version to 10.1

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -104,7 +104,7 @@ class WPSEO_News {
 	 */
 	protected function check_dependencies( $wp_version ) {
 		// When WordPress function is too low.
-		if ( version_compare( $wp_version, '4.8', '<' ) ) {
+		if ( version_compare( $wp_version, '5.0', '<' ) ) {
 			add_action( 'all_admin_notices', array( $this, 'error_upgrade_wp' ) );
 
 			return false;
@@ -119,8 +119,8 @@ class WPSEO_News {
 			return false;
 		}
 
-		// Make sure Yoast SEO is installed on version 7.0 or an RC candidate of that version.
-		if ( version_compare( $wordpress_seo_version, '6.9', '<' ) ) {
+		// Make sure the Yoast SEO version is least 10.1. In 10.1, we've removed the License Manager code from this addon. With older YoastSEO versions, this addon won't get any updates.
+		if ( version_compare( $wordpress_seo_version, '10.1', '<' ) ) {
 			add_action( 'all_admin_notices', array( $this, 'error_upgrade_wpseo' ) );
 
 			return false;

--- a/tests/test-class-wpseo-news.php
+++ b/tests/test-class-wpseo-news.php
@@ -51,11 +51,11 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 	public function check_dependencies_data() {
 		return array(
 			array( false, '7.0', '3.0', 'WordPress is below the minimal required version.' ),
-			array( false, '7.0', '3.5', 'WordPress is below the minimal required version.' ),
+			array( false, '7.0', '4.9', 'WordPress is below the minimal required version.' ),
 			array( false, false, '5.0', 'WordPress SEO is not installed.' ),
-			array( false, '6.0', '5.0', 'WordPress SEO is below the minimal required version.' ),
-			array( true, '7.0', '5.0', 'WordPress (5.0) and WordPress SEO have the minimal required versions.' ),
-			array( true, '8.0', '4.8', 'WordPress (4.8) and WordPress SEO have the minimal required versions.' ),
+			array( false, '8.1', '5.0', 'WordPress SEO is below the minimal required version.' ),
+			array( true, '10.1', '5.0', 'WordPress (5.0) and WordPress SEO have the minimal required versions.' ),
+			array( true, '10.1', '5.1', 'WordPress (5.1) and WordPress SEO have the minimal required versions.' ),
 		);
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not for changelog] Sets the minimum required WordPress version to 5.0.
* Sets the minimum required Yoast SEO version to 10.1.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Install this branch on a WP site with a version below 5.0. See a notification.
* Install this branch on an installation with a Yoast SEO version lower than 10.1. See a notification.
* Install this branch on a WP site with a version >=5.0 and Yoast SEO version >= 10.1. See no notifications.

Fixes [Yoast/wordpress-seo#12331](https://github.com/Yoast/wordpress-seo/issues/12331)