### PR TITLE
Composer: sync with other config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Google News plugin for the Yoast SEO plugin",
     "type": "wordpress-plugin",
     "license": "GPL-2.0-or-later",
+    "homepage": "https://yoast.com/wordpress/plugins/news-seo/",
     "authors": [
         {
             "name": "Team Yoast",
@@ -10,7 +11,12 @@
             "homepage": "https://yoast.com"
         }
     ],
+    "support": {
+        "issues": "https://github.com/Yoast/wpseo-news/issues",
+        "source": "https://github.com/Yoast/wpseo-news"
+    },
     "require": {
+        "php": ">=5.2",
         "xrstf/composer-php52": "^1.0.20",
         "yoast/wp-helpscout": "^1.0||^2.0",
         "yoast/i18n-module": "^3.1.1"
@@ -33,8 +39,17 @@
     },
     "scripts": {
         "config-yoastcs": [
-            "\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs",
-            "\"vendor/bin/phpcs\" --config-set default_standard Yoast"
+            "@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs",
+            "@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set default_standard Yoast"
+        ],
+        "check-cs": [
+            "@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs"
+        ],
+        "fix-cs": [
+            "@php ./vendor/squizlabs/php_codesniffer/scripts/phpcbf"
+        ],
+        "test": [
+            "@php ./vendor/phpunit/phpunit/phpunit"
         ],
         "post-install-cmd": [
             "xrstf\\Composer52\\Generator::onPostInstallCmd"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7108bb1f09493c881083af8c43f4465a",
+    "content-hash": "1c63d9b003a8743a3a297af96dd04549",
     "packages": [
         {
             "name": "xrstf/composer-php52",
@@ -2002,6 +2002,8 @@
     "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.2"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

I've done a compare between the `composer.json` config files in (nearly) all plugin repos.

This commit adds some additional properties to the config file to improve consistency with the other repos and predictability for devs.

* Adds an explicit minimum PHP version.
* Adds `check-cs`, `fix-cs` and `test` scripts for use by devs.
* Makes the existing `config-yoastcs` script respect the PHP version Composer is run on.
     See Yoast/yoastcs#114 for a more detailed explanation.
* Add a few miscellanous other properties.

## Test instructions

This PR can be tested by following these steps:

* Run each of the composer scripts to test them (make sure you have run `composer install` beforehand):
    - `composer config-yoastcs`
    - `composer check-cs`
    - `composer fix-cs`
    - `composer test`

