### PR TITLE
Stop explicit support for PHP < 5.6 / WP < 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,19 +26,15 @@ jobs:
   fast_finish: true
   include:
     - php: 7.3
-      env: WP_VERSION=master
+      env: WP_VERSION=master PHPUNIT=1
     - php: 7.2
-      env: WP_VERSION=latest WP_MULTISITE=1 PHPLINT=1 PHPCS=1 SECURITY=1 COVERAGE=1
-    - php: 5.2
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
-      dist: precise
-      env: WP_VERSION=5.0 WP_MULTISITE=1 PHPLINT=1 PHPUNIT_INTEGRATION=1
+      env: WP_VERSION=5.2 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 SECURITY=1 COVERAGE=1
     - php: 5.6
-      env: WP_VERSION=latest PHPUNIT=1
+      env: WP_VERSION=5.2 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
       dist: trusty
     - php: "7.4snapshot"
-      env: WP_VERSION=latest PHPUNIT=1
+      env: WP_VERSION=master PHPUNIT=1
     - stage: deploy-to-github-dist
       env: WP_VERSION=latest
       if: tag IS present
@@ -68,21 +64,19 @@ jobs:
   allow_failures:
     # Allow failures for unstable builds.
     - php: "7.4snapshot"
-      env: WP_VERSION=latest PHPUNIT=1
+      env: WP_VERSION=master PHPUNIT=1
     - php: 7.3
-      env: WP_VERSION=master
+      env: WP_VERSION=master PHPUNIT=1
 
 before_install:
 - if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
 - export SECURITYCHECK_DIR=/tmp/security-checker
 
 install:
-- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then phpenv local 5.6.13; fi
 - |
-  if [[ "$PHPCS" == "1" || ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
+  if [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" || "$COVERAGE" == "1" ]]; then
     composer install --no-interaction
-    composer config-yoastcs
-  else
+  elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "deploy-to-github-dist" ]]; then
     composer install --no-dev --no-interaction
   fi
 - |
@@ -90,8 +84,10 @@ install:
     # Install phpcov so we can combine the coverage results of unit and integration tests.
     composer require phpunit/phpcov ^3.1
   fi
-- composer dump-autoload
-- phpenv local --unset
+- |
+  if [[ "$PHPCS" == "1" ]]; then
+    composer config-yoastcs
+  fi
 - if [[ "$SECURITY" == "1" ]]; then wget -P $SECURITYCHECK_DIR https://get.sensiolabs.org/security-checker.phar && chmod +x $SECURITYCHECK_DIR/security-checker.phar;fi
 
 before_script:
@@ -117,28 +113,35 @@ before_script:
 
 # Clone WordPress
 #
-- git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
+- |
+  if [[ "$PHPUNIT" == "1" || "$COVERAGE" == "1" ]]; then
+    git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
+  fi
 
 # Clone WPSEO and its submodule
 #
-- git clone --depth=1 --branch="trunk" https://github.com/Yoast/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
-- cd /tmp/wordpress/src/wp-content/plugins/wordpress-seo
-- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then phpenv local 5.6.13; fi
-- composer install --no-dev --no-interaction --ignore-platform-reqs
-- phpenv local --unset
-- cd -
+- |
+  if [[ "$PHPUNIT" == "1" || "$COVERAGE" == "1" ]]; then
+    git clone --depth=1 --branch="trunk" https://github.com/Yoast/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
+    cd /tmp/wordpress/src/wp-content/plugins/wordpress-seo
+    composer install --no-dev --no-interaction --ignore-platform-reqs
+    cd -
+  fi
 
 # Copy news seo to test dir
-- cd ..
-- cp -r "$PLUGIN_SLUG" "$WP_DEVELOP_DIR/src/wp-content/plugins/$PLUGIN_SLUG"
-- cd /tmp/wordpress/
-- cp wp-tests-config-sample.php wp-tests-config.php
-- sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
-- sed -i "s/yourusernamehere/travis/" wp-tests-config.php
-- sed -i "s/yourpasswordhere//" wp-tests-config.php
-- mysql -e "CREATE DATABASE wordpress_tests;" -uroot
-- cd "$WP_DEVELOP_DIR/src/wp-content/plugins/$PLUGIN_SLUG"
-- phpenv rehash
+- |
+  if [[ "$PHPUNIT" == "1" || "$COVERAGE" == "1" ]]; then
+    cd ..
+    cp -r "$PLUGIN_SLUG" "$WP_DEVELOP_DIR/src/wp-content/plugins/$PLUGIN_SLUG"
+    cd /tmp/wordpress/
+    cp wp-tests-config-sample.php wp-tests-config.php
+    sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
+    sed -i "s/yourusernamehere/travis/" wp-tests-config.php
+    sed -i "s/yourpasswordhere//" wp-tests-config.php
+    mysql -e "CREATE DATABASE wordpress_tests;" -uroot
+    cd "$WP_DEVELOP_DIR/src/wp-content/plugins/$PLUGIN_SLUG"
+    phpenv rehash
+  fi
 
 script:
 # JavaScript checks
@@ -150,13 +153,7 @@ script:
   fi
 # PHP Linting
 - |
-  if [[ "$PHPLINT" == "1" && ${TRAVIS_PHP_VERSION:0:3} < "5.6" ]]; then
-    travis_fold start "PHP.check" && travis_time_start
-    find -L . -path ./vendor -prune -o -path ./tests -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-    travis_time_finish && travis_fold end "PHP.check"
-  fi
-- |
-  if [[ "$PHPLINT" == "1" && ${TRAVIS_PHP_VERSION:0:3} > "5.5" ]]; then
+  if [[ "$PHPLINT" == "1" ]]; then
     travis_fold start "PHP.check" && travis_time_start
     find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
     travis_time_finish && travis_fold end "PHP.check"
@@ -165,49 +162,37 @@ script:
 - |
   if [[ "$PHPCS" == "1" ]]; then
     travis_fold start "PHP.code-style" && travis_time_start
-    vendor/bin/phpcs -q --runtime-set ignore_warnings_on_exit 1
+    composer check-cs
     travis_time_finish && travis_fold end "PHP.code-style"
   fi
 # PHP Integration Tests
 - |
-  if [[ "$PHPUNIT_INTEGRATION" == "1" && ${TRAVIS_PHP_VERSION:0:3} < "7.2" ]]; then
+  if [[ "$PHPUNIT" == "1" ]]; then
     travis_fold start "PHP.integration-tests" && travis_time_start
-    phpunit -c phpunit-integration.xml.dist
-    travis_time_finish && travis_fold end "PHP.integration-tests"
-  fi
-- |
-  if [[ "$PHPUNIT_INTEGRATION" == "1" && ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
-    travis_fold start "PHP.integration-tests" && travis_time_start
-    vendor/bin/phpunit -c phpunit-integration.xml.dist
+    composer integration-test
     travis_time_finish && travis_fold end "PHP.integration-tests"
   fi
 # PHP Unit Tests
 - |
-  if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:3} < "7.2" ]]; then
+  if [[ "$PHPUNIT" == "1" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
-    phpunit -c phpunit.xml.dist
-    travis_time_finish && travis_fold end "PHP.tests"
-  fi
-- |
-  if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
-    travis_fold start "PHP.tests" && travis_time_start
-    vendor/bin/phpunit -c phpunit.xml.dist
+    composer test
     travis_time_finish && travis_fold end "PHP.tests"
   fi
 # PHP Coverage
 - |
   if [[ "$COVERAGE" == "1" ]]; then
     travis_fold start "PHP.coverage.part1" && travis_time_start
-    vendor/bin/phpunit -c phpunit-integration.xml.dist --coverage-php /tmp/coverage/integration-tests.cov
+    composer integration-test -- --coverage-php /tmp/coverage/integration-tests.cov
     travis_time_finish && travis_fold end "PHP.coverage.part1"
   fi
 - |
   if [[ "$COVERAGE" == "1" ]]; then
     travis_fold start "PHP.coverage.part2" && travis_time_start
-    vendor/bin/phpunit --coverage-php /tmp/coverage/tests.cov
+    composer test -- --coverage-php /tmp/coverage/tests.cov
     travis_time_finish && travis_fold end "PHP.coverage.part2"
   fi
-- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
 # Check for known security vulnerabilities in the currently locked-in dependencies.
 - if [[ "$SECURITY" == "1" ]]; then php $SECURITYCHECK_DIR/security-checker.phar -n security:check $(pwd)/composer.lock;fi
 

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,13 @@
         "source": "https://github.com/Yoast/wpseo-news"
     },
     "require": {
-        "php": ">=5.2",
-        "xrstf/composer-php52": "^1.0.20",
+        "php": ">=5.6",
         "yoast/wp-helpscout": "^1.0||^2.0",
         "yoast/i18n-module": "^3.1.1"
     },
     "require-dev": {
         "yoast/yoastcs": "^0.4.3",
-        "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0",
+        "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
         "brain/monkey": "^2.3"
     },
     "minimum-stability": "dev",
@@ -45,7 +44,7 @@
             "@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set default_standard Yoast"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs"
+            "@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --runtime-set ignore_warnings_on_exit 1"
         ],
         "fix-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/scripts/phpcbf"
@@ -55,15 +54,6 @@
         ],
         "integration-test": [
             "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
-        ],
-        "post-install-cmd": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
-        ],
-        "post-update-cmd": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
-        ],
-        "post-autoload-dump": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
         ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,39 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2da6b6e3457f3599f2f26545f075e8fe",
+    "content-hash": "97a7f90a76f14df3658f395e94fb63e3",
     "packages": [
-        {
-            "name": "xrstf/composer-php52",
-            "version": "v1.0.20",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer-php52/composer-php52.git",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer-php52/composer-php52/zipball/bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "shasum": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-default": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "xrstf\\Composer52": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "time": "2016-04-16T21:52:24+00:00"
-        },
         {
             "name": "yoast/i18n-module",
             "version": "3.1.1",
@@ -2221,7 +2190,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.2"
+        "php": ">=5.6"
     },
     "platform-dev": []
 }

--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -25,7 +25,7 @@ $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( 'wordpress-seo/wp-seo.php', 'wpseo-news/wpseo-news.php' ),
 );
 
-if ( file_exists( dirname( dirname( __FILE__ ) ) . '/vendor/autoload_52.php' ) === false ) {
+if ( file_exists( dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;
 	exit( 1 );
 }

--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -39,8 +39,8 @@ if ( ! defined( 'WPSEO_NEWS_FILE' ) ) {
 
 define( 'WPSEO_NEWS_VERSION', '12.2' );
 
-if ( file_exists( dirname( __FILE__ ) . '/vendor/autoload_52.php' ) ) {
-	require dirname( __FILE__ ) . '/vendor/autoload_52.php';
+if ( file_exists( dirname( __FILE__ ) . '/vendor/autoload.php' ) ) {
+	require dirname( __FILE__ ) . '/vendor/autoload.php';
 }
 
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

> ~~This PR requires PR #553 to be merged first~~
> ~~Once that PR has been merged, I will rebase this PR and change it from Draft to Mergable.~~


Brief analysis of the Travis script shows me that:
* There are a number of builds _which do not do anything_.
    All the tasks in `script` are set up conditionally based on environment variables.
    - Any build which did not have an environment variable, such as `PHPLINT`, `PHPCS` or `PHPUNIT` is basically completely useless, i.e the `PHP 7.3 WP_VERSION=master` build.
* There are three different environment variables related to toggles for running the unit tests:
    - `PHPUNIT` - to run the new BrainMonkey based tests.
    - `PHPUNIT_INTEGRATION` - to run the old integration tests.
    - `COVERAGE` - to run both and generate code coverage.
    While the basic setup for the BrainMonkey tests has been done, there are currently no such tests for the News plugin.
	So basically any build which only has the `PHPUNIT` environment variable for testing is - again - useless, i.e. the `PHP 5.6` and the  `PHP 7.4` builds.
* While the unit test related tasks are set up to run conditionally, the _preparation of the environment_ for running the integration tests, i.e. downloading WordPress, cloning YoastSEO Free, setting up the database _is all done **unconditionally**_.

So, with that in mind, I have made the following changes to the Travis script - please read this carefully:
* Removing builds against PHP < 5.6.
* Changing the `WP_VERSION` environment variables in the matrix to use a minimum of `5.2`.
    Note: this will change again once WP 5.3 comes out.
* Actually running the unit tests on all builds.
* Removing the `PHPUNIT_INTEGRATION` environment variable and setting up the `PHPUNIT` environment variable to run both the integration tests as well as the BrainMonkey tests.
* Removing the toggle for a full/no-dev composer install.
    As a composer install was being run on all builds anyway in one way or another **and** there is a committed `composer.lock` file **and** Travis caching of the downloads is set up, doing a full install each time will not make the build significantly slower.
    Also: It is better to always test based on the dependencies we've set up than to rely on a PHP image created by Travis which may fail unexpectedly (especially as Travis has seen some issues recently with incorrect PHPUnit versions on certain images).
    This also means the `composer dump-autoload` can be removed as it will now always have run whenever the autoload is needed.
    **Note**: this changes the `composer install` for the `deploy` stage from a full install to a `no-dev` install.
   That stage was currently being run against PHP 7.2, so was getting a full install, while AFAICS that shouldn't be needed.
* Adding conditions around the commands setting up the integration test environment.
    Downloading WP and YoastSEO is only needed when the unit tests are run.
* Using the composer scripts to run various tasks.
    As PHPUnit will now always be available in `vendor`, using the composer scripts simplifies things.

Includes:
* Removing the `xrstf/composer-php52` dependency and references to the `vendor/autoload_52.php` file.
* Dropping PHPUnit < 5.7 from the Composer `require-dev`.

Related to https://github.com/Yoast/wordpress-seo/issues/13758


## Test instructions

This PR can be tested by following these steps:
* Check the detailed output of the Travis scripts to verify that all is working as expected.

**_Please be extra critical reviewing this PR for any changes which may impact the `deploy` stage as those won't show up during the PR build._**