### PR TITLE
Travis: don't allow builds against PHP 7.4 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,15 @@ jobs:
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
     - php: 7.2
-      env: WP_VERSION=5.2 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 SECURITY=1 COVERAGE=1
+      env: WP_VERSION=5.3 WP_MULTISITE=1 PHPCS=1 SECURITY=1 COVERAGE=1
     - php: 5.6
       env: WP_VERSION=5.2 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
       dist: trusty
     - php: "7.4snapshot"
-      env: WP_VERSION=master PHPUNIT=1
+      env: WP_VERSION=5.3 PHPLINT=1 PHPUNIT=1
+    - php: "nightly"
+      env:  PHPLINT=1
     - stage: deploy-to-github-dist
       env: WP_VERSION=latest
       if: tag IS present
@@ -63,8 +65,7 @@ jobs:
           all_branches: true
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "7.4snapshot"
-      env: WP_VERSION=master PHPUNIT=1
+    - php: "nightly"
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Includes:
* Adjusting the Travis matrix now WP 5.3 has been released
* Removing the build against PHP 7.4 from `allowed failures`.
* Adding (back) a build against PHP `nightly` (PHP 8) and adding it to  `allowed_failures`.
    For now, this build will only lint the code. Unit testing is not yet possible with  the current setup.

## Test instructions

This PR can be tested by following these steps:
* Check the detailed output of the Travis script