### PR TITLE
Schema: fix failing test

### DIFF
--- a/integration-tests/schema-test.php
+++ b/integration-tests/schema-test.php
@@ -113,7 +113,7 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 			'@type'           => 'NewsArticle',
 			'copyrightYear'   => $this->date->format( 'Y' ),
 			'copyrightHolder' => array(
-				'@id' => 'http://example.org#organization',
+				'@id' => 'http://example.org/#organization',
 			),
 		);
 		$actual   = $this->default_mock->change_article( array() );
@@ -146,7 +146,7 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 		$expected = array(
 			'copyrightYear'   => $this->date->format( 'Y' ),
 			'copyrightHolder' => array(
-				'@id' => 'http://example.org#organization',
+				'@id' => 'http://example.org/#organization',
 			),
 		);
 		$actual   = $this->default_mock->change_article( array() );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

This test has been failing for a while - since commit 460da5aa4903f831ca3ab0659708516ae48ba594 - and the failure was hidden by errors in the Travis script.

The change made in the above mentioned commit means that the URL for `copyrightHolder` will always have a trailing slash before the hash `#`.
The unit tests were not updated for this change, causing them to fail.

Related to and a prerequisite for #553



## Test instructions

This PR can be tested by following these steps:
* Run the integration tests locally against a high PHP version in combination with `trunk` and see them fail.
* Switch to this branch and see the unit tests passing.