### PR TITLE
Fix more failing tests

### DIFF
--- a/integration-tests/meta-box-test.php
+++ b/integration-tests/meta-box-test.php
@@ -29,9 +29,17 @@ class WPSEO_News_Meta_Box_Test extends WPSEO_News_UnitTestCase {
 			)
 			->getMock();
 
-		$stub->method( 'is_post_type_supported' )->willReturn( true );
-		$stub->method( 'get_meta_boxes' )->willReturn( array( 'metakey' => 'metabox' ) );
-		$stub->method( 'do_meta_box' )->willReturn( '[content]' );
+		$stub->expects( $this->any() )
+			->method( 'is_post_type_supported' )
+			->will( $this->returnValue( true ) );
+	
+		$stub->expects( $this->any() )
+			->method( 'get_meta_boxes' )
+			->will( $this->returnValue( array( 'metakey' => 'metabox' ) ) );
+	
+		$stub->expects( $this->any() )
+			->method( 'do_meta_box' )
+			->will( $this->returnValue( '[content]' ) );
 
 		$sections = $stub->add_metabox_section( array() );
 
@@ -53,7 +61,9 @@ class WPSEO_News_Meta_Box_Test extends WPSEO_News_UnitTestCase {
 			->setMethods( array( 'is_post_type_supported' ) )
 			->getMock();
 
-		$stub->method( 'is_post_type_supported' )->willReturn( false );
+		$stub->expects( $this->any() )
+			->method( 'is_post_type_supported' )
+			->will( $this->returnValue( false ) );
 
 		$sections = $stub->add_metabox_section( array() );
 

--- a/integration-tests/schema-test.php
+++ b/integration-tests/schema-test.php
@@ -39,6 +39,7 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 			->getMock();
 
 		$this->default_mock
+			->expects( $this->any() )
 			->method( 'get_post' )
 			->will(
 				$this->returnValue(


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

These tests have been failing for a while (if not forever) and the failure was hidden by errors in the Travis script.

```
Fatal error: Call to undefined method Mock_WPSEO_News_Meta_Box_Double_d7df196f::method() in /tmp/wordpress/src/wp-content/plugins/wpseo-news/integration-tests/meta-box-test.php on line 32
```

The short of it is that these tests are using more modern PHPUnit syntax, while the tests are also still being run on older PHPUnit versions where that syntax was not yet available.

Related to and a prerequisite for #553



## Test instructions

This PR can be tested by following these steps:
* Run the integration tests locally against `trunk` in combination with WP 5.1 on PHP 5.2 with PHPUnit 3.x and see them fail.
* Run them again against this branch and see a different error, but no longer the one mentioned above.