### PR TITLE
Tests: fix test double classes not being found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ install:
     # Install phpcov so we can combine the coverage results of unit and integration tests.
     composer require phpunit/phpcov ^3.1
   fi
+- composer dump-autoload
 - phpenv local --unset
 - if [[ "$SECURITY" == "1" ]]; then wget -P $SECURITYCHECK_DIR https://get.sensiolabs.org/security-checker.phar && chmod +x $SECURITYCHECK_DIR/security-checker.phar;fi
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Some of the build failures are due to the test double classes not being found when they are supposed to be auto-loaded.

```
Fatal error: Class 'WPSEO_News_Sitemap_Item_Double' not found in /tmp/wordpress/src/wp-content/plugins/wpseo-news/integration-tests/sitemap-item-test.php on line 34
```

The problem here is that the `composer.json` contains an `autoload` `classmap` directive as well as an `autoload-dev` `classmap`.

In the Travis script, the `composer install` command is run with `--no-dev` on PHP < 7.2.
That means that for those PHP versions, the classmap generated did not contain the test classes, leading to the above mentioned kind of failures.

So, while using the Travis standard PHPUnit version in combination with a `--no-dev` `composer install` will lead to faster builds, we do need to make sure the `dev` classmap is generated, so it includes the unit test related files for autoloading.

Running `composer dump-autoload` (without `--no-dev`) after the installs are done, will fix this.

Related to and a prerequisite for #553



## Test instructions

This PR can be tested by following these steps:
* Make sure you are set up with a local (non-composer) PHPUnit install, for instance using the PHPUnit `phar` file.
* Throw away the `vendor` directory.
* On `trunk`, run `composer install --no-dev`.
* Now run the integration tests using the PHPUnit `phar` and see them fail with fatal errors like the one above.
* Next run `composer dump-autoload`.
* Run the integration tests again and see them still fail, but no longer on throwing this fatal error.

(yes, there is still more wrong, more PRs upcoming)