### PR TITLE
QA: use the most specific PHPUnit assertion possible

### DIFF
--- a/tests/framework/unittestcase.php
+++ b/tests/framework/unittestcase.php
@@ -45,7 +45,7 @@ class WPSEO_News_UnitTestCase extends WP_UnitTestCase {
 	protected function expectOutput( $string ) {
 		$output = ob_get_contents();
 		ob_clean();
-		$this->assertEquals( $output, $string );
+		$this->assertSame( $output, $string );
 	}
 
 	/**

--- a/tests/sitemap-item-test.php
+++ b/tests/sitemap-item-test.php
@@ -36,8 +36,8 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$original_post_utc_time      = date( $timezone_format, $base_time );
 		$get_publication_date_output = $instance->get_publication_date( $test_post_date_gmt );
 
-		// Check if post_date_gmt is equal to output of get_publication_date().
-		$this->assertEquals( $original_post_utc_time, $get_publication_date_output );
+		// Check if post_date_gmt is the same as the output of get_publication_date().
+		$this->assertSame( $original_post_utc_time, $get_publication_date_output );
 	}
 
 	/**
@@ -68,8 +68,8 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$original_post_date          = date( $timezone_format, $base_time );
 		$get_publication_date_output = $instance->get_publication_date( $test_post_date );
 
-		// Check if post_date is equal to output of get_publication_date().
-		$this->assertEquals( $original_post_date, $get_publication_date_output );
+		// Check if post_date is the same as the output of get_publication_date().
+		$this->assertSame( $original_post_date, $get_publication_date_output );
 	}
 
 	/**
@@ -94,8 +94,8 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 
 		$get_publication_date_output = $instance->get_publication_date( $test_post_date_gmt );
 
-		// Check if post_date_gmt is equal to output of get_publication_date().
-		$this->assertEquals( '', $get_publication_date_output );
+		// Check if post_date_gmt is the same as the output of get_publication_date().
+		$this->assertSame( '', $get_publication_date_output );
 	}
 
 	/**
@@ -117,7 +117,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$blogname     = get_bloginfo( 'name' );
 
 		// Check if correct post_title - blogname is returned.
-		$this->assertEquals( 'Post without SEO title - ' . $blogname, $title_output );
+		$this->assertSame( 'Post without SEO title - ' . $blogname, $title_output );
 	}
 
 	/**
@@ -141,7 +141,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		WPSEO_Options::set( 'title-' . $test_seo_title->post_type, '' );
 
 		// Check if correct post_title is returned.
-		$this->assertEquals( 'Post without SEO title and no default set', $title_output );
+		$this->assertSame( 'Post without SEO title and no default set', $title_output );
 	}
 
 	/**
@@ -162,7 +162,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$title_output = $instance->get_item_title( null );
 
 		// Check if an empty string is correctly returned.
-		$this->assertEquals( '', $title_output );
+		$this->assertSame( '', $title_output );
 	}
 
 	/**
@@ -185,7 +185,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$title_output = $instance->get_item_title( $test_seo_title );
 
 		// Check if correct post_title is returned.
-		$this->assertEquals( 'SEO title of the post', $title_output );
+		$this->assertSame( 'SEO title of the post', $title_output );
 	}
 }
 

--- a/tests/sitemap-test.php
+++ b/tests/sitemap-test.php
@@ -34,7 +34,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	public function test_add_to_index_no_items() {
 		$input  = '';
 		$output = $this->instance->add_to_index( $input );
-		$this->assertEquals( $input, $output );
+		$this->assertSame( $input, $output );
 	}
 
 	/**
@@ -64,7 +64,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output .= '<lastmod>' . htmlspecialchars( $output_date->format( 'c' ) ) . '</lastmod>' . "\n";
 		$expected_output .= '</sitemap>' . "\n";
 
-		$this->assertEquals( $expected_output, $output );
+		$this->assertSame( $expected_output, $output );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
 </urlset>';
 
-		$this->assertEquals( $expected_output, $output );
+		$this->assertSame( $expected_output, $output );
 	}
 
 	/**
@@ -127,8 +127,8 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
 </urlset>';
 
-		// Check if the $output contains the $expected_output.
-		$this->assertContains( $expected_output, $output );
+		// Check if the $output is the same as the $expected_output.
+		$this->assertSame( $expected_output, $output );
 	}
 
 	/**
@@ -230,7 +230,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap::news_sitemap_basename
 	 */
 	public function test_sitemap_default_name() {
-		$this->assertEquals( 'news', WPSEO_News_Sitemap::news_sitemap_basename() );
+		$this->assertSame( 'news', WPSEO_News_Sitemap::news_sitemap_basename() );
 	}
 
 	/**
@@ -241,7 +241,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	public function test_sitemap_name_on_post_type() {
 		register_post_type( 'news' );
 
-		$this->assertEquals( 'yoast-news', WPSEO_News_Sitemap::news_sitemap_basename() );
+		$this->assertSame( 'yoast-news', WPSEO_News_Sitemap::news_sitemap_basename() );
 	}
 
 	/**
@@ -252,7 +252,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	public function test_sitemap_name_on_constant() {
 		define( 'YOAST_NEWS_SITEMAP_BASENAME', 'unit-test-news' );
 
-		$this->assertEquals( 'unit-test-news', WPSEO_News_Sitemap::news_sitemap_basename() );
+		$this->assertSame( 'unit-test-news', WPSEO_News_Sitemap::news_sitemap_basename() );
 	}
 
 	/**

--- a/tests/wpseo-news-test.php
+++ b/tests/wpseo-news-test.php
@@ -35,7 +35,7 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 			->will( $this->returnValue( $wordpress_seo_version ) );
 
 
-		$this->assertEquals( $expected, $class_instance->check_dependencies( $wordpress_version ), $message );
+		$this->assertSame( $expected, $class_instance->check_dependencies( $wordpress_version ), $message );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available have been extended  hugely over the years.
To have the most reliable tests, the most specific assertion should be used.

This implements this for the News plugin, while keeping in mind that at this time, PHPUnit 3.x should still be supported.

Refs:
* https://phpunit.de/manual/4.8/en/appendixes.assertions.html
* https://phpunit.readthedocs.io/en/7.5/assertions.html#

Most notably, this changes calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison and `assertSame()` does a strict type comparison.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame

## Test instructions

This PR can be tested by following these steps:

* As long as the unit tests pass in the Travis builds, we are good.
