### PR TITLE
Tests: fix path to WP native bootstrap

### DIFF
--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -40,7 +40,7 @@ if ( defined( 'WP_DEVELOP_DIR' ) ) {
 	}
 }
 elseif ( file_exists( '../../../../tests/phpunit/includes/bootstrap.php' ) ) {
-	require '../../../../integration-tests/phpunit/includes/bootstrap.php';
+	require '../../../../tests/phpunit/includes/bootstrap.php';
 }
 else {
 	echo PHP_EOL, 'ERROR: The WordPress native unit test bootstrap file could not be found. Please set the WP_DEVELOP_DIR environment variable either in your OS or in a custom phpunit.xml file.', PHP_EOL;


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Probably changed when a blanket search/replace was done for `/tests/`, but this is not the WPSEO News `tests` directory, but the WP Core ` tests` directory which is being referred to.

Related to and a prerequisite for #553

## Test instructions

This PR can be tested by following these steps:
* _N/A_
This should fix a small part of the build failures, but cannot easily be tested stand alone.