### PR TITLE
CS/QA: make sure $_SERVER array key is set before using it

### DIFF
--- a/classes/class-meta-box.php
+++ b/classes/class-meta-box.php
@@ -28,7 +28,9 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 		add_filter( 'wpseo_save_metaboxes', array( $this, 'save' ), 10, 1 );
 		add_action( 'add_meta_boxes', array( $this, 'add_tab_hooks' ) );
 
-		if ( $pagenow === 'post.php' || $pagenow === 'post-new.php' || stristr( $_SERVER['REQUEST_URI'], '/news-sitemap.xml' ) ) {
+		if ( $pagenow === 'post.php' || $pagenow === 'post-new.php'
+			|| ( isset( $_SERVER['REQUEST_URI'] ) && stristr( $_SERVER['REQUEST_URI'], '/news-sitemap.xml' ) )
+		) {
 			add_filter( 'add_extra_wpseo_meta_fields', array( $this, 'add_meta_fields_to_wpseo_meta' ) );
 		}
 	}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Depending on server configuration, the `REQUEST_URI` for the `$_SERVER` superglobal _may_ not be available. This prevents an "Undefined index" notice if that would happen.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    As it's neigh impossible to fake server variables, this can not be tested manually. A unit test _could_ be added for this. but so far, this whole class is untested.
