### PR TITLE
 PHPCompatibility fix: pass encoding to htmlspecialchars() et al functions

### DIFF
--- a/classes/sitemap-images.php
+++ b/classes/sitemap-images.php
@@ -175,15 +175,16 @@ class WPSEO_News_Sitemap_Images {
 		 */
 		$src = apply_filters( 'wpseo_xml_sitemap_img_src', $src, $this->item );
 
+		$encoding      = get_bloginfo( 'charset' );
 		$this->output .= "\t<image:image>\n";
-		$this->output .= "\t\t<image:loc>" . htmlspecialchars( $src ) . "</image:loc>\n";
+		$this->output .= "\t\t<image:loc>" . htmlspecialchars( $src, ENT_COMPAT, $encoding, false ) . "</image:loc>\n";
 
 		if ( ! empty( $img['title'] ) ) {
-			$this->output .= "\t\t<image:title>" . htmlspecialchars( $img['title'] ) . "</image:title>\n";
+			$this->output .= "\t\t<image:title>" . htmlspecialchars( $img['title'], ENT_COMPAT, $encoding, false ) . "</image:title>\n";
 		}
 
 		if ( ! empty( $img['alt'] ) ) {
-			$this->output .= "\t\t<image:caption>" . htmlspecialchars( $img['alt'] ) . "</image:caption>\n";
+			$this->output .= "\t\t<image:caption>" . htmlspecialchars( $img['alt'], ENT_COMPAT, $encoding, false ) . "</image:caption>\n";
 		}
 
 		$this->output .= "\t</image:image>\n";

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -143,7 +143,7 @@ class WPSEO_News_Sitemap_Item {
 
 		$this->output .= "\t\t<news:publication>\n";
 		$this->output .= "\t\t\t<news:name>" . $publication_name . '</news:name>' . "\n";
-		$this->output .= "\t\t\t<news:language>" . htmlspecialchars( $publication_lang ) . '</news:language>' . "\n";
+		$this->output .= "\t\t\t<news:language>" . htmlspecialchars( $publication_lang, ENT_COMPAT, get_bloginfo( 'charset' ), false ) . '</news:language>' . "\n";
 		$this->output .= "\t\t</news:publication>\n";
 	}
 

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -56,7 +56,7 @@ class WPSEO_News_Sitemap {
 
 		$str .= '<sitemap>' . "\n";
 		$str .= '<loc>' . self::get_sitemap_name() . '</loc>' . "\n";
-		$str .= '<lastmod>' . htmlspecialchars( $date->format( 'c' ) ) . '</lastmod>' . "\n";
+		$str .= '<lastmod>' . htmlspecialchars( $date->format( 'c' ), ENT_COMPAT, get_bloginfo( 'charset' ), false ) . '</lastmod>' . "\n";
 		$str .= '</sitemap>' . "\n";
 
 		return $str;

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -61,7 +61,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		);
 		$expected_output  = '<sitemap>' . "\n";
 		$expected_output .= '<loc>' . home_url( 'news-sitemap.xml' ) . '</loc>' . "\n";
-		$expected_output .= '<lastmod>' . htmlspecialchars( $output_date->format( 'c' ) ) . '</lastmod>' . "\n";
+		$expected_output .= '<lastmod>' . htmlspecialchars( $output_date->format( 'c' ), ENT_COMPAT, 'UTF-8', false ) . '</lastmod>' . "\n";
 		$expected_output .= '</sitemap>' . "\n";
 
 		$this->assertSame( $expected_output, $output );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

(well, unless anyone ever reported a bug about this, but chances of that are small as it would only really come into play when using UTF-8 characters in the images titles and captions in combination with PHP < 5.4)

## Relevant technical choices:

From the PHP 5.4 changelogs:
> The default character set for htmlspecialchars() and htmlentities() is now UTF-8, instead of ISO-8859-1.

While _most_ of the WP world uses the WP default `utf-8` character encoding, this can be changed, so to be on the safe side, one should always pass the encoding to functions affected by it.

Refs:
* https://www.php.net/manual/en/migration54.other.php
* https://www.php.net/manual/en/function.htmlentities.php#refsect1-function.htmlentities-changelog
* https://www.php.net/manual/en/function.htmlspecialchars.php#refsect1-function.htmlspecialchars-changelog


## Test instructions

This PR can be tested by following these steps:

**_Only for die-hard testers_**

On `trunk`:
* Make sure you have both PHP 5.2/5.3 and a higher PHP version installed.
* Make sure the WP install is on UTF-8.
* Add a news item with an image with a title and a caption using UTF-8 characters - think something in Russian or Chinese would be good.
* View the news image sitemap on both PHP versions.
    In PHP 5.2/5.3, the texts will be "weird", i.e. contain wrongly encoded characters. In the higher PHP version all should be fine.

Rinse & repeat with this branch and all should be good on both PHP versions.