### PR TITLE
Tests: mark two tests for skipping on low PHP versions

### DIFF
--- a/integration-tests/sitemap-item-test.php
+++ b/integration-tests/sitemap-item-test.php
@@ -46,6 +46,9 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
 	 * @covers WPSEO_News_Sitemap_Item::is_valid_datetime
 	 * @covers WPSEO_News_Sitemap_Item::format_date_with_timezone
+	 *
+	 * Prior to PHP 5.5.10, timezone offsets were not supported by `DateTimeZone` causing the test to fail.
+	 * @requires PHP 5.5.10
 	 */
 	public function test_get_publication_date_returning_correct_post_date_when_no_gmt_set() {
 		$base_time       = time();

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -41,6 +41,9 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * Verifies that the news sitemap is correctly added to the sitemap index when there are news items.
 	 *
 	 * @covers WPSEO_News_Sitemap::add_to_index
+	 *
+	 * Prior to PHP 5.5.10, timezone offsets were not supported by `DateTimeZone` causing the test to fail.
+	 * @requires PHP 5.5.10
 	 */
 	public function test_add_to_index() {
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

These two tests both use the `DateTimeZone` class combined with the output of the `WPSEO_News_Sitemap_Timezone::wp_get_timezone_string()` method.

This method _may_ return the timezone as an UTC-offset, but the PHP `DateTimeZone` class did not support timezone offsets as input until PHP 5.5.10.

As support for PHP < 5.6 is about to be dropped, for now, let's just skip these tests on low PHP versions.

Ref: https://www.php.net/manual/en/datetimezone.construct.php#refsect1-datetimezone.construct-changelog

Related to and a prerequisite for #553

## Test instructions

This PR can be tested by following these steps:
* Set your local environment to a PHP version < PHP 5.5.10.
* Switch WP to WP 5.1.
* Switch to a PHPUnit version which will run with that environment (PHPUnit 3.x or 4.x).
* Run the integration tests locally against `trunk` and see them fail.
The errors will look like this:
```
.............E......E................                                                                                                     
                                                                                                                                          
Time: 18.06 seconds, Memory: 58.25Mb                                                                                                      
                                                                                                                                          
There were 2 errors:                                                                                                                      
                                                                                                                                          
1) WPSEO_News_Sitemap_Item_Test::test_get_publication_date_returning_correct_post_date_when_no_gmt_set                                    
Exception: DateTimeZone::__construct() [http://php.net/manual/datetimezone.--construct]: Unknown or bad timezone (+0000)                  
                                                                                                                                          
path/to/wpseo-news/classes/sitemap-item.php:255
path/to/wpseo-news/classes/sitemap-item.php:238
path/to/wpseo-news/integration-tests/doubles/sitemap-item-double.php:17
path/to/wpseo-news/classes/sitemap-item.php:127
path/to/wpseo-news/classes/sitemap-item.php:101
path/to/wpseo-news/classes/sitemap-item.php:46
path/to/wpseo-news/integration-tests/sitemap-item-test.php:66
                                                                                                                                          
2) WPSEO_News_Sitemap_Test::test_add_to_index                                                                                             
Exception: DateTimeZone::__construct() [http://php.net/manual/datetimezone.--construct]: Unknown or bad timezone (+0000)                  
                                                                                                                                          
path/to/wpseo-news/integration-tests/sitemap-test.php:60
```
* Switch to this branch and see the problem tests being skipped.