### PR TITLE
QA: sanitize use of a superglobal

### DIFF
--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -29,7 +29,8 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 		add_action( 'add_meta_boxes', array( $this, 'add_tab_hooks' ) );
 
 		if ( $pagenow === 'post.php' || $pagenow === 'post-new.php'
-			|| ( isset( $_SERVER['REQUEST_URI'] ) && stristr( $_SERVER['REQUEST_URI'], '/news-sitemap.xml' ) )
+			|| ( isset( $_SERVER['REQUEST_URI'] )
+			&& stristr( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '/news-sitemap.xml' ) )
 		) {
 			add_filter( 'add_extra_wpseo_meta_fields', array( $this, 'add_meta_fields_to_wpseo_meta' ) );
 		}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* WP slashes all superglobals, so before actually using a index, it should be unslashed.
* Before doing a compare, sanitize the text string to clean it off null bytes and invalid UTF-8.


## Test instructions

This PR can be tested by following these steps:
* ... good question....