### PR TITLE
Enable usage tracking

### DIFF
--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -70,6 +70,9 @@ class WPSEO_News {
 		add_filter( 'wpseo_submenu_pages', array( $this, 'add_submenu_pages' ) );
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_init', array( $this, 'init_helpscout_beacon' ) );
+
+		// Enable Yoast usage tracking.
+		add_filter( 'wpseo_enable_tracking', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Enable usage tracking.

This PR can be summarized in the following changelog entry:

*  None needed.

## Test instructions

This PR can be tested by following these steps:

* Site should send tracking info if this plugin is enabled icw Yoast SEO free.
