### PR TITLE
Travis: test builds against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
       env: WP_VERSION=latest PHPUNIT=1
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
       dist: trusty
-    - php: nightly
+    - php: "7.4snapshot"
       env: WP_VERSION=latest PHPUNIT=1
     - stage: deploy-to-github-dist
       env: WP_VERSION=latest
@@ -67,7 +67,7 @@ jobs:
           all_branches: true
   allow_failures:
     # Allow failures for unstable builds.
-    - php: nightly
+    - php: "7.4snapshot"
       env: WP_VERSION=latest PHPUNIT=1
     - php: 7.3
       env: WP_VERSION=master
@@ -84,7 +84,7 @@ install:
   else
     composer install --no-dev --no-interaction
   fi
-- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then composer require --dev phpunit/phpunit ^5.7; fi
+- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then composer require --dev phpunit/phpunit ^5.7; fi
 - phpenv local --unset
 
 before_script:
@@ -161,7 +161,7 @@ script:
     if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then
         phpunit
     fi
-    if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then
         vendor/bin/phpunit
     fi
     travis_time_finish && travis_fold end "PHP.tests"


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Nightly has become PHP 8.0 since PHP 7.4 has been branched, so to continue to also test against PHP 7.4, it needs to be added separately.

Refs:
* https://twitter.com/nikita_ppv/status/1089839541828112384
* https://twitter.com/nikita_ppv/status/1094897743594770433

As PHP 8.x - current `nightly` - is not expected to be released until December 2020, with PHP 7.4 expected in December 2019, I've elected to replace the build against `nightly` with a build against `7.4snapshot`.

Once PHP 7.4 is released, the "high PHP" build - currently PHP 7.3 - should be replaced with a build against PHP 7.4 (stable) and the "unstable" build - now `7.4snapshot` - should be reverted to `nightly`.


## Test instructions

This PR can be tested by following these steps:
* Check the Travis build output.