### PR TITLE
Use date helper

### DIFF
--- a/classes/schema.php
+++ b/classes/schema.php
@@ -60,7 +60,7 @@ class WPSEO_News_Schema {
 			if ( ! $this->is_post_excluded( $post ) ) {
 				$data['@type'] = 'NewsArticle';
 			}
-			
+	
 			$data['copyrightYear']   = $this->date->format( $post->post_date_gmt, 'Y' );
 			$data['copyrightHolder'] = array( '@id' => trailingslashit( WPSEO_Utils::get_home_url() ) . WPSEO_Schema_IDs::ORGANIZATION_HASH );
 		}

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -11,11 +11,20 @@
 class WPSEO_News_Schema {
 
 	/**
+	 * The date helper.
+	 *
+	 * @var Date_Helper
+	 */
+	protected $date;
+
+	/**
 	 * WPSEO_News_Schema Constructor.
 	 *
 	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
+		$this->date = new Date_Helper();
+
 		add_filter( 'wpseo_schema_article_post_types', array( $this, 'article_post_types' ) );
 		add_filter( 'wpseo_schema_article', array( $this, 'change_article' ) );
 	}
@@ -51,7 +60,8 @@ class WPSEO_News_Schema {
 			if ( ! $this->is_post_excluded( $post ) ) {
 				$data['@type'] = 'NewsArticle';
 			}
-			$data['copyrightYear']   = mysql2date( 'Y', $post->post_date_gmt, false );
+			
+			$data['copyrightYear']   = $this->date->format( $post->post_date_gmt, 'Y' );
 			$data['copyrightHolder'] = array( '@id' => trailingslashit( WPSEO_Utils::get_home_url() ) . WPSEO_Schema_IDs::ORGANIZATION_HASH );
 		}
 

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -60,7 +60,7 @@ class WPSEO_News_Schema {
 			if ( ! $this->is_post_excluded( $post ) ) {
 				$data['@type'] = 'NewsArticle';
 			}
-	
+
 			$data['copyrightYear']   = $this->date->format( $post->post_date_gmt, 'Y' );
 			$data['copyrightHolder'] = array( '@id' => trailingslashit( WPSEO_Utils::get_home_url() ) . WPSEO_Schema_IDs::ORGANIZATION_HASH );
 		}


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the time in the `copyrightYear` schema output could be incorrect.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

#### Schema Article
* Create a new post and view the source of the frontend.
* Search the schema output `NewsArticle` piece.
* Verify the `copyrightYear` still has the UTC / GMT time with `+00:00` included.

Fixes https://github.com/Yoast/wordpress-seo/issues/13906
