### PR TITLE
Remove the usage of the seo title

### DIFF
--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -159,28 +159,8 @@ class WPSEO_News_Sitemap_Item {
 		if ( $item === null ) {
 			return '';
 		}
-		// Get the SEO title.
-		$title = $this->get_frontend_title( $item );
 
-		if ( ! empty( $title ) ) {
-			return $title;
-		}
-
-		// Fallback to the post title.
 		return $item->post_title;
-	}
-
-	/**
-	 * Gets the SEO title of an item, used for static home and posts pages as well as singular titles.
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @param WP_Post $item Item to get the title for.
-	 *
-	 * @return string The formatted title.
-	 */
-	protected function get_frontend_title( $item ) {
-		return WPSEO_Frontend::get_instance()->get_content_title( $item );
 	}
 
 	/**

--- a/integration-tests/sitemap-item-test.php
+++ b/integration-tests/sitemap-item-test.php
@@ -155,16 +155,13 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 			'post_type'  => 'post',
 		);
 		$test_seo_title = self::factory()->post->create_and_get( $post_details );
-
 		$test_options = WPSEO_News::get_options();
-
-		WPSEO_Meta::set_value( 'title', 'SEO title of the post', $test_seo_title->ID );
 		$instance = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
 
 		$title_output = $instance->get_item_title( $test_seo_title );
 
 		// Check if correct post_title is returned.
-		$this->assertSame( 'SEO title of the post', $title_output );
+		$this->assertSame( 'Post with SEO title', $title_output );
 	}
 }
 

--- a/integration-tests/sitemap-item-test.php
+++ b/integration-tests/sitemap-item-test.php
@@ -120,31 +120,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$blogname     = get_bloginfo( 'name' );
 
 		// Check if correct post_title - blogname is returned.
-		$this->assertSame( 'Post without SEO title - ' . $blogname, $title_output );
-	}
-
-	/**
-	 * Checks if the post title output for the sitemap defaults to only the post title when no SEO title is present
-	 * and no SEO title defaults are set.
-	 *
-	 * @covers WPSEO_News_Sitemap_Item::get_item_title
-	 */
-	public function test_get_item_title_when_no_seo_title_set_and_no_default_is_set() {
-		$post_details   = array(
-			'post_title' => 'Post without SEO title and no default set',
-			'post_type'  => 'test_post_type',
-		);
-		$test_seo_title = self::factory()->post->create_and_get( $post_details );
-
-		$test_options = WPSEO_News::get_options();
-		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
-		$title_output = $instance->get_item_title( $test_seo_title );
-
-		// Set the default SEO title for this post type to empty, to force it to return just the post_title.
-		WPSEO_Options::set( 'title-' . $test_seo_title->post_type, '' );
-
-		// Check if correct post_title is returned.
-		$this->assertSame( 'Post without SEO title and no default set', $title_output );
+		$this->assertSame( 'Post without SEO title', $title_output );
 	}
 
 	/**

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -104,7 +104,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output .= "\t\t\t<news:language>en</news:language>\n";
 		$expected_output .= "\t\t</news:publication>\n";
 		$expected_output .= "\t\t<news:publication_date>" . get_the_date( DATE_ATOM, $post_id ) . "</news:publication_date>\n";
-		$expected_output .= "\t\t<news:title><![CDATA[generate rss - " . get_bloginfo( 'name' ) . "]]></news:title>\n";
+		$expected_output .= "\t\t<news:title><![CDATA[generate rss]]></news:title>\n";
 		$expected_output .= "\t</news:news>\n";
 		$expected_output .= '</url>';
 
@@ -296,10 +296,10 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$output = $this->instance->build_sitemap();
 
 		// Check if the $output contains the $expected_output.
-		$this->assertContains( "\t\t<news:title><![CDATA[Newest post - " . get_bloginfo( 'name' ) . "]]></news:title>\n", $output );
-		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post - " . get_bloginfo( 'name' ) . "]]></news:title>\n", $output );
+		$this->assertContains( "\t\t<news:title><![CDATA[Newest post]]></news:title>\n", $output );
+		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post]]></news:title>\n", $output );
 
-		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post - " . get_bloginfo( 'name' ) . "]]></news:title>\n", $output );
+		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post]]></news:title>\n", $output );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Use the post title instead of the SEO title, this is based on the specs for the news sitemap.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Add a new post
* Open the news sitemap and verify that the title is the post title and not the seo title.

Fixes #
