### PR TITLE
Integration with the WPSEO Options framework.

### DIFF
--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -11,18 +11,9 @@
 class WPSEO_News_Admin_Page {
 
 	/**
-	 * Options.
-	 *
-	 * @var array
-	 */
-	private $options = array();
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->options = WPSEO_News::get_options();
-
 		if ( $this->is_news_page( filter_input( INPUT_GET, 'page' ) ) ) {
 			$this->register_i18n_promo_class();
 		}

--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -24,7 +24,7 @@ class WPSEO_News_Admin_Page {
 	 */
 	public function display() {
 		// Admin header.
-		Yoast_Form::get_instance()->admin_header( true, 'wpseo_news', false, 'yoast_wpseo_news_options' );
+		Yoast_Form::get_instance()->admin_header( true, 'wpseo_news' );
 
 		// Introduction.
 		echo '<p>' . esc_html__( 'You will generally only need a News Sitemap when your website is included in Google News.', 'wordpress-seo-news' ) . '</p>';

--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -132,35 +132,7 @@ class WPSEO_News_Admin_Page {
 	private function get_excluded_post_type_taxonomies( $post_type ) {
 		$excludable_taxonomies = new WPSEO_News_Excludable_Taxonomies( $post_type->name );
 
-		$taxonomy_terms = array_map( array( $this, 'get_terms_for_taxonomy' ), $excludable_taxonomies->get() );
-
-		return array_filter( $taxonomy_terms );
-	}
-
-	/**
-	 * Gets a list of terms for the given taxonomy, and returns them along with the taxonomy in an array.
-	 *
-	 * @param WP_Taxonomy $taxonomy The taxonomy to get the terms for.
-	 *
-	 * @return array An array containing both the taxonomy and its terms.
-	 */
-	protected function get_terms_for_taxonomy( WP_Taxonomy $taxonomy ) {
-		$terms = get_terms(
-			array(
-				'taxonomy'   => $taxonomy->name,
-				'hide_empty' => false,
-				'show_ui'    => true,
-			)
-		);
-
-		if ( count( $terms ) === 0 ) {
-			return null;
-		}
-
-		return array(
-			'taxonomy' => $taxonomy,
-			'terms'    => $terms,
-		);
+		return $excludable_taxonomies->get_terms();
 	}
 
 	/**

--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -91,7 +91,8 @@ class WPSEO_News_Admin_Page {
 		echo '<h2>' . esc_html__( 'Post Types to include in News Sitemap', 'wordpress-seo-news' ) . '</h2>';
 		echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'Post Types to include:', 'wordpress-seo-news' ) . '</legend>';
 
-		foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $posttype ) {
+		$post_types = get_post_types( array( 'public' => true ), 'objects' );
+		foreach ( $post_types as $posttype ) {
 			Yoast_Form::get_instance()->checkbox( 'news_sitemap_include_post_type_' . $posttype->name, $posttype->labels->name . ' (<code>' . $posttype->name . '</code>)', false );
 		}
 

--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -51,11 +51,11 @@ class WPSEO_News_Admin_Page {
 		echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'News Sitemap settings', 'wordpress-seo-news' ) . '</legend>';
 
 		// Google News Publication Name.
-		Yoast_Form::get_instance()->textinput( 'name', __( 'Google News Publication Name', 'wordpress-seo-news' ) );
+		Yoast_Form::get_instance()->textinput( 'news_sitemap_name', __( 'Google News Publication Name', 'wordpress-seo-news' ) );
 
 		// Default Genre.
 		Yoast_Form::get_instance()->select(
-			'default_genre',
+			'news_sitemap_default_genre',
 			__( 'Default Genre', 'wordpress-seo-news' ),
 			WPSEO_News::list_genres()
 		);
@@ -101,7 +101,7 @@ class WPSEO_News_Admin_Page {
 		echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'Post Types to include:', 'wordpress-seo-news' ) . '</legend>';
 
 		foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $posttype ) {
-			Yoast_Form::get_instance()->checkbox( 'newssitemap_include_' . $posttype->name, $posttype->labels->name . ' (<code>' . $posttype->name . '</code>)', false );
+			Yoast_Form::get_instance()->checkbox( 'news_sitemap_include_post_type_' . $posttype->name, $posttype->labels->name . ' (<code>' . $posttype->name . '</code>)', false );
 		}
 
 		echo '</fieldset><br>';
@@ -127,9 +127,7 @@ class WPSEO_News_Admin_Page {
 	 * @return bool Whether or not the post type should be included in the sitemap.
 	 */
 	protected function filter_included_post_type( $post_type ) {
-		$option_key = 'newssitemap_include_' . $post_type->name;
-
-		return isset( $this->options[ $option_key ] ) && $this->options[ $option_key ] === 'on';
+		return WPSEO_Options::get( 'news_sitemap_include_post_type_' . $post_type->name ) === 'on';
 	}
 
 	/**
@@ -201,7 +199,7 @@ class WPSEO_News_Admin_Page {
 			foreach ( $terms as $term ) {
 
 				Yoast_Form::get_instance()->checkbox(
-					'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type->name,
+					'news_sitemap_exclude_term_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type->name,
 					$term->name,
 					false
 				);

--- a/classes/excludable-taxonomies.php
+++ b/classes/excludable-taxonomies.php
@@ -38,6 +38,18 @@ class WPSEO_News_Excludable_Taxonomies {
 	}
 
 	/**
+	 * Retrieves the terms that belong to the taxonomy.
+	 *
+	 * @return array
+	 */
+	public function get_terms() {
+		$taxonomies     = $this->get();
+		$taxonomy_terms = array_map( array( $this, 'get_terms_for_taxonomy' ), $taxonomies );
+
+		return array_filter( $taxonomy_terms );
+	}
+
+	/**
 	 * Filter to check whether a taxonomy is shown in the WordPress ui.
 	 *
 	 * @param WP_Taxonomy $taxonomy The taxonomy to filter.
@@ -46,5 +58,31 @@ class WPSEO_News_Excludable_Taxonomies {
 	 */
 	protected function filter_taxonomies( WP_Taxonomy $taxonomy ) {
 		return $taxonomy->show_ui === true;
+	}
+
+	/**
+	 * Gets a list of terms for the given taxonomy, and returns them along with the taxonomy in an array.
+	 *
+	 * @param WP_Taxonomy $taxonomy The taxonomy to get the terms for.
+	 *
+	 * @return array An array containing both the taxonomy and its terms.
+	 */
+	protected function get_terms_for_taxonomy( $taxonomy ) {
+		$terms = get_terms(
+			array(
+				'taxonomy'   => $taxonomy->name,
+				'hide_empty' => false,
+				'show_ui'    => true,
+			)
+		);
+
+		if ( count( $terms ) === 0 ) {
+			return null;
+		}
+
+		return array(
+			'taxonomy' => $taxonomy,
+			'terms'    => $terms,
+		);
 	}
 }

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -11,19 +11,10 @@
 class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 
 	/**
-	 * Options.
-	 *
-	 * @var array
-	 */
-	private $options;
-
-	/**
 	 * WPSEO_News_Meta_Box constructor.
 	 */
 	public function __construct() {
 		global $pagenow;
-
-		$this->options = WPSEO_News::get_options();
 
 		add_filter( 'wpseo_save_metaboxes', array( $this, 'save' ), 10, 1 );
 		add_action( 'add_meta_boxes', array( $this, 'add_tab_hooks' ) );

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -54,7 +54,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 			'newssitemap-genre'        => array(
 				'name'        => 'newssitemap-genre',
 				'type'        => 'multiselect',
-				'std'         => ( ( isset( $this->options['default_genre'] ) ) ? $this->options['default_genre'] : 'blog' ),
+				'std'         => WPSEO_Options::get( 'news_sitemap_default_genre', 'blog' ),
 				'title'       => __( 'Google News Genre', 'wordpress-seo-news' ),
 				'description' => __( 'Genre to show in Google News Sitemap.', 'wordpress-seo-news' ),
 				'options'     => WPSEO_News::list_genres(),

--- a/classes/option-news.php
+++ b/classes/option-news.php
@@ -110,7 +110,7 @@ class WPSEO_Option_News extends WPSEO_Option {
 
 		foreach ( $clean as $key => $value ) {
 			switch ( $key ) {
-				case 'news-version':
+				case 'news_version':
 					$clean[ $key ] = WPSEO_NEWS_VERSION;
 				break;
 				case 'news_sitemap_name':

--- a/classes/option-news.php
+++ b/classes/option-news.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Internals\Options
+ */
+
+/**
+ * Class representing the wpseo_news options.
+ */
+class WPSEO_Option_News extends WPSEO_Option {
+
+	/**
+	 * The option name.
+	 *
+	 * @var string
+	 */
+	protected $option_name = 'wpseo_news';
+
+	/**
+	 * The defaults.
+	 *
+	 * @var array
+	 */
+	protected $defaults = array(
+		'news_sitemap_name'          => '',
+		'news_sitemap_default_genre' => '',
+		'news_version'               => '0',
+	);
+
+	/**
+	 * Used for "caching" during pageload.
+	 *
+	 * @var array
+	 */
+	protected $enriched_defaults;
+
+	/**
+	 * Registers the option to the WPSEO Options framework.
+	 */
+	public static function register_option() {
+		WPSEO_Options::register_option( self::get_instance() );
+	}
+
+	/**
+	 * Get the singleton instance of this class.
+	 *
+	 * @return object
+	 */
+	public static function get_instance() {
+		if ( ! ( self::$instance instanceof self ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+	/**
+	 * Add dynamically created default options based on available post types and taxonomies.
+	 *
+	 * @return void
+	 */
+	public function enrich_defaults() {
+		$enriched_defaults = $this->enriched_defaults;
+		if ( $enriched_defaults !== null ) {
+			$this->defaults += $enriched_defaults;
+			return;
+		}
+
+		$enriched_defaults = [];
+
+		/*
+		 * Retrieve all the relevant post type and taxonomy arrays.
+		 *
+		 * WPSEO_Post_Type::get_accessible_post_types() should *not* be used here.
+		 * These are the defaults and can be prepared for any public post type.
+		 */
+		$post_types = get_post_types( [ 'public' => true ], 'objects' );
+
+		if ( $post_types ) {
+			foreach ( $post_types as $post_type ) {
+				$enriched_defaults[ 'news_sitemap_include_post_type_' . $post_type->name ] = '';
+
+				$excludable_taxonomies = new WPSEO_News_Excludable_Taxonomies( $post_type->name );
+
+				foreach ( $excludable_taxonomies->get_terms() as $data ) {
+					$terms = $data['terms'];
+
+					foreach ( $terms as $term ) {
+						$enriched_defaults[ 'news_sitemap_exclude_term_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type->name ] = '';
+					}
+				}
+			}
+		}
+
+		$this->enriched_defaults = $enriched_defaults;
+		$this->defaults         += $enriched_defaults;
+	}
+
+	/**
+	 * All concrete classes must contain a validate_option() method which validates all
+	 * values within the option.
+	 *
+	 * @param array $dirty New value for the option.
+	 * @param array $clean Clean value for the option, normally the defaults.
+	 * @param array $old   Old value of the option.
+	 *
+	 * @return $clean The cleaned an validated option.
+	 */
+	protected function validate_option( $dirty, $clean, $old ) {
+
+		foreach ( $clean as $key => $value ) {
+			switch ( $key ) {
+				case 'news-version':
+					$clean[ $key ] = WPSEO_NEWS_VERSION;
+				break;
+				case 'news_sitemap_name':
+					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
+						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $dirty[ $key ] );
+					}
+					break;
+				case 'news_sitemap_default_genre' :
+					if ( isset( $dirty[ $key ] ) && is_array( $dirty[ $key ] ) ) {
+						$clean[ $key ] = array_map( [ 'WPSEO_Utils', 'sanitize_text_field' ], $dirty[ $key ] );
+					}
+
+					if ( isset( $dirty[ $key ] ) &&  is_string( $dirty[ $key ] ) ) {
+						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $dirty[ $key ] );
+					}
+
+					break;
+
+				default :
+					if ( stripos( $key, 'news_sitemap_include_post_type_' ) === 0 || stripos( $key, 'news_sitemap_exclude_term_' ) === 0  ) {
+						if ( ! empty( $dirty[ $key ] ) ) {
+							$clean[ $key ] = 'on';
+						}
+						else {
+							unset ( $clean[ $key ] );
+						}
+					}
+
+					break;
+			}
+		}
+
+		return $clean;
+	}
+}

--- a/classes/option.php
+++ b/classes/option.php
@@ -8,7 +8,7 @@
 /**
  * Class representing the wpseo_news options.
  */
-class WPSEO_Option_News extends WPSEO_Option {
+class WPSEO_News_Option extends WPSEO_Option {
 
 	/**
 	 * The option name.
@@ -135,7 +135,7 @@ class WPSEO_Option_News extends WPSEO_Option {
 							$clean[ $key ] = 'on';
 						}
 						else {
-							unset ( $clean[ $key ] );
+							unset( $clean[ $key ] );
 						}
 					}
 

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -71,11 +71,13 @@ class WPSEO_News_Schema {
 	/**
 	 * Checks if the given post should be excluded or not.
 	 *
+	 * @codeCoverageIgnore It just wraps logic.
+	 *
 	 * @param WP_Post $post The post to check for.
 	 *
 	 * @return bool True if the post should be excluded.
 	 */
-	private function is_post_excluded( $post ) {
+	protected function is_post_excluded( $post ) {
 		return (
 			WPSEO_News::is_excluded_through_sitemap( $post->ID )
 			|| WPSEO_News::is_excluded_through_terms( $post->ID, $post->post_type )

--- a/classes/sitemap-images.php
+++ b/classes/sitemap-images.php
@@ -34,10 +34,11 @@ class WPSEO_News_Sitemap_Images {
 	/**
 	 * Setting properties and build the item.
 	 *
-	 * @param object $item News post object.
+	 * @param object $item    News post object.
+	 * @param null   $options Deprecated. The options.
 	 */
-	public function __construct( $item ) {
-		if ( func_get_arg( 1 ) ) {
+	public function __construct( $item, $options = null ) {
+		if ( $options !== null ) {
 			_deprecated_argument( __METHOD__, 'WPSEO News: 12.4', 'The options argument is deprecated' );
 		}
 

--- a/classes/sitemap-images.php
+++ b/classes/sitemap-images.php
@@ -25,13 +25,6 @@ class WPSEO_News_Sitemap_Images {
 	private $output = '';
 
 	/**
-	 * The options.
-	 *
-	 * @var array
-	 */
-	private $options;
-
-	/**
 	 * Storage for the images.
 	 *
 	 * @var array
@@ -41,12 +34,14 @@ class WPSEO_News_Sitemap_Images {
 	/**
 	 * Setting properties and build the item.
 	 *
-	 * @param object $item    News post object.
-	 * @param array  $options The options.
+	 * @param object $item News post object.
 	 */
-	public function __construct( $item, $options ) {
-		$this->item    = $item;
-		$this->options = $options;
+	public function __construct( $item ) {
+		if ( func_get_arg( 1 ) ) {
+			_deprecated_argument( __METHOD__, 'WPSEO News: 12.4', 'The options argument is deprecated' );
+		}
+
+		$this->item = $item;
 
 		$this->parse_item_images();
 	}
@@ -77,8 +72,7 @@ class WPSEO_News_Sitemap_Images {
 	 * Getting the images for the given $item.
 	 */
 	private function get_item_images() {
-		$restrict_sitemap_featured_img = isset( $this->options['restrict_sitemap_featured_img'] ) ? $this->options['restrict_sitemap_featured_img'] : false;
-		if ( ! $restrict_sitemap_featured_img && preg_match_all( '/<img [^>]+>/', $this->item->post_content, $matches ) ) {
+		if ( preg_match_all( '/<img [^>]+>/', $this->item->post_content, $matches ) ) {
 			$this->get_images_from_content( $matches );
 		}
 

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -242,6 +242,6 @@ class WPSEO_News_Sitemap_Item {
 	 * Getting the images for current item.
 	 */
 	private function get_item_images() {
-		$this->output .= new WPSEO_News_Sitemap_Images( $this->item, $this->options );
+		$this->output .= new WPSEO_News_Sitemap_Images( $this->item );
 	}
 }

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -35,9 +35,10 @@ class WPSEO_News_Sitemap_Item {
 	 * Setting properties and build the item.
 	 *
 	 * @param object $item    The post.
+	 * @param null   $options Deprecated. The options.
 	 */
-	public function __construct( $item ) {
-		if ( func_get_arg( 1 ) ) {
+	public function __construct( $item, $options = null ) {
+		if ( $options !== null ) {
 			_deprecated_argument( __METHOD__, 'WPSEO News: 12.4', 'The options argument is deprecated' );
 		}
 

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -32,22 +32,17 @@ class WPSEO_News_Sitemap_Item {
 	private $item;
 
 	/**
-	 * The options.
-	 *
-	 * @var array
-	 */
-	private $options;
-
-	/**
 	 * Setting properties and build the item.
 	 *
 	 * @param object $item    The post.
-	 * @param array  $options The options.
 	 */
-	public function __construct( $item, $options ) {
-		$this->item    = $item;
-		$this->options = $options;
-		$this->date    = new WPSEO_Date_Helper();
+	public function __construct( $item ) {
+		if ( func_get_arg( 1 ) ) {
+			_deprecated_argument( __METHOD__, 'WPSEO News: 12.4', 'The options argument is deprecated' );
+		}
+
+		$this->item = $item;
+		$this->date = new WPSEO_Date_Helper();
 
 		// Check if item should be skipped.
 		if ( ! $this->skip_build_item() ) {

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -146,7 +146,7 @@ class WPSEO_News_Sitemap_Item {
 	 * Builds the publication tag.
 	 */
 	private function build_publication_tag() {
-		$publication_name = ! empty( $this->options['name'] ) ? $this->options['name'] : get_bloginfo( 'name' );
+		$publication_name = WPSEO_Options::get( 'news_sitemap_name', get_bloginfo( 'name' ) );
 		$publication_lang = $this->get_publication_lang();
 
 		$this->output .= "\t\t<news:publication>\n";
@@ -182,8 +182,9 @@ class WPSEO_News_Sitemap_Item {
 			$genre = implode( ',', $genre );
 		}
 
-		if ( $genre === '' && isset( $this->options['default_genre'] ) && $this->options['default_genre'] !== '' ) {
-			$genre = is_array( $this->options['default_genre'] ) ? implode( ',', $this->options['default_genre'] ) : $this->options['default_genre'];
+		$default_genre = WPSEO_Options::get( 'news_sitemap_default_genre' );
+		if ( $genre === '' && $default_genre ) {
+			$genre = is_array( $default_genre ) ? implode( ',', $default_genre ) : $default_genre;
 		}
 
 		$genre = trim( preg_replace( '/^none,?/', '', $genre ) );

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -18,13 +18,6 @@ class WPSEO_News_Sitemap {
 	protected $date;
 
 	/**
-	 * Options.
-	 *
-	 * @var array
-	 */
-	private $options;
-
-	/**
 	 * The sitemap basename.
 	 *
 	 * @var string
@@ -35,8 +28,7 @@ class WPSEO_News_Sitemap {
 	 * Constructor. Set options, basename and add actions.
 	 */
 	public function __construct() {
-		$this->options = WPSEO_News::get_options();
-		$this->date    = new WPSEO_Date_Helper();
+		$this->date = new WPSEO_Date_Helper();
 
 		add_action( 'init', array( $this, 'init' ), 10 );
 
@@ -255,7 +247,7 @@ class WPSEO_News_Sitemap {
 	private function build_items( $items ) {
 		$output = '';
 		foreach ( $items as $item ) {
-			$output .= new WPSEO_News_Sitemap_Item( $item, $this->options );
+			$output .= new WPSEO_News_Sitemap_Item( $item );
 		}
 
 		return $output;

--- a/classes/upgrade-manager.php
+++ b/classes/upgrade-manager.php
@@ -170,7 +170,7 @@ class WPSEO_News_Upgrade_Manager {
 			unset( $options['default_genre'] );
 		}
 
-		foreach( $options as $option_name => $option_value ) {
+		foreach ( $options as $option_name => $option_value ) {
 			if ( strpos( $option_name, 'newssitemap_include_' ) === 0 ) {
 				$options[ str_replace( 'newssitemap_include_', 'news_sitemap_include_post_type_', $option_name ) ] = $option_value;
 

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -12,28 +12,6 @@ class WPSEO_News {
 	const VERSION = WPSEO_NEWS_VERSION;
 
 	/**
-	 * Get WPSEO News options.
-	 *
-	 * @return array
-	 */
-	public static function get_options() {
-		$defaults = array(
-			'name'          => '',
-			'default_genre' => array(),
-			'ep_image_src'  => '',
-			'version'       => '0',
-		);
-		$options  = wp_parse_args( get_option( 'wpseo_news', array() ), $defaults );
-
-		/**
-		 * Filter: 'wpseo_news_options' - Allow modifying of Yoast News SEO options.
-		 *
-		 * @api array $wpseo_news_options The Yoast News SEO options.
-		 */
-		return apply_filters( 'wpseo_news_options', $options );
-	}
-
-	/**
 	 * Initializes the plugin.
 	 */
 	public function __construct() {
@@ -344,8 +322,6 @@ class WPSEO_News {
 		static $post_types;
 
 		if ( $post_types === null ) {
-			$options = self::get_options();
-
 			// Get supported post types.
 			$post_types = array();
 			foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $post_type ) {
@@ -400,7 +376,6 @@ class WPSEO_News {
 	 * @return bool True if the post is excluded.
 	 */
 	public static function is_excluded_through_terms( $post_id, $post_type ) {
-		$options = self::get_options();
 		$terms   = self::get_terms_for_post( $post_id, $post_type );
 
 		foreach ( $terms as $term ) {

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -47,7 +47,7 @@ class WPSEO_News {
 		add_filter( 'plugin_action_links', array( $this, 'plugin_links' ), 10, 2 );
 		add_filter( 'wpseo_submenu_pages', array( $this, 'add_submenu_pages' ) );
 		add_action( 'admin_init', array( $this, 'init_helpscout_beacon' ) );
-		add_action( 'init', array( 'WPSEO_Option_News', 'register_option' ), 1 );
+		add_action( 'init', array( 'WPSEO_News_Option', 'register_option' ), 1 );
 
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -47,7 +47,7 @@ class WPSEO_News {
 		add_filter( 'plugin_action_links', array( $this, 'plugin_links' ), 10, 2 );
 		add_filter( 'wpseo_submenu_pages', array( $this, 'add_submenu_pages' ) );
 		add_action( 'admin_init', array( $this, 'init_helpscout_beacon' ) );
-		add_action( 'admin_init', array( 'WPSEO_Option_News', 'register_option' ), 1 );
+		add_action( 'init', array( 'WPSEO_Option_News', 'register_option' ), 1 );
 
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
@@ -358,9 +358,7 @@ class WPSEO_News {
 		$terms   = self::get_terms_for_post( $post_id, $post_type );
 
 		foreach ( $terms as $term ) {
-			$term_exclude_option = WPSEO_Options::get( 'news_sitemap_exclude_term_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type );
-
-			if ( isset( $options[ $term_exclude_option ] ) ) {
+			if ( WPSEO_Options::get( 'news_sitemap_exclude_term_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type ) === 'on' ) {
 				return true;
 			}
 		}

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -46,7 +46,6 @@ class WPSEO_News {
 	private function set_hooks() {
 		add_filter( 'plugin_action_links', array( $this, 'plugin_links' ), 10, 2 );
 		add_filter( 'wpseo_submenu_pages', array( $this, 'add_submenu_pages' ) );
-		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_init', array( $this, 'init_helpscout_beacon' ) );
 		add_action( 'admin_init', array( 'WPSEO_Option_News', 'register_option' ), 1 );
 
@@ -145,26 +144,6 @@ class WPSEO_News {
 		}
 
 		return $links;
-	}
-
-	/**
-	 * Register the premium settings.
-	 */
-	public function register_settings() {
-		register_setting( 'yoast_wpseo_news_options', 'wpseo_news', array( $this, 'sanitize_options' ) );
-	}
-
-	/**
-	 * Sanitize options.
-	 *
-	 * @param array $options The options to sanitize.
-	 *
-	 * @return mixed
-	 */
-	public function sanitize_options( $options ) {
-		$options['version'] = self::VERSION;
-
-		return $options;
 	}
 
 	/**

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -349,7 +349,7 @@ class WPSEO_News {
 			// Get supported post types.
 			$post_types = array();
 			foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $post_type ) {
-				if ( isset( $options[ 'newssitemap_include_' . $post_type->name ] ) && ( $options[ 'newssitemap_include_' . $post_type->name ] === 'on' ) ) {
+				if ( WPSEO_Options::get( 'news_sitemap_include_post_type_' . $post_type->name ) === 'on' ) {
 					$post_types[] = $post_type->name;
 				}
 			}
@@ -404,7 +404,7 @@ class WPSEO_News {
 		$terms   = self::get_terms_for_post( $post_id, $post_type );
 
 		foreach ( $terms as $term ) {
-			$term_exclude_option = 'term_exclude_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type;
+			$term_exclude_option = WPSEO_Options::get( 'news_sitemap_exclude_term_' . $term->taxonomy . '_' . $term->slug . '_for_' . $post_type );
 
 			if ( isset( $options[ $term_exclude_option ] ) ) {
 				return true;

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -70,6 +70,7 @@ class WPSEO_News {
 		add_filter( 'wpseo_submenu_pages', array( $this, 'add_submenu_pages' ) );
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_init', array( $this, 'init_helpscout_beacon' ) );
+		add_action( 'admin_init', array( 'WPSEO_Option_News', 'register_option' ), 1 );
 
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );

--- a/integration-tests/schema-test.php
+++ b/integration-tests/schema-test.php
@@ -35,7 +35,7 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 
 		$this->default_mock = $this
 			->getMockBuilder( 'WPSEO_News_Schema_Double' )
-			->setMethods( array( 'get_post' ) )
+			->setMethods( array( 'get_post', 'is_post_excluded' ) )
 			->getMock();
 
 		$this->default_mock
@@ -81,6 +81,11 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_post' );
 
+		$this->default_mock
+			->expects( $this->once() )
+			->method( 'is_post_excluded' )
+			->willReturn( $this->returnValue( true ) );
+
 		$actual = $this->default_mock->article_post_types( array() );
 
 		$this->assertEquals( array(), $actual );
@@ -120,6 +125,11 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 		$this->default_mock
 			->expects( $this->once() )
 			->method( 'get_post' );
+
+		$this->default_mock
+			->expects( $this->once() )
+			->method( 'is_post_excluded' )
+			->willReturn( $this->returnValue( true ) );
 
 		/*
 		 * Note there is no `@type` expected here. This is because we do not __override__ it.

--- a/integration-tests/schema-test.php
+++ b/integration-tests/schema-test.php
@@ -59,9 +59,6 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	 *
 	 * @covers WPSEO_News_Schema::article_post_types
 	 * @covers WPSEO_News_Schema::is_post_excluded
-	 * @covers WPSEO_News::is_excluded_through_sitemap
-	 * @covers WPSEO_News::is_excluded_through_terms
-	 * @covers WPSEO_News::get_terms_for_post
 	 */
 	public function test_article_post_types() {
 		$this->default_mock
@@ -78,17 +75,11 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	 *
 	 * @covers WPSEO_News_Schema::article_post_types
 	 * @covers WPSEO_News_Schema::is_post_excluded
-	 * @covers WPSEO_News::is_excluded_through_sitemap
-	 * @covers WPSEO_News::is_excluded_through_terms
-	 * @covers WPSEO_News::get_terms_for_post
 	 */
 	public function test_article_post_types_with_excluded_term() {
 		$this->default_mock
 			->expects( $this->once() )
 			->method( 'get_post' );
-
-		// Add the term exclusion in the options.
-		add_filter( 'wpseo_news_options', array( $this, 'filter_options_exclude_uncategorized' ) );
 
 		$actual = $this->default_mock->article_post_types( array() );
 
@@ -100,9 +91,6 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	 *
 	 * @covers WPSEO_News_Schema::change_article
 	 * @covers WPSEO_News_Schema::is_post_excluded
-	 * @covers WPSEO_News::is_excluded_through_sitemap
-	 * @covers WPSEO_News::is_excluded_through_terms
-	 * @covers WPSEO_News::get_terms_for_post
 	 */
 	public function test_change_article() {
 		$this->default_mock
@@ -127,17 +115,11 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	 *
 	 * @covers WPSEO_News_Schema::change_article
 	 * @covers WPSEO_News_Schema::is_post_excluded
-	 * @covers WPSEO_News::is_excluded_through_sitemap
-	 * @covers WPSEO_News::is_excluded_through_terms
-	 * @covers WPSEO_News::get_terms_for_post
 	 */
 	public function test_change_article_with_an_excluded_term() {
 		$this->default_mock
 			->expects( $this->once() )
 			->method( 'get_post' );
-
-		// Add the term exclusion in the options.
-		add_filter( 'wpseo_news_options', array( $this, 'filter_options_exclude_uncategorized' ) );
 
 		/*
 		 * Note there is no `@type` expected here. This is because we do not __override__ it.
@@ -152,17 +134,5 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 		$actual   = $this->default_mock->change_article( array() );
 
 		$this->assertEquals( $expected, $actual );
-	}
-
-	/**
-	 * Adds the options to exclude uncategorized posts. This is a filter function.
-	 *
-	 * @param array $options The options that get passed through the filter.
-	 *
-	 * @return array $options
-	 */
-	public function filter_options_exclude_uncategorized( $options ) {
-		$options['term_exclude_category_uncategorized_for_post'] = true;
-		return $options;
 	}
 }

--- a/integration-tests/sitemap-images-test.php
+++ b/integration-tests/sitemap-images-test.php
@@ -25,13 +25,12 @@ class WPSEO_News_Sitemap_Images_Test extends WPSEO_News_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		// Create a post and retrieve options so the new object can actually be created.
+		// Create a post, so the new object can actually be created.
 		// Neither is actually used for the current unit tests.
 		$post_id = $this->factory->post->create();
 		$post    = get_post( $post_id );
-		$options = WPSEO_News::get_options();
 
-		$this->instance = new WPSEO_News_Sitemap_Images( $post, $options );
+		$this->instance = new WPSEO_News_Sitemap_Images( $post );
 	}
 
 	/**

--- a/integration-tests/sitemap-item-test.php
+++ b/integration-tests/sitemap-item-test.php
@@ -28,8 +28,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 			)
 		);
 
-		$test_options = WPSEO_News::get_options();
-		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_post_date_gmt, $test_options );
+		$instance = new WPSEO_News_Sitemap_Item_Double( $test_post_date_gmt );
 
 		$original_post_utc_time      = gmdate( $timezone_format, $base_time );
 		$get_publication_date_output = $instance->get_publication_date( $test_post_date_gmt );
@@ -61,8 +60,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		// Manually set post_date_gmt to an invalid string, because at creation WP forces a valid string.
 		$test_post_date->post_date_gmt = 'This is an invalid string';
 
-		$test_options = WPSEO_News::get_options();
-		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_post_date, $test_options );
+		$instance = new WPSEO_News_Sitemap_Item_Double( $test_post_date );
 
 		$original_post_date          = '';
 		$get_publication_date_output = $instance->get_publication_date( $test_post_date );
@@ -88,8 +86,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$test_post_date_gmt->post_date     = -10;
 		$test_post_date_gmt->post_date_gmt = -10;
 
-		$test_options = WPSEO_News::get_options();
-		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_post_date_gmt, $test_options );
+		$instance = new WPSEO_News_Sitemap_Item_Double( $test_post_date_gmt );
 
 		$get_publication_date_output = $instance->get_publication_date( $test_post_date_gmt );
 
@@ -110,8 +107,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		);
 		$test_seo_title = self::factory()->post->create_and_get( $post_details );
 
-		$test_options = WPSEO_News::get_options();
-		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
+		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title );
 		$title_output = $instance->get_item_title( $test_seo_title );
 		$blogname     = get_bloginfo( 'name' );
 
@@ -131,8 +127,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		);
 		$test_seo_title = self::factory()->post->create_and_get( $post_details );
 
-		$test_options = WPSEO_News::get_options();
-		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
+		$instance = new WPSEO_News_Sitemap_Item_Double( $test_seo_title );
 
 		$title_output = $instance->get_item_title( null );
 
@@ -151,8 +146,7 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 			'post_type'  => 'post',
 		);
 		$test_seo_title = self::factory()->post->create_and_get( $post_details );
-		$test_options   = WPSEO_News::get_options();
-		$instance       = new WPSEO_News_Sitemap_Item_Double( $test_seo_title, $test_options );
+		$instance       = new WPSEO_News_Sitemap_Item_Double( $test_seo_title );
 
 		$title_output = $instance->get_item_title( $test_seo_title );
 

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -190,41 +190,6 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	}
 
 	/**
-	 * Checks what happens if there is one post added with a image in its content.
-	 *
-	 * @covers WPSEO_News_Sitemap::build_sitemap
-	 */
-	public function test_sitemap_WITH_featured_image_restricted() {
-
-		add_action( 'wpseo_news_options', array( $this, 'restrict_featured_image' ) );
-
-		$this->instance = new WPSEO_News_Sitemap();
-
-		$image        = home_url( 'tests/assets/yoast.png' );
-		$post_details = array(
-			'post_title'   => 'featured image',
-			'post_content' => '<img src="' . $image . '" />',
-		);
-		$post_id      = $this->factory->post->create( $post_details );
-
-		$featured_image = home_url( 'tests/assets/yoast_featured.png' );
-		$thumbnail_id   = $this->create_attachment( $featured_image, $post_id );
-
-		update_post_meta( $post_id, '_thumbnail_id', $thumbnail_id );
-
-		$output = $this->instance->build_sitemap();
-
-		$expected_output  = "\t</news:news>\n";
-		$expected_output .= "\t<image:image>\n";
-		$expected_output .= "\t\t<image:loc>" . $featured_image . "</image:loc>\n";
-		$expected_output .= "\t\t<image:title>attachment</image:title>\n";
-		$expected_output .= "\t</image:image>\n";
-
-		// Check if the $output contains the $expected_output.
-		$this->assertContains( $expected_output, $output );
-	}
-
-	/**
 	 * Checks that the sitemap uses the default name of news when no news post type is present.
 	 *
 	 * @covers WPSEO_News_Sitemap::news_sitemap_basename
@@ -297,19 +262,6 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post]]></news:title>\n", $output );
 
 		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post]]></news:title>\n", $output );
-	}
-
-	/**
-	 * Test helper. Filter the option return value.
-	 *
-	 * @param array $options Current value of the option.
-	 *
-	 * @return array Adjusted option value.
-	 */
-	public function restrict_featured_image( $options ) {
-		$options['restrict_sitemap_featured_img'] = true;
-
-		return $options;
 	}
 
 	/**

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -88,6 +88,8 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap::build_sitemap
 	 */
 	public function test_sitemap_NOT_empty() {
+		WPSEO_Options::set( 'news_sitemap_name', 'Test Blog' );
+
 		$post_id = $this->factory->post->create( array( 'post_title' => 'generate rss' ) );
 
 		$output = $this->instance->build_sitemap();


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Integratie with the WPSEO Options framework.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:
* Checkout `master` and make some settings on the News SEO page. Set a name, a default genre, include a post type, save it and then select some terms to exclude and save it again.
* Go to your database and copy in the table `wp_options` the option value for `wpseo_news`
* Checkout this `release/12.4` 
* Open the news settings and verify the settings are there. 
* Save the settings and see all fields are empty.
* To be sure set the copied option value in the database.
* Checkout this branch
* Go the the settings page for news. All fields should be filled.
* Save it and verify all fields keeps filled.
* Go to your news sitemap and verify this still works.
* Make a category for a post, create a post and attach the category you just made.
* Visit the news sitemap and see the post is in it.
* Now exclude this category in the news seo settings and it should be gone from the sitemap.
 
Fixes #548 
