### PR TITLE
Add missing multisite checks for the actions

### DIFF
--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -98,6 +98,11 @@ class WPSEO_News_Sitemap {
 			return;
 		}
 
+		// Bail if this is a multisite installation and the site has been switched.
+		if ( is_multisite() && ms_is_switched() ) {
+			return;
+		}
+
 		// Only invalidate when we are in a News Post Type object.
 		if ( ! in_array( get_post_type( $post_id ), WPSEO_News::get_included_post_types(), true ) ) {
 			return;


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the sitemap could be invalidated twice on multisite with MultilingualPress.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

These are kind of hard to test. The idea is that the code could get called twice when on multisite.
Therefore, some debugging is needed to verify this. [See this Wiki page to learn how](https://github.com/Yoast/Wiki/wiki/PHPStorm-debugging).

*Note: To acquire a copy of MultilingualPress, login to LastPass -> Shared-licenses vault. There's a login there for MultilingualPress so you can download the latest version.*

These are kind of hard to test. The idea is that the code could get called twice when on multisite.
Therefore, some debugging is needed to verify this. [See this Wiki page to learn how](https://github.com/Yoast/Wiki/wiki/PHPStorm-debugging).

*Note: To acquire a copy of MultilingualPress, login to LastPass -> Shared-licenses vault. There's a login there for MultilingualPress so you can download the latest version.*

Setup your multisite with MLP:
* Ensure you have a multisite environment with MultilingualPress and Yoast SEO installed.
* Configure at least two languages in MultilingualPress.

Test the `core` > `invalidate_sitemap`:
* Set a breakpoint in `classes/class-core.php` in the method `invalidate_sitemap` on lines 265 (the new `return`) and 268 (the first statement after the new `return`).
* Create a new post and ensure you set it to sync with the secondary language in the MLP metabox) and publish it. Please ignore the first debug call when you just clicked on create new post. This is the creation of the draft.
* You should see both debug lines executed now. The actual post (not the MLP match) is called twice (probably the revision).


Related https://github.com/Yoast/wordpress-seo/issues/13765
