### PR TITLE
Travis: minor clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,10 +87,6 @@ install:
     composer install --no-dev --no-interaction
   fi
 - |
-  if [[ "$PHPUNIT" == "1" || "$PHPUNIT_INTEGRATION" == "1" ]]; then
-    composer install --no-interaction
-  fi
-- |
   if [[ "$COVERAGE" == "1" ]]; then
     # Install phpcov so we can combine the coverage results of unit and integration tests.
     composer require phpunit/phpcov ^3.1


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Remove redundant, duplicate `composer install`.

The `script` will use the Travis provided PHPUnit version when compatible and use the Composer installed one when not.
See: https://github.com/Yoast/wpseo-news/blob/af1ebddf58a4f568e46e9258549fbcc1609cc7eb/.travis.yml#L176-L197

The preceding `composer install` already takes this into account.
See: https://github.com/Yoast/wpseo-news/blob/af1ebddf58a4f568e46e9258549fbcc1609cc7eb/.travis.yml#L82-L88

So, there is no need to run a second `composer install` based on the unit test ENV variables.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a build-script-only change and should have no effect on the functionality.
