### PR TITLE
Add NewsArticle output to News post types

### DIFF
--- a/classes/class-schema.php
+++ b/classes/class-schema.php
@@ -13,7 +13,6 @@ class WPSEO_News_Schema {
 	 * WPSEO_News_Head Constructor.
 	 */
 	public function __construct() {
-		$this->post_types = WPSEO_News::get_included_post_types();
 		add_filter( 'wpseo_schema_article_post_types', array( $this, 'article_post_types' ) );
 		add_filter( 'wpseo_schema_article', array( $this, 'change_article' ) );
 	}
@@ -26,7 +25,7 @@ class WPSEO_News_Schema {
 	 * @return array $post_types Supported post types.
 	 */
 	public function article_post_types( $post_types ) {
-		$post_types = array_merge( $this->post_types, $post_types );
+		$post_types = array_merge( WPSEO_News::get_included_post_types(), $post_types );
 
 		return $post_types;
 	}
@@ -40,7 +39,7 @@ class WPSEO_News_Schema {
 	 */
 	public function change_article( $data ) {
 		$post = get_post();
-		if ( in_array( $post->post_type, $this->post_types ) ) {
+		if ( in_array( $post->post_type, WPSEO_News::get_included_post_types() ) ) {
 			$data['@type']           = 'NewsArticle';
 			$data['copyrightYear']   = mysql2date( 'Y', $post->post_date_gmt, false );
 			$data['copyrightHolder'] = array( '@id' => WPSEO_Utils::get_home_url() . WPSEO_Schema_IDs::ORGANIZATION_HASH );

--- a/classes/class-schema.php
+++ b/classes/class-schema.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Yoast SEO: News plugin file.
+ *
+ * @package WPSEO_News
+ */
+
+/**
+ * Makes the require Schema changes.
+ */
+class WPSEO_News_Schema {
+	/**
+	 * WPSEO_News_Head Constructor.
+	 */
+	public function __construct() {
+		$this->post_types = WPSEO_News::get_included_post_types();
+		add_filter( 'wpseo_schema_article_post_types', array( $this, 'article_post_types' ) );
+		add_filter( 'wpseo_schema_article', array( $this, 'change_article' ) );
+	}
+
+	/**
+	 * Make all News post types output Article schema.
+	 *
+	 * @param array $post_types Supported post types.
+	 *
+	 * @return array $post_types Supported post types.
+	 */
+	public function article_post_types( $post_types ) {
+		$post_types = array_merge( $this->post_types, $post_types );
+
+		return $post_types;
+	}
+
+	/**
+	 * Change Article to NewsArticle.
+	 *
+	 * @param array $data Schema Article data.
+	 *
+	 * @return array $data Schema Article data.
+	 */
+	public function change_article( $data ) {
+		if ( in_array( get_post_type(), $this->post_types ) ) {
+			$data['@type'] = 'NewsArticle';
+		}
+
+		return $data;
+	}
+}

--- a/classes/class-schema.php
+++ b/classes/class-schema.php
@@ -39,8 +39,11 @@ class WPSEO_News_Schema {
 	 * @return array $data Schema Article data.
 	 */
 	public function change_article( $data ) {
-		if ( in_array( get_post_type(), $this->post_types ) ) {
-			$data['@type'] = 'NewsArticle';
+		$post = get_post();
+		if ( in_array( $post->post_type, $this->post_types ) ) {
+			$data['@type']           = 'NewsArticle';
+			$data['copyrightYear']   = mysql2date( 'Y', $post->post_date_gmt, false );
+			$data['copyrightHolder'] = array( '@id' => WPSEO_Utils::get_home_url() . WPSEO_Schema_IDs::ORGANIZATION_HASH );
 		}
 
 		return $data;

--- a/classes/class-wpseo-news.php
+++ b/classes/class-wpseo-news.php
@@ -52,6 +52,9 @@ class WPSEO_News {
 		// Head.
 		new WPSEO_News_Head();
 
+		// Schema.
+		new WPSEO_News_Schema();
+
 		if ( is_admin() ) {
 			$this->init_admin();
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds Schema.org `NewsArticle` markup to all post types that you've selected as News.

## Relevant technical choices:

* Makes all post types selected in the backend output `Article`, subsequently changing that to `NewsArticle`.

## Test instructions

This PR can be tested by following these steps:

* Create a post or page.
* Make sure the post type is selected in the News SEO settings.
* See the output contains `NewsArticle` schema.

Fixes #485
Fixes #179
Fixes #343
