### PR TITLE
QA: use gmdate() instead of date()

### DIFF
--- a/integration-tests/sitemap-item-test.php
+++ b/integration-tests/sitemap-item-test.php
@@ -24,8 +24,8 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$test_post_date_gmt = self::factory()->post->create_and_get(
 			array(
 				'post_title'    => 'Newest post',
-				'post_date'     => date( $timezone_format, $base_time ),
-				'post_date_gmt' => date( $timezone_format, $base_time ),
+				'post_date'     => gmdate( $timezone_format, $base_time ),
+				'post_date_gmt' => gmdate( $timezone_format, $base_time ),
 				'post_type'     => 'post',
 			)
 		);
@@ -33,7 +33,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$test_options = WPSEO_News::get_options();
 		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_post_date_gmt, $test_options );
 
-		$original_post_utc_time      = date( $timezone_format, $base_time );
+		$original_post_utc_time      = gmdate( $timezone_format, $base_time );
 		$get_publication_date_output = $instance->get_publication_date( $test_post_date_gmt );
 
 		// Check if post_date_gmt is the same as the output of get_publication_date().
@@ -54,7 +54,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$test_post_date = self::factory()->post->create_and_get(
 			array(
 				'post_title'    => 'Newest post',
-				'post_date'     => date( $timezone_format, $base_time ),
+				'post_date'     => gmdate( $timezone_format, $base_time ),
 				'post_type'     => 'post',
 			)
 		);
@@ -65,7 +65,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$test_options = WPSEO_News::get_options();
 		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_post_date, $test_options );
 
-		$original_post_date          = date( $timezone_format, $base_time );
+		$original_post_date          = gmdate( $timezone_format, $base_time );
 		$get_publication_date_output = $instance->get_publication_date( $test_post_date );
 
 		// Check if post_date is the same as the output of get_publication_date().

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -265,8 +265,8 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$this->factory->post->create(
 			array(
 				'post_title'    => 'Newest post',
-				'post_date'     => date( 'Y-m-d H:i:s', $base_time ),
-				'post_date_gmt' => date( 'Y-m-d H:i:s', $base_time ),
+				'post_date'     => gmdate( 'Y-m-d H:i:s', $base_time ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $base_time ),
 			)
 		);
 
@@ -275,8 +275,8 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$this->factory->post->create(
 			array(
 				'post_title'    => 'New-ish post',
-				'post_date'     => date( 'Y-m-d H:i:s', $two_days_ago ),
-				'post_date_gmt' => date( 'Y-m-d H:i:s', $two_days_ago ),
+				'post_date'     => gmdate( 'Y-m-d H:i:s', $two_days_ago ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $two_days_ago ),
 			)
 		);
 
@@ -285,8 +285,8 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$this->factory->post->create(
 			array(
 				'post_title'    => 'Too old Post',
-				'post_date'     => date( 'Y-m-d H:i:s', $two_days_ago_one_minute ),
-				'post_date_gmt' => date( 'Y-m-d H:i:s', $two_days_ago_one_minute ),
+				'post_date'     => gmdate( 'Y-m-d H:i:s', $two_days_ago_one_minute ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $two_days_ago_one_minute ),
 			)
 		);
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

> WordPress core sets PHP time zone to UTC during boot. However it cannot guarantee that timezone isn't changed by third party code, which is relatively common in the wild.
>
> date() calls rely on current PHP time zone. If time zone is changed from UTC it causes invalid results through the core and extensions code.

Refs:
* https://core.trac.wordpress.org/ticket/46438
* https://github.com/WordPress/WordPress-Coding-Standards/issues/1713

Note: WPCS 2.2.0 (not yet released) will contain a check for the use of `date()`.

## Test instructions

This PR can be tested by following these steps:

* _N/A_ These changes only affect unit test files, so as long as those still pass, we should be good.