### PR TITLE
Fix various CS errors and warnings

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -106,6 +106,7 @@
 	<rule ref="Yoast.Files.TestDoubles">
 		<properties>
 			<property name="doubles_path" type="array">
+				<element value="/tests/doubles"/>
 				<element value="/integration-tests/doubles"/>
 			</property>
 		</properties>
@@ -121,6 +122,7 @@
 
 	<!-- Allow for the double/mock classes to override methods just to change the visibility. -->
 	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">
+		<exclude-pattern>/tests/doubles/*-double\.php$</exclude-pattern>
 		<exclude-pattern>/integration-tests/doubles/*-double\.php$</exclude-pattern>
 	</rule>
 
@@ -132,9 +134,11 @@
 
 	<!-- For documentation of the double/mock classes, please refer to the _real_ classes. -->
 	<rule ref="Generic.Commenting.DocComment.MissingShort">
+		<exclude-pattern>/tests/doubles/*-double\.php$</exclude-pattern>
 		<exclude-pattern>/integration-tests/doubles/*-double\.php$</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
+		<exclude-pattern>/tests/doubles/*-double\.php$</exclude-pattern>
 		<exclude-pattern>/integration-tests/doubles/*-double\.php$</exclude-pattern>
 	</rule>
 

--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -91,7 +91,7 @@ class WPSEO_News_Admin_Page {
 		echo '<h2>' . esc_html__( 'Post Types to include in News Sitemap', 'wordpress-seo-news' ) . '</h2>';
 		echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'Post Types to include:', 'wordpress-seo-news' ) . '</legend>';
 
-		$post_types = get_post_types( array( 'public' => true ), 'objects' );
+		$post_types      = get_post_types( array( 'public' => true ), 'objects' );
 		$post_types_list = array();
 		foreach ( $post_types as $post_type ) {
 			$post_types_list[ $post_type->name ] = $post_type->labels->name . ' (' . $post_type->name . ')';

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -302,7 +302,7 @@ class WPSEO_News {
 
 		if ( $post_types === null ) {
 			// Get supported post types.
-			$post_types = array();
+			$post_types          = array();
 			$included_post_types = (array) WPSEO_Options::get( 'news_sitemap_include_post_types', array() );
 			foreach ( get_post_types( array( 'public' => true ), 'names' ) as $post_type ) {
 				if ( array_key_exists( $post_type, $included_post_types ) && $included_post_types[ $post_type ] === 'on' ) {
@@ -360,7 +360,7 @@ class WPSEO_News {
 		$excluded_terms = (array) WPSEO_Options::get( 'news_sitemap_exclude_terms', array() );
 		foreach ( $terms as $term ) {
 			$option_key = $term->taxonomy . '_' . $term->slug . '_for_' . $post_type;
-			if ( array_key_exists( $option_key, $excluded_terms ) && $excluded_terms[ $option_key ] === 'on'  ) {
+			if ( array_key_exists( $option_key, $excluded_terms ) && $excluded_terms[ $option_key ] === 'on' ) {
 				return true;
 			}
 		}

--- a/tests/doubles/option-double.php
+++ b/tests/doubles/option-double.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Test double.
- *
- * @package Yoast\WP\News\Tests\Doubles
- */
 
 namespace Yoast\WP\News\Tests\Doubles;
 

--- a/tests/news-test.php
+++ b/tests/news-test.php
@@ -5,6 +5,9 @@ namespace Yoast\WP\News\Tests;
 use WPSEO_News;
 use function Brain\Monkey\Functions\expect;
 
+/**
+ * Test the WPSEO_News class.
+ */
 class News_Test extends TestCase {
 
 	/**
@@ -15,7 +18,7 @@ class News_Test extends TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function test_get_included_post_types() {
-		$options = \Mockery::mock('overload:\WPSEO_Options' );
+		$options = \Mockery::mock( 'overload:\WPSEO_Options' );
 		$options
 			->shouldReceive( 'get' )
 			->with( 'news_sitemap_include_post_types', [] )
@@ -40,7 +43,7 @@ class News_Test extends TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function test_get_included_post_types_with_no_set_post_types() {
-		$options = \Mockery::mock('overload:\WPSEO_Options' );
+		$options = \Mockery::mock( 'overload:\WPSEO_Options' );
 		$options
 			->shouldReceive( 'get' )
 			->with( 'news_sitemap_include_post_types', [] )
@@ -66,12 +69,11 @@ class News_Test extends TestCase {
 		$excluded_terms = (array) WPSEO_Options::get( 'news_sitemap_exclude_terms', array() );
 		foreach ( $terms as $term ) {
 			$option_key = $term->taxonomy . '_' . $term->slug . '_for_' . $post_type;
-			if ( array_key_exists( $option_key, $excluded_terms ) && $excluded_terms[ $option_key ] === 'on'  ) {
+			if ( array_key_exists( $option_key, $excluded_terms ) && $excluded_terms[ $option_key ] === 'on' ) {
 				return true;
 			}
 		}
 
 		return false;
 	}
-
 }

--- a/tests/option-test.php
+++ b/tests/option-test.php
@@ -2,6 +2,9 @@
 
 namespace Yoast\WP\News\Tests;
 
+/**
+ * Test the News Option class.
+ */
 class Option_Test extends TestCase {
 
 	/**
@@ -17,9 +20,9 @@ class Option_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$externalMock = \Mockery::mock('overload:\WPSEO_Option' );
-		$externalMock->option_name = 'wpseo_news';
-		$externalMock->defaults    = [];
+		$external_mock              = \Mockery::mock( 'overload:\WPSEO_Option' );
+		$external_mock->option_name = 'wpseo_news';
+		$external_mock->defaults    = [];
 
 		$this->instance = new Doubles\Option_Double();
 	}
@@ -30,10 +33,12 @@ class Option_Test extends TestCase {
 	 * @param string $option_name The option name.
 	 * @param array  $clean       The clean data.
 	 * @param array  $dirty       The data to validate.
-	 * @param array  $expected    The expected value
+	 * @param array  $expected    The expected value.
 	 * @param string $message     Message to show when test fails.
 	 *
 	 * @dataProvider validate_option_provider
+	 *
+	 * @covers WPSEO_News_Option::validate_option
 	 */
 	public function test_validate_option( $option_name, $clean, $dirty, $expected, $message ) {
 		$clean    = [ $option_name => $clean ];
@@ -44,6 +49,11 @@ class Option_Test extends TestCase {
 		$this->assertEquals( $expected, $actual, $message );
 	}
 
+	/**
+	 * Data provider for test_validate_option.
+	 *
+	 * @return array The options.
+	 */
 	public function validate_option_provider() {
 		return [
 			[


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* The `trunk` build on Travis was failing. I've fixed all errors/warnings, except the following errors/warnings in `tests/doubles/option-double.php`:

```
FILE: tests/doubles/option-double.php
----------------------------------------------------------------------
FOUND 5 ERRORS AND 2 WARNINGS AFFECTING 4 LINES
----------------------------------------------------------------------
  8 | ERROR   | Double/Mock test helper classes should be placed in a
    |         | dedicated test doubles sub-directory. Found class:
    |         | Option_Double
    |         | (Yoast.Files.TestDoubles.WrongDirectory)
 13 | WARNING | Possible useless method overriding detected
    |         | (Generic.CodeAnalysis.UselessOverridingMethod.Found)
 17 | ERROR   | Missing short description in doc comment
    |         | (Generic.Commenting.DocComment.MissingShort)
 17 | ERROR   | Doc comment for parameter "$dirty" missing
    |         | (Squiz.Commenting.FunctionComment.MissingParamTag)
 17 | ERROR   | Doc comment for parameter "$clean" missing
    |         | (Squiz.Commenting.FunctionComment.MissingParamTag)
 17 | ERROR   | Doc comment for parameter "$old" missing
    |         | (Squiz.Commenting.FunctionComment.MissingParamTag)
 20 | WARNING | Possible useless method overriding detected
    |         | (Generic.CodeAnalysis.UselessOverridingMethod.Found)
----------------------------------------------------------------------

Time: 1.64 secs; Memory: 14MB
```

@jrfnl Can you please assist?
- Is the error on line 8 a config problem, or should the double be moved?
- The warnings on line 13 and 20 seem odd for a double.
- The errors on line 17 are about a function that has an `@inheritdoc`. An `@inheritdoc` for a double doesn't feel odd.

## Test instructions

This PR can be tested by following these steps:

*
