### PR TITLE
Bugfix: use the magic constant

### DIFF
--- a/classes/sitemap-timezone.php
+++ b/classes/sitemap-timezone.php
@@ -37,7 +37,7 @@ class WPSEO_News_Sitemap_Timezone {
 	 * @return string Valid PHP timezone string.
 	 */
 	public function wp_get_timezone_string() {
-		_deprecated_function( __METHOD, 'WPSEO News 12.4' );
+		_deprecated_function( __METHOD__, 'WPSEO News 12.4' );
 
 		// If site timezone string exists, return it.
 		$timezone = get_option( 'timezone_string' );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

**Note**: while this is a bugfix, the bug has not been in a released version yet, so this is non-user-facing.

## Relevant technical choices:

The constant `__METHOD` does not exist. The magic PHP constant `__METHOD__` does.

Ref: https://www.php.net/manual/en/language.constants.predefined.php

Using a non-existent constant will cause PHP < 8 to thrown a warning + then treat the constant as a string.
In this case, that means that the deprecation warning would not list the method name of the deprecated method, but would say something like `__METHOD is deprecated since version ...`.


## Test instructions

This PR can be tested by following these steps:
* Make sure `WP_DEBUG` is on / PHP `error_reporting` is set to `-1`.
* Add a code snippet in a custom plugin/theme `functions.php` file to explicitly trigger the `WPSEO_News_Sitemap_Timezone::wp_get_timezone_string()` function.
* On `trunk` run the code snippet just added and see the incorrect deprecation notice being thrown.
* Switch to this branch and see the correct deprecation notice, listing the name of the deprecated message, being thrown.