### PR TITLE
CS: Each parameter should start on a new line in multi-line function calls

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -234,9 +234,8 @@ class WPSEO_News {
 
 		wp_enqueue_script(
 			'wpseo-news-admin-page',
-			plugins_url( 'assets/admin-page' . $this->file_ext( '.js' ), WPSEO_NEWS_FILE ), array(
-				'jquery',
-			),
+			plugins_url( 'assets/admin-page' . $this->file_ext( '.js' ), WPSEO_NEWS_FILE ),
+			array( 'jquery' ),
 			self::VERSION,
 			true
 		);

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -86,9 +86,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap::build_sitemap
 	 */
 	public function test_sitemap_NOT_empty() {
-		$post_id = $this->factory->post->create( array(
-			'post_title' => 'generate rss',
-		) );
+		$post_id = $this->factory->post->create( array( 'post_title' => 'generate rss' ) );
 
 		$output = $this->instance->build_sitemap();
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* WordPress-Coding-Standards/WordPress-Coding-Standards#1330

This commit addresses multi-line function calls where parameters did not each start on a new line (and sometimes didn't need to either).


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.