### PR TITLE
Test documentation: fix @covers tags

### DIFF
--- a/tests/test-class-sitemap-images.php
+++ b/tests/test-class-sitemap-images.php
@@ -46,7 +46,7 @@ class WPSEO_News_Sitemap_Images_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Tests parsing of the image source attribute value.
 	 *
-	 * @covers WPSEO_News_Sitemap_Images::parse_image_source()
+	 * @covers WPSEO_News_Sitemap_Images::parse_image_source
 	 *
 	 * @dataProvider provider_parse_image_source
 	 *

--- a/tests/test-class-wpseo-news.php
+++ b/tests/test-class-wpseo-news.php
@@ -20,7 +20,7 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 	 * @param string $wordpress_version     The WordPress version to check.
 	 * @param string $message               Message given by PHPUnit after assertion.
 	 *
-	 * @covers WPSEO_News::check_dependencies()
+	 * @covers WPSEO_News::check_dependencies
 	 */
 	public function test_check_dependencies( $expected, $wordpress_seo_version, $wordpress_version, $message ) {
 		$class_instance = $this


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

`@covers` tags are used to indicate what class/method/function a test covers when calculating code coverage of the tests and should follow the specifications of PHPUnit.

Ref:
* https://phpunit.de/manual/6.5/en/appendixes.annotations.html#appendixes.annotations.covers
* https://github.com/Yoast/yoastcs/issues/123

## Test instructions

This PR can be tested by following these steps:

* _N/A_