### PR TITLE
 CS: Move multi-line parameters out of function calls

### DIFF
--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -18,17 +18,20 @@ class WPSEO_News {
 	 * @return array
 	 */
 	public static function get_options() {
+		$defaults = array(
+			'name'          => '',
+			'default_genre' => array(),
+			'ep_image_src'  => '',
+			'version'       => '0',
+		);
+		$options  = wp_parse_args( get_option( 'wpseo_news', array() ), $defaults );
+
 		/**
 		 * Filter: 'wpseo_news_options' - Allow modifying of Yoast News SEO options.
 		 *
 		 * @api array $wpseo_news_options The Yoast News SEO options.
 		 */
-		return apply_filters( 'wpseo_news_options', wp_parse_args( get_option( 'wpseo_news', array() ), array(
-			'name'                     => '',
-			'default_genre'            => array(),
-			'ep_image_src'             => '',
-			'version'                  => '0',
-		) ) );
+		return apply_filters( 'wpseo_news_options', $options );
 	}
 
 	/**

--- a/tests/test-class-sitemap-item.php
+++ b/tests/test-class-sitemap-item.php
@@ -105,12 +105,11 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap_Item::get_item_title
 	 */
 	public function test_get_item_title_when_no_seo_title_set() {
-		$test_seo_title = self::factory()->post->create_and_get(
-			array(
-				'post_title'    => 'Post without SEO title',
-				'post_type'     => 'post',
-			)
+		$post_details   = array(
+			'post_title' => 'Post without SEO title',
+			'post_type'  => 'post',
 		);
+		$test_seo_title = self::factory()->post->create_and_get( $post_details );
 
 		$test_options = WPSEO_News::get_options();
 		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
@@ -128,12 +127,11 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap_Item::get_item_title
 	 */
 	public function test_get_item_title_when_no_seo_title_set_and_no_default_is_set() {
-		$test_seo_title = self::factory()->post->create_and_get(
-			array(
-				'post_title'    => 'Post without SEO title and no default set',
-				'post_type'     => 'test_post_type',
-			)
+		$post_details   = array(
+			'post_title' => 'Post without SEO title and no default set',
+			'post_type'  => 'test_post_type',
 		);
+		$test_seo_title = self::factory()->post->create_and_get( $post_details );
 
 		$test_options = WPSEO_News::get_options();
 		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
@@ -152,12 +150,11 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap_Item::get_item_title
 	 */
 	public function test_get_item_title_when_post_is_null() {
-		$test_seo_title = self::factory()->post->create_and_get(
-			array(
-				'post_title'    => 'title',
-				'post_type'     => 'post',
-			)
+		$post_details   = array(
+			'post_title' => 'title',
+			'post_type'  => 'post',
 		);
+		$test_seo_title = self::factory()->post->create_and_get( $post_details );
 
 		$test_options = WPSEO_News::get_options();
 		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
@@ -174,12 +171,11 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap_Item::get_item_title
 	 */
 	public function test_get_item_title_when_seo_title_set() {
-		$test_seo_title = self::factory()->post->create_and_get(
-			array(
-				'post_title'    => 'Post with SEO title',
-				'post_type'     => 'post',
-			)
+		$post_details   = array(
+			'post_title' => 'Post with SEO title',
+			'post_type'  => 'post',
 		);
+		$test_seo_title = self::factory()->post->create_and_get( $post_details );
 
 		$test_options = WPSEO_News::get_options();
 

--- a/tests/test-class-sitemap.php
+++ b/tests/test-class-sitemap.php
@@ -139,11 +139,12 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 */
 	public function test_sitemap_WITH_image() {
 
-		$image   = home_url( 'tests/assets/yoast.png' );
-		$post_id = $this->factory->post->create( array(
+		$image        = home_url( 'tests/assets/yoast.png' );
+		$post_details = array(
 			'post_title'   => 'with images',
 			'post_content' => '<img src="' . $image . '" />',
-		) );
+		);
+		$post_id      = $this->factory->post->create( $post_details );
 
 		$output = $this->instance->build_sitemap();
 
@@ -162,11 +163,12 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 */
 	public function test_sitemap_WITHOUT_featured_image_restricted() {
 
-		$image   = home_url( 'tests/assets/yoast.png' );
-		$post_id = $this->factory->post->create( array(
+		$image        = home_url( 'tests/assets/yoast.png' );
+		$post_details = array(
 			'post_title'   => 'featured image',
 			'post_content' => '<img src="' . $image . '" />',
-		) );
+		);
+		$post_id      = $this->factory->post->create( $post_details );
 
 		$featured_image = home_url( 'tests/assets/yoast_featured.png' );
 		$thumbnail_id   = $this->create_attachment( $featured_image, $post_id );
@@ -199,11 +201,12 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 
 		$this->instance = new WPSEO_News_Sitemap();
 
-		$image   = home_url( 'tests/assets/yoast.png' );
-		$post_id = $this->factory->post->create( array(
+		$image        = home_url( 'tests/assets/yoast.png' );
+		$post_details = array(
 			'post_title'   => 'featured image',
 			'post_content' => '<img src="' . $image . '" />',
-		) );
+		);
+		$post_id      = $this->factory->post->create( $post_details );
 
 		$featured_image = home_url( 'tests/assets/yoast_featured.png' );
 		$thumbnail_id   = $this->create_attachment( $featured_image, $post_id );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.

WPCS 1.1.0 introduced a stricter check on function call layouts.
Multi-line function calls now need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

See:
* https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.1.0
* WordPress-Coding-Standards/WordPress-Coding-Standards#1330

With this mind, function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS after the changes in WPCS 1.1.0, have been fixed - depending on the existing code - by:
* either changing multi-line function call arguments to single line;
* or by moving a multi-line function call arguments out of the function call and defining it as a variable before passing it to the function call.

This commit contains changes for the second variant.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.