### PR TITLE
Implement date helper

### DIFF
--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -26,9 +26,6 @@ class WPSEO_News_Admin_Page {
 		if ( $this->is_news_page( filter_input( INPUT_GET, 'page' ) ) ) {
 			$this->register_i18n_promo_class();
 		}
-
-		// When the timezone is an empty string.
-		$this->add_timezone_notice();
 	}
 
 	/**
@@ -223,37 +220,5 @@ class WPSEO_News_Admin_Page {
 		$news_pages = array( 'wpseo_news' );
 
 		return in_array( $page, $news_pages, true );
-	}
-
-	/**
-	 * Shows a notice when the timezone is in UTC format.
-	 */
-	private function add_timezone_notice() {
-		if ( ! class_exists( 'Yoast_Notification_Center' ) ) {
-			return;
-		}
-
-		$notification_message = sprintf(
-			/* translators: %1$s resolves to the opening tag of the link to the general settings page, %1$s resolves to the closing tag for the link */
-			__( 'Your timezone settings should reflect your real timezone, not a UTC offset, please change this on the %1$sGeneral Settings page%2$s.', 'wordpress-seo-news' ),
-			'<a href="' . esc_url( admin_url( 'options-general.php' ) ) . '">',
-			'</a>'
-		);
-
-		$notification_options = array(
-			'type'         => Yoast_Notification::ERROR,
-			'id'           => 'wpseo-news_timezone_format_empty',
-		);
-
-		$timezone_notification = new Yoast_Notification( $notification_message, $notification_options );
-
-		$notification_center = Yoast_Notification_Center::get();
-
-		if ( get_option( 'timezone_string' ) === '' ) {
-			$notification_center->add_notification( $timezone_notification );
-		}
-		else {
-			$notification_center->remove_notification( $timezone_notification );
-		}
 	}
 }

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -221,73 +221,7 @@ class WPSEO_News_Sitemap_Item {
 			return $this->date->format( $item->post_date_gmt );
 		}
 
-		// Fallback: post_date.
-		if ( $this->date->is_valid_datetime( $item->post_date ) ) {
-			return $this->format_date_with_timezone( $item->post_date, new WPSEO_News_Sitemap_Timezone() );
-		}
-
 		return '';
-	}
-
-	/**
-	 * Format a date string with a timezone.
-	 *
-	 * @param string                             $item_date Date to parse.
-	 * @param string|WPSEO_News_Sitemap_Timezone $time_zone Timezone to parse.
-	 *
-	 * @return string The formatted date string.
-	 */
-	private function format_date_with_timezone( $item_date, $time_zone ) {
-
-		// Create a DateTime object date in the correct timezone.
-		$datetime = new DateTime( $item_date, new DateTimeZone( $time_zone ) );
-
-		return $datetime->format( $this->get_date_format() );
-	}
-
-	/**
-	 * Checks if a DateTimeZone string is usable, either as a known timezone or as a numeric entry.
-	 *
-	 * @param string $timezone_string DateTimeZone string to check.
-	 *
-	 * @return bool
-	 */
-	private function is_timezone_usable( $timezone_string ) {
-		if ( $timezone_string === '' ) {
-			return false;
-		}
-
-		if ( in_array( $timezone_string, DateTimeZone::listIdentifiers(), true ) ) {
-			return true;
-		}
-
-		// Checks if the string matches a valid numeric DateTimeZone, for example "+0200".
-		return ( preg_match( '/[+-][0-9]{4}/', $timezone_string ) === 1 );
-	}
-
-	/**
-	 * When the timezone string option in WordPress is empty, just return YYYY-MM-DD as format.
-	 *
-	 * @return string
-	 */
-	private function get_date_format() {
-		static $timezone_format;
-
-		if ( $timezone_format === null ) {
-			// Set a default.
-			$timezone_format = 'Y-m-d';
-
-			// Get the timezone string.
-			$timezone_option = new WPSEO_News_Sitemap_Timezone();
-			$timezone_string = $timezone_option->wp_get_timezone_string();
-
-			// Is there a usable timezone string and does it exist in the list of 'valid' timezones.
-			if ( $this->is_timezone_usable( $timezone_string ) ) {
-				$timezone_format = DateTime::W3C;
-			}
-		}
-
-		return $timezone_format;
 	}
 
 	/**

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -11,6 +11,13 @@
 class WPSEO_News_Sitemap_Item {
 
 	/**
+	 * The date helper.
+	 *
+	 * @var WPSEO_Date_Helper
+	 */
+	protected $date;
+
+	/**
 	 * The output which will be returned.
 	 *
 	 * @var string
@@ -40,6 +47,7 @@ class WPSEO_News_Sitemap_Item {
 	public function __construct( $item, $options ) {
 		$this->item    = $item;
 		$this->options = $options;
+		$this->date    = new WPSEO_Date_Helper();
 
 		// Check if item should be skipped.
 		if ( ! $this->skip_build_item() ) {
@@ -209,12 +217,12 @@ class WPSEO_News_Sitemap_Item {
 	 * @return string
 	 */
 	protected function get_publication_date( $item ) {
-		if ( $this->is_valid_datetime( $item->post_date_gmt ) ) {
-			return $this->format_date_with_timezone( $item->post_date_gmt, 'UTC' );
+		if ( $this->date->is_valid_datetime( $item->post_date_gmt ) ) {
+			return $this->date->format( $item->post_date_gmt );
 		}
 
 		// Fallback: post_date.
-		if ( $this->is_valid_datetime( $item->post_date ) ) {
+		if ( $this->date->is_valid_datetime( $item->post_date ) ) {
 			return $this->format_date_with_timezone( $item->post_date, new WPSEO_News_Sitemap_Timezone() );
 		}
 
@@ -301,20 +309,5 @@ class WPSEO_News_Sitemap_Item {
 	 */
 	private function get_item_images() {
 		$this->output .= new WPSEO_News_Sitemap_Images( $this->item, $this->options );
-	}
-
-	/**
-	 * Wrapper function to check if we have a valid datetime (Uses a new util in WPSEO).
-	 *
-	 * @param string $datetime Datetime to check.
-	 *
-	 * @return bool
-	 */
-	private function is_valid_datetime( $datetime ) {
-		if ( method_exists( 'WPSEO_Utils', 'is_valid_datetime' ) ) {
-			return WPSEO_Utils::is_valid_datetime( $datetime );
-		}
-
-		return true;
 	}
 }

--- a/classes/sitemap-timezone.php
+++ b/classes/sitemap-timezone.php
@@ -7,11 +7,16 @@
 
 /**
  * Convert the sitemap dates to the correct timezone.
+ *
+ * @deprecated 12.4
  */
 class WPSEO_News_Sitemap_Timezone {
 
 	/**
 	 * Returns the timezone string for a site, even if it's set to a UTC offset.
+	 *
+	 * @deprecated 12.4
+	 * @codeCoverageIgnore
 	 *
 	 * @return string
 	 */
@@ -24,11 +29,15 @@ class WPSEO_News_Sitemap_Timezone {
 	 *
 	 * Adapted from http://www.php.net/manual/en/function.timezone-name-from-abbr.php#89155
 	 *
+	 * @deprecated 12.4
+	 * @codeCoverageIgnore
+	 *
 	 * @since 7.0 Changed the visibility of the method from private to public.
 	 *
 	 * @return string Valid PHP timezone string.
 	 */
 	public function wp_get_timezone_string() {
+		_deprecated_function( __METHOD, 'WPSEO News 12.4' );
 
 		// If site timezone string exists, return it.
 		$timezone = get_option( 'timezone_string' );

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -11,6 +11,13 @@
 class WPSEO_News_Sitemap {
 
 	/**
+	 * The date helper.
+	 *
+	 * @var WPSEO_Date_Helper
+	 */
+	protected $date;
+
+	/**
 	 * Options.
 	 *
 	 * @var array
@@ -29,6 +36,7 @@ class WPSEO_News_Sitemap {
 	 */
 	public function __construct() {
 		$this->options = WPSEO_News::get_options();
+		$this->date    = new WPSEO_Date_Helper();
 
 		add_action( 'init', array( $this, 'init' ), 10 );
 
@@ -52,11 +60,9 @@ class WPSEO_News_Sitemap {
 			return $str;
 		}
 
-		$date = new DateTime( get_lastpostdate( 'gmt' ), new DateTimeZone( 'UTC' ) );
-
 		$str .= '<sitemap>' . "\n";
 		$str .= '<loc>' . self::get_sitemap_name() . '</loc>' . "\n";
-		$str .= '<lastmod>' . htmlspecialchars( $date->format( 'c' ), ENT_COMPAT, get_bloginfo( 'charset' ), false ) . '</lastmod>' . "\n";
+		$str .= '<lastmod>' . htmlspecialchars( $this->date->format( get_lastpostdate( 'gmt' ) ), ENT_COMPAT, get_bloginfo( 'charset' ), false ) . '</lastmod>' . "\n";
 		$str .= '</sitemap>' . "\n";
 
 		return $str;

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -172,7 +172,7 @@ class WPSEO_News_Sitemap {
 		// Make the browser cache this file properly.
 		header( 'Pragma: public' );
 		header( 'Cache-Control: maxage=' . YEAR_IN_SECONDS );
-		header( 'Expires: ' . $this->date->format_timestamp( time() +  YEAR_IN_SECONDS, 'D, d M Y H:i:s' ) . ' GMT' );
+		header( 'Expires: ' . $this->date->format_timestamp( (time() + YEAR_IN_SECONDS), 'D, d M Y H:i:s' ) . ' GMT' );
 
 		readfile( dirname( WPSEO_NEWS_FILE ) . '/assets/xml-news-sitemap.xsl' );
 		die();

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -172,7 +172,7 @@ class WPSEO_News_Sitemap {
 		// Make the browser cache this file properly.
 		header( 'Pragma: public' );
 		header( 'Cache-Control: maxage=' . YEAR_IN_SECONDS );
-		header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', ( time() + YEAR_IN_SECONDS ) ) . ' GMT' );
+		header( 'Expires: ' . $this->date->format_timestamp( time() +  YEAR_IN_SECONDS, 'D, d M Y H:i:s' ) . ' GMT' );
 
 		readfile( dirname( WPSEO_NEWS_FILE ) . '/assets/xml-news-sitemap.xsl' );
 		die();

--- a/classes/upgrade-manager.php
+++ b/classes/upgrade-manager.php
@@ -56,6 +56,11 @@ class WPSEO_News_Upgrade_Manager {
 		if ( version_compare( $current_version, '8.3', '<' ) ) {
 			$this->upgrade_83();
 		}
+
+		// Upgrade to version 12.4.
+		if ( version_compare( $current_version, '12.4-RC0', '<' ) ) {
+			$this->upgrade_124();
+		}
 	}
 
 	/**
@@ -135,6 +140,13 @@ class WPSEO_News_Upgrade_Manager {
 
 		// Update options.
 		update_option( 'wpseo_news', $options );
+	}
+
+	/**
+	 * Removes the timezone notice when set.
+	 */
+	private function upgrade_124() {
+		Yoast_Notification_Center::get()->remove_notification_by_id('wpseo-news_timezone_format_empty');
 	}
 
 	/**

--- a/classes/upgrade-manager.php
+++ b/classes/upgrade-manager.php
@@ -146,7 +146,7 @@ class WPSEO_News_Upgrade_Manager {
 	 * Removes the timezone notice when set.
 	 */
 	private function upgrade_124() {
-		Yoast_Notification_Center::get()->remove_notification_by_id('wpseo-news_timezone_format_empty');
+		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-news_timezone_format_empty' );
 	}
 
 	/**

--- a/classes/upgrade-manager.php
+++ b/classes/upgrade-manager.php
@@ -58,7 +58,7 @@ class WPSEO_News_Upgrade_Manager {
 		}
 
 		// Upgrade to version 12.4.
-		if ( version_compare( $current_version, '12.4-RC0', '<' ) ) {
+		if ( version_compare( $current_version, '12.4-RC0', '<=' ) ) {
 			$this->upgrade_124();
 		}
 	}

--- a/integration-tests/sitemap-item-test.php
+++ b/integration-tests/sitemap-item-test.php
@@ -14,7 +14,6 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * Checks if the time output for the sitemap is correct when there is a post_date_gmt set.
 	 *
 	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
-	 * @covers WPSEO_News_Sitemap_Item::is_valid_datetime
 	 * @covers WPSEO_News_Sitemap_Item::format_date_with_timezone
 	 */
 	public function test_get_publication_date_returning_correct_UTC_time() {
@@ -44,7 +43,6 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * Checks if the time output for the sitemap is correct when there is no post_date_gmt set.
 	 *
 	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
-	 * @covers WPSEO_News_Sitemap_Item::is_valid_datetime
 	 * @covers WPSEO_News_Sitemap_Item::format_date_with_timezone
 	 *
 	 * Prior to PHP 5.5.10, timezone offsets were not supported by `DateTimeZone` causing the test to fail.

--- a/integration-tests/sitemap-item-test.php
+++ b/integration-tests/sitemap-item-test.php
@@ -14,7 +14,6 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * Checks if the time output for the sitemap is correct when there is a post_date_gmt set.
 	 *
 	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
-	 * @covers WPSEO_News_Sitemap_Item::format_date_with_timezone
 	 */
 	public function test_get_publication_date_returning_correct_UTC_time() {
 		$base_time       = time();
@@ -43,7 +42,6 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * Checks if the time output for the sitemap is correct when there is no post_date_gmt set.
 	 *
 	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
-	 * @covers WPSEO_News_Sitemap_Item::format_date_with_timezone
 	 *
 	 * Prior to PHP 5.5.10, timezone offsets were not supported by `DateTimeZone` causing the test to fail.
 	 * @requires PHP 5.5.10
@@ -66,7 +64,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$test_options = WPSEO_News::get_options();
 		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_post_date, $test_options );
 
-		$original_post_date          = gmdate( $timezone_format, $base_time );
+		$original_post_date          = '';
 		$get_publication_date_output = $instance->get_publication_date( $test_post_date );
 
 		// Check if post_date is the same as the output of get_publication_date().

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -58,10 +58,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 
 		$output = $this->instance->add_to_index( '' );
 
-		$output_date      = new DateTime(
-			get_lastpostdate( 'gmt' ),
-			new DateTimeZone( new WPSEO_News_Sitemap_Timezone() )
-		);
+		$output_date      = new DateTime( get_lastpostdate( 'gmt' ) );
 		$expected_output  = '<sitemap>' . "\n";
 		$expected_output .= '<loc>' . home_url( 'news-sitemap.xml' ) . '</loc>' . "\n";
 		$expected_output .= '<lastmod>' . htmlspecialchars( $output_date->format( 'c' ), ENT_COMPAT, 'UTF-8', false ) . '</lastmod>' . "\n";


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Show dates in UTC+0 format everywhere.

## Relevant technical choices:

* Removal of the timezone notice, because we now always rely on the UTC+0 time.

## Test instructions

This PR can be tested by following these steps:

* Make sure no notice will be shown when setting timezone settings to a utc + somewhat value.
* Make sure the right date (UTC time +00:00) is shown in the sitemaps:
	* test with a location-based timezone
    * test with a +number timezone (e.g. +02:00)
* test the upgrade routine

Related: https://github.com/Yoast/wordpress-seo/issues/13906