### PR TITLE
CS/QA: use `self` when referencing a (static) class member from within the same class

### DIFF
--- a/classes/class-sitemap.php
+++ b/classes/class-sitemap.php
@@ -67,7 +67,7 @@ class WPSEO_News_Sitemap {
 	 */
 	public function init() {
 
-		$this->basename = WPSEO_News_Sitemap::get_sitemap_name( false );
+		$this->basename = self::get_sitemap_name( false );
 
 		// Setting stylesheet for cached sitemap.
 		add_action( 'wpseo_sitemap_stylesheet_cache_' . $this->basename, array( $this, 'set_stylesheet_cache' ) );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.
* Code style compliance.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.