### PR TITLE
Don't copy files we don't need in the zip

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -8,6 +8,13 @@ module.exports = {
 					// Folders to copy.
 					"vendor/**",
 					"!vendor/bin",
+					"!vendor/composer/installed.json",
+					"!vendor/xrstf/composer-php52/composer.json",
+					"!vendor/xrstf/composer-php52/README.md",
+					"!vendor/yoast/i18n-module/composer.json",
+					"!vendor/yoast/i18n-module/README.md",
+					"!vendor/yoast/i18n-module/LICENSE",
+					"!vendor/yoast/wp-helpscout/composer.json",
 					"languages/*.mo",
 					"classes/**",
 					// Files to copy.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Makes sure we don't copy files we don't need in the zip. 

## Relevant technical choices:

* When I compared the zip that was build before https://github.com/Yoast/Wiki/pull/90, and the one with https://github.com/Yoast/Wiki/pull/90, I noticed some differences. This PR removes the files that were never included in the zip, but would otherwise be included after https://github.com/Yoast/Wiki/pull/90.

## Test instructions

This PR can be tested by following these steps:

* See https://github.com/Yoast/Wiki/pull/90

