### PR TITLE
Travis: fix broken script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: xenial
-sudo: false
 
 services:
    - mysql
@@ -156,11 +155,12 @@ script:
     find -L . -path ./vendor -prune -o -path ./tests -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
     travis_time_finish && travis_fold end "PHP.check"
   fi
+- |
   if [[ "$PHPLINT" == "1" && ${TRAVIS_PHP_VERSION:0:3} > "5.5" ]]; then
-      travis_fold start "PHP.check" && travis_time_start
-      find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-      travis_time_finish && travis_fold end "PHP.check"
-    fi
+    travis_fold start "PHP.check" && travis_time_start
+    find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+    travis_time_finish && travis_fold end "PHP.check"
+  fi
 # PHP Code Style
 - |
   if [[ "$PHPCS" == "1" ]]; then
@@ -170,40 +170,50 @@ script:
   fi
 # PHP Integration Tests
 - |
-  if [[ "$PHPUNIT_INTEGRATION" == "1" ]]; then
+  if [[ "$PHPUNIT_INTEGRATION" == "1" && ${TRAVIS_PHP_VERSION:0:3} < "7.2" ]]; then
     travis_fold start "PHP.integration-tests" && travis_time_start
-    if [[ ${TRAVIS_PHP_VERSION:0:3} < "7.2" ]]; then
-        phpunit -c phpunit-integration.xml.dist
-    fi
-    if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
-        vendor/bin/phpunit -c phpunit-integration.xml.dist
-    fi
+    phpunit -c phpunit-integration.xml.dist
+    travis_time_finish && travis_fold end "PHP.integration-tests"
+  fi
+- |
+  if [[ "$PHPUNIT_INTEGRATION" == "1" && ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
+    travis_fold start "PHP.integration-tests" && travis_time_start
+    vendor/bin/phpunit -c phpunit-integration.xml.dist
     travis_time_finish && travis_fold end "PHP.integration-tests"
   fi
 # PHP Unit Tests
 - |
-  if [[ "$PHPUNIT" == "1" ]]; then
+  if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:3} < "7.2" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
-    if [[ ${TRAVIS_PHP_VERSION:0:3} < "7.2" ]]; then
-        phpunit -c phpunit.xml.dist
-    fi
-    if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
-        vendor/bin/phpunit -c phpunit.xml.dist
-    fi
+    phpunit -c phpunit.xml.dist
+    travis_time_finish && travis_fold end "PHP.tests"
+  fi
+- |
+  if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
+    travis_fold start "PHP.tests" && travis_time_start
+    vendor/bin/phpunit -c phpunit.xml.dist
     travis_time_finish && travis_fold end "PHP.tests"
   fi
 # PHP Coverage
 - |
   if [[ "$COVERAGE" == "1" ]]; then
-    travis_fold start "PHP.coverage" && travis_time_start
+    travis_fold start "PHP.coverage.part1" && travis_time_start
     vendor/bin/phpunit -c phpunit-integration.xml.dist --coverage-php /tmp/coverage/integration-tests.cov
+    travis_time_finish && travis_fold end "PHP.coverage.part1"
+  fi
+- |
+  if [[ "$COVERAGE" == "1" ]]; then
+    travis_fold start "PHP.coverage.part2" && travis_time_start
     vendor/bin/phpunit --coverage-php /tmp/coverage/tests.cov
-    ./vendor/bin/phpcov merge /tmp/coverage --clover build/logs/clover.xml
-    travis_time_finish && travis_fold end "PHP.coverage"
+    travis_time_finish && travis_fold end "PHP.coverage.part2"
   fi
 - if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi
 # Check for known security vulnerabilities in the currently locked-in dependencies.
 - if [[ "$SECURITY" == "1" ]]; then php $SECURITYCHECK_DIR/security-checker.phar -n security:check $(pwd)/composer.lock;fi
 
 after_script:
-  - if [[ "$COVERAGE" == "1" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+- |
+  if [[ "$COVERAGE" == "1" ]]; then
+    ./vendor/bin/phpcov merge /tmp/coverage --clover build/logs/clover.xml
+  fi
+- if [[ "$COVERAGE" == "1" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

The Travis builds have been failing for quite a long time, but due to the script being set up incorrectly, this has gone (nearly) unnoticed.

The main problems were:
* Incorrect indentation.
* Incorrect folding.
* Commands where the exit code should determine build pass/fail being nested.
    Travis does not handle nested conditions well.

The above has all been cleaned up and the build is now correctly failing on all builds which run unit tests.

In addition to this:
* Removing `sudo`.
    Travis has not supported `sudo` for quite a while.
* Moving the merging of the code coverage test output to the `after_script` section.

**IMPORTANT NOTE**:
**The build for this PR will not pass until all the failing unit tests have been fixed and this branch has been rebased after merging the unit test fixes.**

### Failures which were "hidden" until now

These are screenshots of the current failures as per the latest build against `trunk`.

https://travis-ci.org/Yoast/wpseo-news/jobs/604592951#L664-L697 / PHP 7.2 / COVERAGE=1

![image](https://user-images.githubusercontent.com/663378/67804546-6ac3e080-fa8f-11e9-9678-723c4deadbaa.png)

https://travis-ci.org/Yoast/wpseo-news/jobs/604592953#L330-L331 / PHP 5.2 / PHPUNIT_INTEGRATION=1

![image](https://user-images.githubusercontent.com/663378/67804701-caba8700-fa8f-11e9-8423-e9ef1994d3c5.png)

PRs to fix these failures are upcoming.

## Test instructions

This PR can be tested by following these steps:
* Check the **DETAILED** output of the Travis script, not just the pass/fail return value.

Fixes #402
