### PR TITLE
CS/QA: improve output escaping

### DIFF
--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -192,14 +192,14 @@ class WPSEO_News_Admin_Page {
 		}
 
 		/* translators: %1%s expands to the post type name. */
-		echo '<h2>' . sprintf( esc_html__( 'Terms to exclude for %1$s', 'wordpress-seo-news' ), $post_type->labels->name ) . '</h2>';
+		echo '<h2>' . esc_html( sprintf( __( 'Terms to exclude for %1$s', 'wordpress-seo-news' ), $post_type->labels->name ) ) . '</h2>';
 
 		foreach ( $terms_per_taxonomy as $data ) {
 			$taxonomy = $data['taxonomy'];
 			$terms    = $data['terms'];
 
 			/* translators: %1%s expands to the taxonomy name name. */
-			echo '<h3>' . sprintf( esc_html__( '%1$s to exclude', 'wordpress-seo-news' ), $taxonomy->labels->name ) . '</h3>';
+			echo '<h3>' . esc_html( sprintf( __( '%1$s to exclude', 'wordpress-seo-news' ), $taxonomy->labels->name ) ) . '</h3>';
 
 			foreach ( $terms as $term ) {
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Post type and taxonomy labels should never contain HTML, so can safely be escaped with `esc_html()`.

To that end, move the `esc_html()` from inside the `sprintf()` to wrapping the `sprintf()`.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. Well, that is, unless someone would happen to add HTML to the post type/taxonomy labels, in that case, the display will now be different.