### PR TITLE
Exclude from news sitemap schema fallback

### DIFF
--- a/classes/excludable-taxonomies.php
+++ b/classes/excludable-taxonomies.php
@@ -37,7 +37,7 @@ class WPSEO_News_Excludable_Taxonomies {
 	}
 
 	/**
-	 * Filter to check whether a taxonomy is shows in the WordPress ui.
+	 * Filter to check whether a taxonomy is shown in the WordPress ui.
 	 *
 	 * @param WP_Taxonomy $taxonomy The taxonomy to filter.
 	 *

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -28,8 +28,8 @@ class WPSEO_News_Schema {
 	 * @return array $post_types Supported post types.
 	 */
 	public function article_post_types( $post_types ) {
-		// When the news article is excluded do not alter the article post types.
-		if ( $this->is_post_excluded() ) {
+		// Alter the article post types only when the news article is not excluded.
+		if ( ! $this->is_post_excluded() ) {
 			$post_types = array_merge( WPSEO_News::get_included_post_types(), $post_types );
 		}
 
@@ -46,8 +46,8 @@ class WPSEO_News_Schema {
 	public function change_article( $data ) {
 		$post = $this->get_post();
 		if ( $post !== null && in_array( $post->post_type, WPSEO_News::get_included_post_types(), true ) ) {
-			// When the news article is excluded do not change the `@type` to `NewsArticle`.
-			if ( $this->is_post_excluded( $post ) ) {
+			// Change the `@type` to `NewsArticle` only when the news article is not excluded.
+			if ( ! $this->is_post_excluded( $post ) ) {
 				$data['@type'] = 'NewsArticle';
 			}
 			$data['copyrightYear']   = mysql2date( 'Y', $post->post_date_gmt, false );
@@ -70,9 +70,9 @@ class WPSEO_News_Schema {
 		}
 
 		return (
-			$post !== null
-			&& WPSEO_News::is_excluded_through_sitemap( $post->ID ) === false
-			&& WPSEO_News::is_excluded_through_terms( $post->ID, $post->post_type ) === false
+			$post === null
+			|| WPSEO_News::is_excluded_through_sitemap( $post->ID )
+			|| WPSEO_News::is_excluded_through_terms( $post->ID, $post->post_type )
 		);
 	}
 

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -70,16 +70,16 @@ class WPSEO_News_Schema {
 		}
 
 		return (
-			$post !== null &&
-			WPSEO_News::is_excluded_through_sitemap( $post->ID ) === false &&
-			WPSEO_News::is_excluded_through_terms( $post->ID, $post->post_type ) === false
+			$post !== null
+			&& WPSEO_News::is_excluded_through_sitemap( $post->ID ) === false
+			&& WPSEO_News::is_excluded_through_terms( $post->ID, $post->post_type ) === false
 		);
 	}
 
 	/**
 	 * Retrieves post data given a post ID or post object.
 	 *
-	 * This function exists to be abe to mock the get_post call and should
+	 * This function exists to be able to mock the get_post call and should
 	 * no longer be needed when moving the tests suite over to BrainMonkey.
 	 *
 	 * @codeCoverageIgnore

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -55,11 +55,14 @@ class WPSEO_News_Schema {
 	/**
 	 * Retrieves post data given a post ID or post object.
 	 *
+	 * This function exists to be abe to mock the get_post call and should
+	 * no longer be needed when moving the tests suite over to BrainMonkey.
+	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @param int|WP_Post|null $post Optional. Post ID or post object. Defaults to global $post.
+	 * @param int|WP_Post|null $post Optional. Post ID or post object.
 	 *
-	 * @return WP_Post|null Type corresponding to $output on success or null on failure.
+	 * @return WP_Post|null The post object or null if it cannot be found.
 	 */
 	protected function get_post( $post = null ) {
 		return get_post( $post );

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -11,7 +11,7 @@
 class WPSEO_News_Schema {
 
 	/**
-	 * WPSEO_News_Head Constructor.
+	 * WPSEO_News_Schema Constructor.
 	 */
 	public function __construct() {
 		add_filter( 'wpseo_schema_article_post_types', array( $this, 'article_post_types' ) );
@@ -39,13 +39,29 @@ class WPSEO_News_Schema {
 	 * @return array $data Schema Article data.
 	 */
 	public function change_article( $data ) {
-		$post = get_post();
-		if ( in_array( $post->post_type, WPSEO_News::get_included_post_types(), true ) ) {
-			$data['@type']           = 'NewsArticle';
+		$post = $this->get_post();
+		if ( $post !== null && in_array( $post->post_type, WPSEO_News::get_included_post_types(), true ) ) {
+			// When the news article is excluded (from the news sitemap) do not change the `@type` to `NewsArticle`.
+			if ( WPSEO_News::is_news_article_excluded( $post->ID ) === false && WPSEO_News::exclude_item_terms( $post->ID, $post->post_type ) === false ) {
+				$data['@type'] = 'NewsArticle';
+			}
 			$data['copyrightYear']   = mysql2date( 'Y', $post->post_date_gmt, false );
 			$data['copyrightHolder'] = array( '@id' => WPSEO_Utils::get_home_url() . WPSEO_Schema_IDs::ORGANIZATION_HASH );
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Retrieves post data given a post ID or post object.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @param int|WP_Post|null $post Optional. Post ID or post object. Defaults to global $post.
+	 *
+	 * @return WP_Post|null Type corresponding to $output on success or null on failure.
+	 */
+	protected function get_post( $post = null ) {
+		return get_post( $post );
 	}
 }

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -28,8 +28,9 @@ class WPSEO_News_Schema {
 	 * @return array $post_types Supported post types.
 	 */
 	public function article_post_types( $post_types ) {
+		$post = $this->get_post();
 		// Alter the article post types only when the news article is not excluded.
-		if ( ! $this->is_post_excluded() ) {
+		if ( $post !== null && ! $this->is_post_excluded( $post ) ) {
 			$post_types = array_merge( WPSEO_News::get_included_post_types(), $post_types );
 		}
 
@@ -60,18 +61,13 @@ class WPSEO_News_Schema {
 	/**
 	 * Checks if the given post should be excluded or not.
 	 *
-	 * @param WP_Post|null $post The post to check for.
+	 * @param WP_Post $post The post to check for.
 	 *
 	 * @return bool True if the post should be excluded.
 	 */
-	private function is_post_excluded( $post = null ) {
-		if ( $post === null ) {
-			$post = $this->get_post();
-		}
-
+	private function is_post_excluded( $post ) {
 		return (
-			$post === null
-			|| WPSEO_News::is_excluded_through_sitemap( $post->ID )
+			WPSEO_News::is_excluded_through_sitemap( $post->ID )
 			|| WPSEO_News::is_excluded_through_terms( $post->ID, $post->post_type )
 		);
 	}

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -31,7 +31,7 @@ class WPSEO_News_Schema {
 		$post = $this->get_post();
 		// Alter the article post types only when the news article is not excluded.
 		if ( $post !== null && ! $this->is_post_excluded( $post ) ) {
-			$post_types = array_merge( WPSEO_News::get_included_post_types(), $post_types );
+			$post_types = array_unique( array_merge( WPSEO_News::get_included_post_types(), $post_types ) );
 		}
 
 		return $post_types;

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -62,7 +62,7 @@ class WPSEO_News_Sitemap_Item {
 	 * @return bool True if the item has to be skipped.
 	 */
 	private function skip_build_item() {
-		if ( WPSEO_News::is_news_article_excluded( $this->item->ID ) ) {
+		if ( WPSEO_News::is_excluded_through_sitemap( $this->item->ID ) ) {
 			return true;
 		}
 
@@ -81,7 +81,7 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
-		if ( WPSEO_News::exclude_item_terms( $this->item->ID, $this->item->post_type ) ) {
+		if ( WPSEO_News::is_excluded_through_terms( $this->item->ID, $this->item->post_type ) ) {
 			return true;
 		}
 

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -62,7 +62,7 @@ class WPSEO_News_Sitemap_Item {
 	 * @return bool True if the item has to be skipped.
 	 */
 	private function skip_build_item() {
-		if ( WPSEO_Meta::get_value( 'newssitemap-exclude', $this->item->ID ) === 'on' ) {
+		if ( WPSEO_News::is_news_article_excluded( $this->item->ID ) ) {
 			return true;
 		}
 
@@ -81,51 +81,11 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
-		if ( $this->exclude_item_terms() ) {
+		if ( WPSEO_News::exclude_item_terms( $this->item->ID, $this->item->post_type ) ) {
 			return true;
 		}
 
 		return false;
-	}
-
-	/**
-	 * Excludes the item when one of his terms is excluded.
-	 *
-	 * @return bool True if the item should be excluded.
-	 */
-	private function exclude_item_terms() {
-		foreach ( $this->get_terms_for_item() as $term ) {
-			$term_exclude_option = 'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $this->item->post_type;
-
-			if ( isset( $this->options[ $term_exclude_option ] ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Retrieves all the Term IDs for all the items.
-	 *
-	 * @return array The terms for the item.
-	 */
-	private function get_terms_for_item() {
-		$terms = array();
-
-		$excludable_taxonomies = new WPSEO_News_Excludable_Taxonomies( $this->item->post_type );
-
-		foreach ( $excludable_taxonomies->get() as $taxonomy ) {
-			$extra_terms = get_the_terms( $this->item->ID, $taxonomy->name );
-
-			if ( ! is_array( $extra_terms ) || count( $extra_terms ) === 0 ) {
-				continue;
-			}
-
-			$terms = array_merge( $terms, $extra_terms );
-		}
-
-		return $terms;
 	}
 
 	/**

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -91,7 +91,7 @@ class WPSEO_News {
 
 		// Setting action for removing the transient on update options.
 		if ( class_exists( 'WPSEO_Sitemaps_Cache' )
-			 && method_exists( 'WPSEO_Sitemaps_Cache', 'register_clear_on_option_update' )
+			&& method_exists( 'WPSEO_Sitemaps_Cache', 'register_clear_on_option_update' )
 		) {
 			WPSEO_Sitemaps_Cache::register_clear_on_option_update(
 				'wpseo_news',
@@ -161,9 +161,11 @@ class WPSEO_News {
 			$this_plugin = plugin_basename( WPSEO_NEWS_FILE );
 		}
 		if ( $file === $this_plugin ) {
-			$settings_link = '<a href="' . admin_url( 'admin.php?page=wpseo_news' ) . '">'
-							 . __( 'Settings', 'wordpress-seo-news' )
-							 . '</a>';
+			$settings_link = sprintf(
+				'<a href="%1$s">%2$s</a>',
+				admin_url( 'admin.php?page=wpseo_news' ),
+				__( 'Settings', 'wordpress-seo-news' )
+			);
 			array_unshift( $links, $settings_link );
 		}
 
@@ -240,8 +242,8 @@ class WPSEO_News {
 	public function error_missing_wpseo() {
 		echo '<div class="error"><p>';
 		printf(
-		/* translators: %1$s resolves to the link to search for Yoast SEO, %2$s resolves to the closing tag for this link, %3$s resolves to Yoast SEO, %4$s resolves to News SEO */
 			esc_html__(
+				/* translators: %1$s resolves to the link to search for Yoast SEO, %2$s resolves to the closing tag for this link, %3$s resolves to Yoast SEO, %4$s resolves to News SEO */
 				'Please %1$sinstall &amp; activate %3$s%2$s and then enable its XML sitemap functionality to allow the %4$s module to work.',
 				'wordpress-seo-news'
 			),
@@ -261,8 +263,8 @@ class WPSEO_News {
 	public function error_upgrade_wp() {
 		echo '<div class="error"><p>';
 		printf(
-		/* translators: %1$s resolves to News SEO */
 			esc_html__(
+				/* translators: %1$s resolves to News SEO */
 				'Please upgrade WordPress to the latest version to allow WordPress and the %1$s module to work properly.',
 				'wordpress-seo-news'
 			),
@@ -279,8 +281,8 @@ class WPSEO_News {
 	public function error_upgrade_wpseo() {
 		echo '<div class="error"><p>';
 		printf(
-		/* translators: %1$s resolves to Yoast SEO, %2$s resolves to News SEO */
 			esc_html__(
+				/* translators: %1$s resolves to Yoast SEO, %2$s resolves to News SEO */
 				'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.',
 				'wordpress-seo-news'
 			),

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -354,7 +354,7 @@ class WPSEO_News {
 	}
 
 	/**
-	 * Determines whether the post is excluded in the news sitemap (or schema) output.
+	 * Determines whether the post is excluded in the news sitemap (and therefore schema) output.
 	 *
 	 * @param int $post_id The ID of the post to check for.
 	 *

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -360,21 +360,21 @@ class WPSEO_News {
 	 *
 	 * @return bool Whether or not the post is excluded.
 	 */
-	public static function is_news_article_excluded( $post_id ) {
+	public static function is_excluded_through_sitemap( $post_id ) {
 		return WPSEO_Meta::get_value( 'newssitemap-exclude', $post_id ) === 'on';
 	}
 
 	/**
-	 * Excludes the item when one of its terms is excluded.
+	 * Determines if the post is excluded in through a term that is excluded.
 	 *
 	 * @param int    $post_id   The ID of the post.
 	 * @param string $post_type The type of the post.
 	 *
-	 * @return bool True if the item should be excluded.
+	 * @return bool True if the post is excluded.
 	 */
-	public static function exclude_item_terms( $post_id, $post_type ) {
+	public static function is_excluded_through_terms( $post_id, $post_type ) {
 		$options = self::get_options();
-		$terms   = self::get_terms_for_item( $post_id, $post_type );
+		$terms   = self::get_terms_for_post( $post_id, $post_type );
 
 		foreach ( $terms as $term ) {
 			$term_exclude_option = 'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type;
@@ -388,14 +388,14 @@ class WPSEO_News {
 	}
 
 	/**
-	 * Retrieves all the Term IDs for all the items.
+	 * Retrieves all the term IDs for the post.
 	 *
 	 * @param int    $post_id   The ID of the post.
 	 * @param string $post_type The type of the post.
 	 *
 	 * @return array The terms for the item.
 	 */
-	public static function get_terms_for_item( $post_id, $post_type ) {
+	public static function get_terms_for_post( $post_id, $post_type ) {
 		$terms                 = array();
 		$excludable_taxonomies = new WPSEO_News_Excludable_Taxonomies( $post_type );
 

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -91,7 +91,7 @@ class WPSEO_News {
 
 		// Setting action for removing the transient on update options.
 		if ( class_exists( 'WPSEO_Sitemaps_Cache' )
-			&& method_exists( 'WPSEO_Sitemaps_Cache', 'register_clear_on_option_update' )
+			 && method_exists( 'WPSEO_Sitemaps_Cache', 'register_clear_on_option_update' )
 		) {
 			WPSEO_Sitemaps_Cache::register_clear_on_option_update(
 				'wpseo_news',
@@ -162,8 +162,8 @@ class WPSEO_News {
 		}
 		if ( $file === $this_plugin ) {
 			$settings_link = '<a href="' . admin_url( 'admin.php?page=wpseo_news' ) . '">'
-				. __( 'Settings', 'wordpress-seo-news' )
-				. '</a>';
+							 . __( 'Settings', 'wordpress-seo-news' )
+							 . '</a>';
 			array_unshift( $links, $settings_link );
 		}
 
@@ -240,7 +240,7 @@ class WPSEO_News {
 	public function error_missing_wpseo() {
 		echo '<div class="error"><p>';
 		printf(
-			/* translators: %1$s resolves to the link to search for Yoast SEO, %2$s resolves to the closing tag for this link, %3$s resolves to Yoast SEO, %4$s resolves to News SEO */
+		/* translators: %1$s resolves to the link to search for Yoast SEO, %2$s resolves to the closing tag for this link, %3$s resolves to Yoast SEO, %4$s resolves to News SEO */
 			esc_html__(
 				'Please %1$sinstall &amp; activate %3$s%2$s and then enable its XML sitemap functionality to allow the %4$s module to work.',
 				'wordpress-seo-news'
@@ -261,7 +261,7 @@ class WPSEO_News {
 	public function error_upgrade_wp() {
 		echo '<div class="error"><p>';
 		printf(
-			/* translators: %1$s resolves to News SEO */
+		/* translators: %1$s resolves to News SEO */
 			esc_html__(
 				'Please upgrade WordPress to the latest version to allow WordPress and the %1$s module to work properly.',
 				'wordpress-seo-news'
@@ -279,7 +279,7 @@ class WPSEO_News {
 	public function error_upgrade_wpseo() {
 		echo '<div class="error"><p>';
 		printf(
-			/* translators: %1$s resolves to Yoast SEO, %2$s resolves to News SEO */
+		/* translators: %1$s resolves to Yoast SEO, %2$s resolves to News SEO */
 			esc_html__(
 				'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.',
 				'wordpress-seo-news'
@@ -396,8 +396,7 @@ class WPSEO_News {
 	 * @return array The terms for the item.
 	 */
 	public static function get_terms_for_item( $post_id, $post_type ) {
-		$terms = array();
-
+		$terms                 = array();
 		$excludable_taxonomies = new WPSEO_News_Excludable_Taxonomies( $post_type );
 
 		foreach ( $excludable_taxonomies->get() as $taxonomy ) {

--- a/tests/doubles/schema-double.php
+++ b/tests/doubles/schema-double.php
@@ -18,6 +18,6 @@ class WPSEO_News_Schema_Double extends WPSEO_News_Schema {
 	 * @return WP_Post|null The post object or null if it cannot be found.
 	 */
 	public function get_post( $post = null ) {
-		return get_post( $post );
+		return parent::get_post( $post );
 	}
 }

--- a/tests/doubles/schema-double.php
+++ b/tests/doubles/schema-double.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Yoast SEO: News plugin test file.
+ *
+ * @package WPSEO_News\Tests
+ */
+
+/**
+ * Class WPSEO_News_Schema.
+ */
+class WPSEO_News_Schema_Double extends WPSEO_News_Schema {
+
+	/**
+	 * Retrieves post data given a post ID or post object.
+	 *
+	 * @param int|WP_Post|null $post Optional. Post ID or post object. Defaults to global $post.
+	 *
+	 * @return WP_Post|array|null Type corresponding to $output on success or null on failure.
+	 */
+	public function get_post( $post = null ) {
+		return get_post( $post );
+	}
+}

--- a/tests/doubles/schema-double.php
+++ b/tests/doubles/schema-double.php
@@ -13,9 +13,9 @@ class WPSEO_News_Schema_Double extends WPSEO_News_Schema {
 	/**
 	 * Retrieves post data given a post ID or post object.
 	 *
-	 * @param int|WP_Post|null $post Optional. Post ID or post object. Defaults to global $post.
+	 * @param int|WP_Post|null $post Optional. Post ID or post object.
 	 *
-	 * @return WP_Post|array|null Type corresponding to $output on success or null on failure.
+	 * @return WP_Post|null The post object or null if it cannot be found.
 	 */
 	public function get_post( $post = null ) {
 		return get_post( $post );

--- a/tests/schema-test.php
+++ b/tests/schema-test.php
@@ -51,7 +51,7 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	}
 
 	/**
-	 * Tests whether the admin page is generated correctly.
+	 * Tests whether the @type in the schema is correctly changed to NewsArticle.
 	 *
 	 * @covers WPSEO_News_Schema::change_article
 	 * @covers WPSEO_News::is_news_article_excluded
@@ -76,7 +76,7 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	}
 
 	/**
-	 * Tests whether the admin page is generated correctly with an excluded term.
+	 * Tests whether the schema output is generated correctly if one of the terms that is attached to a post is excluded from the news sitemap.
 	 *
 	 * @covers WPSEO_News_Schema::change_article
 	 * @covers WPSEO_News::is_news_article_excluded

--- a/tests/schema-test.php
+++ b/tests/schema-test.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Yoast SEO: News plugin test file.
+ *
+ * @package WPSEO_News\Tests
+ */
+
+/**
+ * Class WPSEO_News_Schema_Test.
+ */
+class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
+
+	/**
+	 * Holds the instance of the class being tested.
+	 *
+	 * @var WPSEO_News_Schema_Double
+	 */
+	private $default_mock;
+
+	/**
+	 * Holds the current date.
+	 *
+	 * @var DateTime
+	 */
+	private $date;
+
+	/**
+	 * Setting up the instance of WPSEO_News_Schema.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->date  = date_create();
+		$date_string = $this->date->format( DateTime::W3C );
+
+		$this->default_mock = $this
+			->getMockBuilder( 'WPSEO_News_Schema_Double' )
+			->setMethods( array( 'get_post' ) )
+			->getMock();
+
+		$this->default_mock
+			->method( 'get_post' )
+			->will( $this->returnValue( self::factory()->post->create_and_get(
+				array(
+					'post_title'    => 'Newest post',
+					'post_date'     => $date_string,
+					'post_date_gmt' => $date_string,
+					'post_type'     => 'post',
+				)
+			) ) );
+	}
+
+	/**
+	 * Tests whether the admin page is generated correctly.
+	 *
+	 * @covers WPSEO_News_Schema::change_article
+	 * @covers WPSEO_News::is_news_article_excluded
+	 * @covers WPSEO_News::exclude_item_terms
+	 * @covers WPSEO_News::get_terms_for_item
+	 */
+	public function test_change_article() {
+		$this->default_mock
+			->expects( $this->once() )
+			->method( 'get_post' );
+
+		$expected = array(
+			'@type'           => 'NewsArticle',
+			'copyrightYear'   => $this->date->format( 'Y' ),
+			'copyrightHolder' => array(
+				'@id' => 'http://example.org#organization',
+			),
+		);
+		$actual   = $this->default_mock->change_article( array() );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether the admin page is generated correctly with an excluded term.
+	 *
+	 * @covers WPSEO_News_Schema::change_article
+	 * @covers WPSEO_News::is_news_article_excluded
+	 * @covers WPSEO_News::exclude_item_terms
+	 * @covers WPSEO_News::get_terms_for_item
+	 */
+	public function test_change_article_with_an_excluded_term() {
+		$this->default_mock
+			->expects( $this->once() )
+			->method( 'get_post' );
+
+		// Add the term exclusion in the options.
+		add_filter( 'wpseo_news_options', array( $this, 'filter_options_exclude_uncategorized' ) );
+
+		/*
+		 * Note there is no `@type` expected here. This is because we do not __override__ it.
+		 * Yoast SEO is setting the default of `Article` in the output of the actual page.
+		 */
+		$expected = array(
+			'copyrightYear'   => $this->date->format( 'Y' ),
+			'copyrightHolder' => array(
+				'@id' => 'http://example.org#organization',
+			),
+		);
+		$actual   = $this->default_mock->change_article( array() );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Adds the options to exclude uncategorized posts. This is a filter function.
+	 *
+	 * @param array $options The options that get passed through the filter.
+	 *
+	 * @return array $options
+	 */
+	public function filter_options_exclude_uncategorized( $options ) {
+		$options[ 'term_exclude_category_uncategorized_for_post' ] = true;
+		return $options;
+	}
+}

--- a/tests/schema-test.php
+++ b/tests/schema-test.php
@@ -51,12 +51,54 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	}
 
 	/**
+	 * Tests whether the article post types includes `post` by default.
+	 *
+	 * @covers WPSEO_News_Schema::article_post_types
+	 * @covers WPSEO_News_Schema::is_post_excluded
+	 * @covers WPSEO_News::is_excluded_through_sitemap
+	 * @covers WPSEO_News::is_excluded_through_terms
+	 * @covers WPSEO_News::get_terms_for_post
+	 */
+	public function test_article_post_types() {
+		$this->default_mock
+			->expects( $this->once() )
+			->method( 'get_post' );
+
+		$actual = $this->default_mock->article_post_types( array() );
+
+		$this->assertEquals( array( 'post' ), $actual );
+	}
+
+	/**
+	 * Tests whether the article post types does not add when the post is excluded through a term.
+	 *
+	 * @covers WPSEO_News_Schema::article_post_types
+	 * @covers WPSEO_News_Schema::is_post_excluded
+	 * @covers WPSEO_News::is_excluded_through_sitemap
+	 * @covers WPSEO_News::is_excluded_through_terms
+	 * @covers WPSEO_News::get_terms_for_post
+	 */
+	public function test_article_post_types_with_excluded_term() {
+		$this->default_mock
+			->expects( $this->once() )
+			->method( 'get_post' );
+
+		// Add the term exclusion in the options.
+		add_filter( 'wpseo_news_options', array( $this, 'filter_options_exclude_uncategorized' ) );
+
+		$actual = $this->default_mock->article_post_types( array() );
+
+		$this->assertEquals( array(), $actual );
+	}
+
+	/**
 	 * Tests whether the @type in the schema is correctly changed to NewsArticle.
 	 *
 	 * @covers WPSEO_News_Schema::change_article
-	 * @covers WPSEO_News::is_news_article_excluded
-	 * @covers WPSEO_News::exclude_item_terms
-	 * @covers WPSEO_News::get_terms_for_item
+	 * @covers WPSEO_News_Schema::is_post_excluded
+	 * @covers WPSEO_News::is_excluded_through_sitemap
+	 * @covers WPSEO_News::is_excluded_through_terms
+	 * @covers WPSEO_News::get_terms_for_post
 	 */
 	public function test_change_article() {
 		$this->default_mock
@@ -79,9 +121,10 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	 * Tests whether the schema output is generated correctly if one of the terms that is attached to a post is excluded from the news sitemap.
 	 *
 	 * @covers WPSEO_News_Schema::change_article
-	 * @covers WPSEO_News::is_news_article_excluded
-	 * @covers WPSEO_News::exclude_item_terms
-	 * @covers WPSEO_News::get_terms_for_item
+	 * @covers WPSEO_News_Schema::is_post_excluded
+	 * @covers WPSEO_News::is_excluded_through_sitemap
+	 * @covers WPSEO_News::is_excluded_through_terms
+	 * @covers WPSEO_News::get_terms_for_post
 	 */
 	public function test_change_article_with_an_excluded_term() {
 		$this->default_mock


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the `@type` in the schema output would be `NewsArticle` instead of `Article` for articles which are excluded from the news sitemap.

## Relevant technical choices:

* Moved the term exclusion functions to keep the code DRY.
* Added a protected function around `get_post` to be able to mock it in the tests.

## Test instructions

This PR can be tested by following these steps:

* Go to the news settings and make sure you have a couple of post types turned on.
* Create a new post (or any/all of the activated above) and publish it.
* Go to the frontend of that post and check the schema output (tip: [GSDTT](https://search.google.com/structured-data/testing-tool)); it should have the `@type` of `NewsArticle`.
* Go to your news sitemap, the newly created post should be in there too.

### Exclude from news sitemap
1. Now turn on the `Exclude from News Sitemap` option in the `Addons` tab -> `Google News` and save the post.
1. Check the schema and sitemap again: it should have the `@type` `Article` and not be in the sitemap.
1. Turn the `Exclude from News Sitemap` back off.

### Exclude term
1. Add a category to the post.
1. Go to your news settings and exclude the category from the news sitemap.
1. Check the schema and sitemap again: it should have the `@type` `Article` and not be in the sitemap.
1. Repeat the steps with a tag instead of a category.

### Other posttypes
* Repeat all the steps with another post type.

Fixes https://github.com/Yoast/bugreports/issues/326
