### PR TITLE
Update i18n-module version to 3.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "xrstf/composer-php52": "^1.0.20",
         "yoast/wp-helpscout": "^1.0||^2.0",
-        "yoast/i18n-module": "^3.0"
+        "yoast/i18n-module": "^3.1.1"
     },
     "require-dev": {
         "yoast/yoastcs": "^0.4.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef6df1b81f4fa516e9722f763b6972aa",
+    "content-hash": "0d2c74537d4fa6af066c22ab4ee6dec5",
     "packages": [
         {
             "name": "xrstf/composer-php52",
@@ -39,16 +39,16 @@
         },
         {
             "name": "yoast/i18n-module",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/i18n-module.git",
-                "reference": "50c69961805a8d79699eed745a65e9e4a76538eb"
+                "reference": "9d0a2f6daea6fb42376b023e7778294d19edd85d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/50c69961805a8d79699eed745a65e9e4a76538eb",
-                "reference": "50c69961805a8d79699eed745a65e9e4a76538eb",
+                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/9d0a2f6daea6fb42376b023e7778294d19edd85d",
+                "reference": "9d0a2f6daea6fb42376b023e7778294d19edd85d",
                 "shasum": ""
             },
             "require": {
@@ -80,7 +80,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2019-05-06T08:29:33+00:00"
+            "time": "2019-05-07T06:45:05+00:00"
         },
         {
             "name": "yoast/wp-helpscout",


### PR DESCRIPTION
i18n-module 3.1.1 reverts the capitalization of class names, which solves fatal errors.