### PR TITLE
PHPCS: Update to YoastCS 2.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -34,12 +34,18 @@
 	-->
 
 	<rule ref="Yoast">
-		<!-- Set the custom test class whitelist for all sniffs which use it in one go.
-			 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
-		-->
 		<properties>
+			<!-- Set the custom test class whitelist for all sniffs which use it in one go.
+				 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
+			-->
 			<property name="custom_test_class_whitelist" type="array">
 				<element value="WPSEO_News_UnitTestCase"/>
+			</property>
+
+			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\News"/>
+				<element value="yoast_news"/>
 			</property>
 		</properties>
 
@@ -68,7 +74,7 @@
 			<!-- Don't trigger on the main file as renaming it would deactivate the plugin.
 				 Also leave the main WPSEO_News class and associated test files alone as
 				 after removing the prefix, there would be nothing left. -->
-			<property name="exclude" type="array">
+			<property name="excluded_files_strict_check" type="array">
 				<element value="wpseo-news.php"/>
 				<element value="classes/wpseo-news.php"/>
 				<element value="integration-tests/wpseo-news-test.php"/>
@@ -76,31 +82,12 @@
 			</property>
 
 			<!-- Remove the following prefixes from the names of object structures. -->
-			<property name="prefixes" type="array">
+			<property name="oo_prefixes" type="array">
 				<element value="wpseo_news"/>
 				<element value="yoast_wpseo_news"/>
 				<element value="yoast_news"/>
 			</property>
 		</properties>
-	</rule>
-
-	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
-		<properties>
-			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array">
-				<element value="wpseo_news"/>
-				<element value="yoast_wpseo_news"/>
-
-				<!-- These are the new prefixes which all code should comply with in the future. -->
-				<element value="yoast_news"/>
-				<element value="Yoast\WP\News"/>
-			</property>
-		</properties>
-
-		<!-- Valid usage: For testing purposes, some non-prefixed globals are being created. -->
-		<exclude-pattern>/tests/bootstrap\.php$</exclude-pattern>
-		<exclude-pattern>/integration-tests/bootstrap\.php$</exclude-pattern>
 	</rule>
 
 	<rule ref="Yoast.Files.TestDoubles">
@@ -142,6 +129,12 @@
 		<exclude-pattern>/integration-tests/doubles/*-double\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Valid usage: For testing purposes, some non-prefixed globals are being created. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>/tests/bootstrap\.php$</exclude-pattern>
+		<exclude-pattern>/integration-tests/bootstrap\.php$</exclude-pattern>
+	</rule>
+
 
 	<!--
 	#############################################################################
@@ -149,6 +142,18 @@
 	Adjustments which should be removed once the associated issue has been resolved.
 	#############################################################################
 	-->
+
+	<!-- Until all prefixes are fixed, some exceptions are allowed to the PrefixAllGlobals sniff. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<!-- Provide the prefixes to look for. -->
+			<property name="prefixes" type="array" extend="true">
+				<element value="wpseo_news"/>
+				<element value="yoast_wpseo_news"/>
+			</property>
+		</properties>
+	</rule>
+
 
 	<!-- Usage of non-cached direct database query. Should be reviewed.
 		 Ticket: https://github.com/Yoast/wpseo-news/issues/585 -->

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -48,9 +48,6 @@
 				<element value="yoast_news"/>
 			</property>
 		</properties>
-
-		<!-- Short arrays will be demanded as of YoastCS 2.0, so ignore for now. -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 	</rule>
 
 

--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -70,7 +70,7 @@ class WPSEO_News_Admin_Page {
 	 */
 	protected function register_i18n_promo_class() {
 		new Yoast_I18n_v3(
-			array(
+			[
 				'textdomain'     => 'wordpress_seo_news',
 				'project_slug'   => 'news-seo',
 				'plugin_name'    => 'WordPress SEO News',
@@ -79,7 +79,7 @@ class WPSEO_News_Admin_Page {
 				'glotpress_name' => 'Yoast Translate',
 				'glotpress_logo' => 'http://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',
 				'register_url'   => 'http://translate.yoast.com/gp/projects#utm_source=plugin&utm_medium=promo-box&utm_campaign=wpseo-news-i18n-promo',
-			)
+			]
 		);
 	}
 
@@ -91,8 +91,8 @@ class WPSEO_News_Admin_Page {
 		echo '<h2>' . esc_html__( 'Post Types to include in News Sitemap', 'wordpress-seo-news' ) . '</h2>';
 		echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'Post Types to include:', 'wordpress-seo-news' ) . '</legend>';
 
-		$post_types      = get_post_types( array( 'public' => true ), 'objects' );
-		$post_types_list = array();
+		$post_types      = get_post_types( [ 'public' => true ], 'objects' );
+		$post_types_list = [];
 		foreach ( $post_types as $post_type ) {
 			$post_types_list[ $post_type->name ] = $post_type->labels->name . ' (' . $post_type->name . ')';
 		}
@@ -108,10 +108,10 @@ class WPSEO_News_Admin_Page {
 	 * @return void
 	 */
 	private function excluded_post_type_taxonomies() {
-		$post_types = get_post_types( array( 'public' => true ), 'objects' );
-		$post_types = array_filter( $post_types, array( $this, 'filter_included_post_type' ) );
+		$post_types = get_post_types( [ 'public' => true ], 'objects' );
+		$post_types = array_filter( $post_types, [ $this, 'filter_included_post_type' ] );
 
-		array_walk( $post_types, array( $this, 'excluded_post_type_taxonomies_output' ) );
+		array_walk( $post_types, [ $this, 'excluded_post_type_taxonomies_output' ] );
 	}
 
 	/**
@@ -154,7 +154,7 @@ class WPSEO_News_Admin_Page {
 	private function excluded_post_type_taxonomies_output( $post_type ) {
 		$terms_per_taxonomy = $this->get_excluded_post_type_taxonomies( $post_type );
 
-		if ( $terms_per_taxonomy === array() ) {
+		if ( $terms_per_taxonomy === [] ) {
 			return;
 		}
 
@@ -168,7 +168,7 @@ class WPSEO_News_Admin_Page {
 			/* translators: %1%s expands to the taxonomy name name. */
 			echo '<h3>' . esc_html( sprintf( __( '%1$s to exclude', 'wordpress-seo-news' ), $taxonomy->labels->name ) ) . '</h3>';
 
-			$taxonomies_list = array();
+			$taxonomies_list = [];
 			foreach ( $terms as $term ) {
 				$taxonomies_list[ $term->taxonomy . '_' . $term->slug . '_for_' . $post_type->name ] = $term->name;
 			}
@@ -185,7 +185,7 @@ class WPSEO_News_Admin_Page {
 	 * @return bool True when currently on a new page.
 	 */
 	protected function is_news_page( $page ) {
-		$news_pages = array( 'wpseo_news' );
+		$news_pages = [ 'wpseo_news' ];
 
 		return in_array( $page, $news_pages, true );
 	}

--- a/classes/excludable-taxonomies.php
+++ b/classes/excludable-taxonomies.php
@@ -34,7 +34,7 @@ class WPSEO_News_Excludable_Taxonomies {
 	public function get() {
 		$taxonomies = get_object_taxonomies( $this->post_type, 'objects' );
 
-		return array_filter( $taxonomies, array( $this, 'filter_taxonomies' ) );
+		return array_filter( $taxonomies, [ $this, 'filter_taxonomies' ] );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class WPSEO_News_Excludable_Taxonomies {
 	 */
 	public function get_terms() {
 		$taxonomies     = $this->get();
-		$taxonomy_terms = array_map( array( $this, 'get_terms_for_taxonomy' ), $taxonomies );
+		$taxonomy_terms = array_map( [ $this, 'get_terms_for_taxonomy' ], $taxonomies );
 
 		return array_filter( $taxonomy_terms );
 	}
@@ -70,20 +70,20 @@ class WPSEO_News_Excludable_Taxonomies {
 	 */
 	protected function get_terms_for_taxonomy( $taxonomy ) {
 		$terms = get_terms(
-			array(
+			[
 				'taxonomy'   => $taxonomy->name,
 				'hide_empty' => false,
 				'show_ui'    => true,
-			)
+			]
 		);
 
 		if ( count( $terms ) === 0 ) {
 			return null;
 		}
 
-		return array(
+		return [
 			'taxonomy' => $taxonomy,
 			'terms'    => $terms,
-		);
+		];
 	}
 }

--- a/classes/head.php
+++ b/classes/head.php
@@ -60,11 +60,31 @@ class WPSEO_News_Head {
 		/**
 		 * Filter: 'wpseo_news_head_display_noindex' - Allow preventing of outputting noindex tag.
 		 *
+		 * @deprecated 12.5.0. Use the {@see 'Yoast\WP\News\head_display_noindex'} filter instead.
+		 *
 		 * @api string $meta_robots The noindex tag.
 		 *
 		 * @param object $post The post.
 		 */
-		if ( apply_filters( 'wpseo_news_head_display_noindex', true, $this->post ) ) {
+		$display_noindex = apply_filters_deprecated(
+			'wpseo_news_head_display_noindex',
+			array( true, $this->post ),
+			'YoastSEO News 12.5.0',
+			'Yoast\WP\News\head_display_noindex'
+		);
+
+		/**
+		 * Filter: 'Yoast\WP\News\head_display_noindex' - Allow preventing of outputting noindex tag.
+		 *
+		 * @since 12.5.0
+		 *
+		 * @api string $meta_robots The noindex tag.
+		 *
+		 * @param object $post The post.
+		 */
+		$display_noindex = apply_filters( 'Yoast\WP\News\head_display_noindex', $display_noindex, $this->post );
+
+		if ( $display_noindex === true ) {
 			$robots_index = WPSEO_Meta::get_value( 'newssitemap-robots-index', $this->post->ID );
 			if ( ! empty( $robots_index ) ) {
 				echo '<meta name="Googlebot-News" content="noindex" />' . "\n";

--- a/classes/head.php
+++ b/classes/head.php
@@ -21,7 +21,19 @@ class WPSEO_News_Head {
 	 * WPSEO_News_Head Constructor.
 	 */
 	public function __construct() {
-		do_action( 'wpseo_news_head' );
+		/**
+		 * Allow for running additional code before adding the News header tags.
+		 *
+		 * @deprecated 12.5.0 Use the {@see 'Yoast\WP\News\head'} action instead.
+		 */
+		do_action_deprecated( 'wpseo_news_head', array(), 'YoastSEO News 12.5.0', 'Yoast\WP\News\head' );
+
+		/**
+		 * Allow for running additional code before adding the News header tags.
+		 *
+		 * @since 12.5.0
+		 */
+		do_action( 'Yoast\WP\News\head' );
 
 		add_action( 'wpseo_head', array( $this, 'add_head_tags' ) );
 	}

--- a/classes/head.php
+++ b/classes/head.php
@@ -26,7 +26,7 @@ class WPSEO_News_Head {
 		 *
 		 * @deprecated 12.5.0 Use the {@see 'Yoast\WP\News\head'} action instead.
 		 */
-		do_action_deprecated( 'wpseo_news_head', array(), 'YoastSEO News 12.5.0', 'Yoast\WP\News\head' );
+		do_action_deprecated( 'wpseo_news_head', [], 'YoastSEO News 12.5.0', 'Yoast\WP\News\head' );
 
 		/**
 		 * Allow for running additional code before adding the News header tags.
@@ -35,7 +35,7 @@ class WPSEO_News_Head {
 		 */
 		do_action( 'Yoast\WP\News\head' );
 
-		add_action( 'wpseo_head', array( $this, 'add_head_tags' ) );
+		add_action( 'wpseo_head', [ $this, 'add_head_tags' ] );
 	}
 
 	/**
@@ -68,7 +68,7 @@ class WPSEO_News_Head {
 		 */
 		$display_noindex = apply_filters_deprecated(
 			'wpseo_news_head_display_noindex',
-			array( true, $this->post ),
+			[ true, $this->post ],
 			'YoastSEO News 12.5.0',
 			'Yoast\WP\News\head_display_noindex'
 		);

--- a/classes/javascript-strings.php
+++ b/classes/javascript-strings.php
@@ -21,10 +21,10 @@ class WPSEO_News_Javascript_Strings {
 	 * Fills the strings with values.
 	 */
 	private static function fill() {
-		self::$strings = array(
+		self::$strings = [
 			'ajaxurl'      => admin_url( 'admin-ajax.php' ),
 			'choose_image' => __( 'Choose image.', 'wordpress-seo-news' ),
-		);
+		];
 	}
 
 	/**

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -16,14 +16,14 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	public function __construct() {
 		global $pagenow;
 
-		add_filter( 'wpseo_save_metaboxes', array( $this, 'save' ), 10, 1 );
-		add_action( 'add_meta_boxes', array( $this, 'add_tab_hooks' ) );
+		add_filter( 'wpseo_save_metaboxes', [ $this, 'save' ], 10, 1 );
+		add_action( 'add_meta_boxes', [ $this, 'add_tab_hooks' ] );
 
 		if ( $pagenow === 'post.php' || $pagenow === 'post-new.php'
 			|| ( isset( $_SERVER['REQUEST_URI'] )
 			&& stristr( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '/news-sitemap.xml' ) )
 		) {
-			add_filter( 'add_extra_wpseo_meta_fields', array( $this, 'add_meta_fields_to_wpseo_meta' ) );
+			add_filter( 'add_extra_wpseo_meta_fields', [ $this, 'add_meta_fields_to_wpseo_meta' ] );
 		}
 	}
 
@@ -35,15 +35,15 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	 * @return array[] Multi-level array with information on each metabox to display.
 	 */
 	public function get_meta_boxes( $post_type = 'post' ) {
-		$mbs = array(
-			'newssitemap-exclude'      => array(
+		$mbs = [
+			'newssitemap-exclude'      => [
 				'name'  => 'newssitemap-exclude',
 				'type'  => 'checkbox',
 				'std'   => 'on',
 				'title' => __( 'News Sitemap', 'wordpress-seo-news' ),
 				'expl'  => __( 'Exclude from News Sitemap', 'wordpress-seo-news' ),
-			),
-			'newssitemap-genre'        => array(
+			],
+			'newssitemap-genre'        => [
 				'name'        => 'newssitemap-genre',
 				'type'        => 'multiselect',
 				'std'         => WPSEO_Options::get( 'news_sitemap_default_genre', 'blog' ),
@@ -51,26 +51,26 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 				'description' => __( 'Genre to show in Google News Sitemap.', 'wordpress-seo-news' ),
 				'options'     => WPSEO_News::list_genres(),
 				'serialized'  => true,
-			),
-			'newssitemap-stocktickers' => array(
+			],
+			'newssitemap-stocktickers' => [
 				'name'        => 'newssitemap-stocktickers',
 				'std'         => '',
 				'type'        => 'text',
 				'title'       => __( 'Stock Tickers', 'wordpress-seo-news' ),
 				'description' => __( 'A comma-separated list of up to 5 stock tickers of the companies, mutual funds, or other financial entities that are the main subject of the article. Each ticker must be prefixed by the name of its stock exchange, and must match its entry in Google Finance. For example, "NASDAQ:AMAT" (but not "NASD:AMAT"), or "BOM:500325" (but not "BOM:RIL").', 'wordpress-seo-news' ),
-			),
-			'newssitemap-robots-index' => array(
+			],
+			'newssitemap-robots-index' => [
 				'type'          => 'radio',
 				'default_value' => '0', // The default value will be 'index'; See the list of options.
 				'std'           => '',
-				'options'       => array(
+				'options'       => [
 					'0' => 'index',
 					'1' => 'noindex',
-				),
+				],
 				'title'         => __( 'Googlebot-News index', 'wordpress-seo-news' ),
 				'description'   => __( 'Using noindex allows you to prevent articles from appearing in Google News.', 'wordpress-seo-news' ),
-			),
-		);
+			],
+		];
 
 		return $mbs;
 	}
@@ -110,7 +110,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	 */
 	public function add_tab_hooks() {
 		if ( $this->is_post_type_supported() ) {
-			add_filter( 'yoast_free_additional_metabox_sections', array( $this, 'add_metabox_section' ) );
+			add_filter( 'yoast_free_additional_metabox_sections', [ $this, 'add_metabox_section' ] );
 		}
 	}
 
@@ -131,11 +131,11 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 			$content .= $this->do_meta_box( $meta_box, $meta_key );
 		}
 
-		$sections[] = array(
+		$sections[] = [
 			'name'         => 'news',
 			'link_content' => '<span class="dashicons dashicons-admin-plugins"></span>' . esc_html__( 'Google News', 'wordpress-seo-news' ),
 			'content'      => $content,
-		);
+		];
 
 		return $sections;
 	}

--- a/classes/option.php
+++ b/classes/option.php
@@ -22,13 +22,13 @@ class WPSEO_News_Option extends WPSEO_Option {
 	 *
 	 * @var array
 	 */
-	protected $defaults = array(
+	protected $defaults = [
 		'news_sitemap_name'               => '',
 		'news_sitemap_default_genre'      => '',
 		'news_version'                    => '0',
-		'news_sitemap_include_post_types' => array(),
-		'news_sitemap_exclude_terms'      => array(),
-	);
+		'news_sitemap_include_post_types' => [],
+		'news_sitemap_exclude_terms'      => [],
+	];
 
 	/**
 	 * Registers the option to the WPSEO Options framework.
@@ -85,9 +85,9 @@ class WPSEO_News_Option extends WPSEO_Option {
 
 				case 'news_sitemap_include_post_types':
 				case 'news_sitemap_exclude_terms':
-					$clean[ $key ] = array();
+					$clean[ $key ] = [];
 
-					if ( isset( $dirty[ $key ] ) && ( is_array( $dirty[ $key ] ) && $dirty[ $key ] !== array() ) ) {
+					if ( isset( $dirty[ $key ] ) && ( is_array( $dirty[ $key ] ) && $dirty[ $key ] !== [] ) ) {
 						foreach ( $dirty[ $key ] as $name => $posted_value ) {
 							if ( is_string( $name ) ) {
 								$clean[ $key ][ $name ] = 'on';

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -25,8 +25,8 @@ class WPSEO_News_Schema {
 	public function __construct() {
 		$this->date = new WPSEO_Date_Helper();
 
-		add_filter( 'wpseo_schema_article_post_types', array( $this, 'article_post_types' ) );
-		add_filter( 'wpseo_schema_article', array( $this, 'change_article' ) );
+		add_filter( 'wpseo_schema_article_post_types', [ $this, 'article_post_types' ] );
+		add_filter( 'wpseo_schema_article', [ $this, 'change_article' ] );
 	}
 
 	/**
@@ -62,7 +62,7 @@ class WPSEO_News_Schema {
 			}
 
 			$data['copyrightYear']   = $this->date->format( $post->post_date_gmt, 'Y' );
-			$data['copyrightHolder'] = array( '@id' => trailingslashit( WPSEO_Utils::get_home_url() ) . WPSEO_Schema_IDs::ORGANIZATION_HASH );
+			$data['copyrightHolder'] = [ '@id' => trailingslashit( WPSEO_Utils::get_home_url() ) . WPSEO_Schema_IDs::ORGANIZATION_HASH ];
 		}
 
 		return $data;

--- a/classes/sitemap-images.php
+++ b/classes/sitemap-images.php
@@ -140,13 +140,13 @@ class WPSEO_News_Sitemap_Images {
 	 * @return string[]
 	 */
 	private function parse_image( $img ) {
-		$image = array();
+		$image = [];
 		if ( preg_match( '/title=("|\')([^"\']+)("|\')/', $img, $match ) ) {
-			$image['title'] = str_replace( array( '-', '_' ), ' ', $match[2] );
+			$image['title'] = str_replace( [ '-', '_' ], ' ', $match[2] );
 		}
 
 		if ( preg_match( '/alt=("|\')([^"\']+)("|\')/', $img, $match ) ) {
-			$image['alt'] = str_replace( array( '-', '_' ), ' ', $match[2] );
+			$image['alt'] = str_replace( [ '-', '_' ], ' ', $match[2] );
 		}
 
 		return $image;
@@ -200,7 +200,7 @@ class WPSEO_News_Sitemap_Images {
 			return;
 		}
 
-		$image = array();
+		$image = [];
 
 		if ( ! empty( $attachment['title'] ) ) {
 			$image['title'] = $attachment['title'];
@@ -231,15 +231,15 @@ class WPSEO_News_Sitemap_Images {
 
 		// Check if we've found an attachment.
 		if ( is_null( $attachment ) ) {
-			return array();
+			return [];
 		}
 
 		// Return properties.
-		return array(
+		return [
 			'title'       => $attachment->post_title,
 			'alt'         => get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ),
 			'href'        => wp_get_attachment_url( $attachment->ID ),
 			'src'         => $attachment->guid,
-		);
+		];
 	}
 }

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -30,9 +30,9 @@ class WPSEO_News_Sitemap {
 	public function __construct() {
 		$this->date = new WPSEO_Date_Helper();
 
-		add_action( 'init', array( $this, 'init' ), 10 );
+		add_action( 'init', [ $this, 'init' ], 10 );
 
-		add_action( 'save_post', array( $this, 'invalidate_sitemap' ) );
+		add_action( 'save_post', [ $this, 'invalidate_sitemap' ] );
 
 		add_action( 'wpseo_news_schedule_sitemap_clear', 'yoast_wpseo_news_clear_sitemap_cache' );
 	}
@@ -68,19 +68,19 @@ class WPSEO_News_Sitemap {
 		$this->basename = self::get_sitemap_name( false );
 
 		// Setting stylesheet for cached sitemap.
-		add_action( 'wpseo_sitemap_stylesheet_cache_' . $this->basename, array( $this, 'set_stylesheet_cache' ) );
+		add_action( 'wpseo_sitemap_stylesheet_cache_' . $this->basename, [ $this, 'set_stylesheet_cache' ] );
 
 		if ( isset( $GLOBALS['wpseo_sitemaps'] ) ) {
-			add_filter( 'wpseo_sitemap_index', array( $this, 'add_to_index' ) );
+			add_filter( 'wpseo_sitemap_index', [ $this, 'add_to_index' ] );
 
 			$this->yoast_wpseo_news_schedule_clear();
 
 			// We might consider deprecating/removing this, because we are using a static xsl file.
-			$GLOBALS['wpseo_sitemaps']->register_sitemap( $this->basename, array( $this, 'build' ) );
+			$GLOBALS['wpseo_sitemaps']->register_sitemap( $this->basename, [ $this, 'build' ] );
 			if ( method_exists( $GLOBALS['wpseo_sitemaps'], 'register_xsl' ) ) {
 				$xsl_rewrite_rule = sprintf( '^%s-sitemap.xsl$', $this->basename );
 
-				$GLOBALS['wpseo_sitemaps']->register_xsl( $this->basename, array( $this, 'build_news_sitemap_xsl' ), $xsl_rewrite_rule );
+				$GLOBALS['wpseo_sitemaps']->register_xsl( $this->basename, [ $this, 'build_news_sitemap_xsl' ], $xsl_rewrite_rule );
 			}
 		}
 	}
@@ -218,7 +218,7 @@ class WPSEO_News_Sitemap {
 		$post_types = WPSEO_News::get_included_post_types();
 
 		if ( empty( $post_types ) ) {
-			return array();
+			return [];
 		}
 
 		$replacements   = $post_types;
@@ -275,7 +275,7 @@ class WPSEO_News_Sitemap {
 		 */
 		$sitemap_name = apply_filters_deprecated(
 			'wpseo_news_sitemap_name',
-			array( self::news_sitemap_basename() ),
+			[ self::news_sitemap_basename() ],
 			'YoastSEO News 12.5.0',
 			'Yoast\WP\News\sitemap_name'
 		);

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -266,8 +266,28 @@ class WPSEO_News_Sitemap {
 	 * @return string
 	 */
 	public static function get_sitemap_name( $full_path = true ) {
-		// This filter is documented in classes/sitemap.php.
-		$sitemap_name = apply_filters( 'wpseo_news_sitemap_name', self::news_sitemap_basename() );
+		/**
+		 * Allows for filtering the News sitemap name.
+		 *
+		 * @deprecated 12.5.0. Use the {@see 'Yoast\WP\News\sitemap_name'} filter instead.
+		 *
+		 * @param string $sitemap_name First portion of the news sitemap "file" name.
+		 */
+		$sitemap_name = apply_filters_deprecated(
+			'wpseo_news_sitemap_name',
+			array( self::news_sitemap_basename() ),
+			'YoastSEO News 12.5.0',
+			'Yoast\WP\News\sitemap_name'
+		);
+
+		/**
+		 * Allows for filtering the News sitemap name.
+		 *
+		 * @since 12.5.0
+		 *
+		 * @param string $sitemap_name First portion of the news sitemap "file" name.
+		 */
+		$sitemap_name = apply_filters( 'Yoast\WP\News\sitemap_name', $sitemap_name );
 
 		// When $full_path is true, it will generate a full path.
 		if ( $full_path ) {

--- a/classes/upgrade-manager.php
+++ b/classes/upgrade-manager.php
@@ -96,10 +96,10 @@ class WPSEO_News_Upgrade_Manager {
 		$current_options = get_option( 'wpseo_news' );
 
 		// Set new options.
-		$new_options = array(
+		$new_options = [
 			'news_sitemap_name'          => ( ( isset( $current_options['newssitemapname'] ) ) ? $current_options['newssitemapname'] : '' ),
 			'news_sitemap_default_genre' => ( ( isset( $current_options['newssitemap_default_genre'] ) ) ? $current_options['newssitemap_default_genre'] : '' ),
-		);
+		];
 
 		// Save new options.
 		update_option( 'wpseo_news', $new_options );
@@ -202,8 +202,8 @@ class WPSEO_News_Upgrade_Manager {
 	private function upgrade_1241() {
 		$options = get_option( 'wpseo_news' );
 
-		$included_post_types = array();
-		$excluded_terms      = array();
+		$included_post_types = [];
+		$excluded_terms      = [];
 
 		if ( isset( $options['news_sitemap_include_post_types'] ) && is_array( $options['news_sitemap_include_post_types'] ) ) {
 			$included_post_types = $options['news_sitemap_include_post_types'];
@@ -252,10 +252,10 @@ class WPSEO_News_Upgrade_Manager {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.SlowDBQuery -- Upgrade routines are only used intermittently.
 		$wpdb->delete(
 			$wpdb->postmeta,
-			array(
+			[
 				'meta_key' => $key,
-			),
-			array( '%s' )
+			],
+			[ '%s' ]
 		);
 		// phpcs:enable
 	}

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -50,10 +50,10 @@ class WPSEO_News {
 	 * Loading the hooks, which will be lead to methods withing this class.
 	 */
 	private function set_hooks() {
-		add_filter( 'plugin_action_links', array( $this, 'plugin_links' ), 10, 2 );
-		add_filter( 'wpseo_submenu_pages', array( $this, 'add_submenu_pages' ) );
-		add_action( 'admin_init', array( $this, 'init_helpscout_beacon' ) );
-		add_action( 'init', array( 'WPSEO_News_Option', 'register_option' ) );
+		add_filter( 'plugin_action_links', [ $this, 'plugin_links' ], 10, 2 );
+		add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_pages' ] );
+		add_action( 'admin_init', [ $this, 'init_helpscout_beacon' ] );
+		add_action( 'init', [ 'WPSEO_News_Option', 'register_option' ] );
 
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
@@ -77,7 +77,7 @@ class WPSEO_News {
 			);
 		}
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 	}
 
 	/**
@@ -90,7 +90,7 @@ class WPSEO_News {
 	protected function check_dependencies( $wp_version ) {
 		// When WordPress function is too low.
 		if ( version_compare( $wp_version, '5.2', '<' ) ) {
-			add_action( 'all_admin_notices', array( $this, 'error_upgrade_wp' ) );
+			add_action( 'all_admin_notices', [ $this, 'error_upgrade_wp' ] );
 
 			return false;
 		}
@@ -99,14 +99,14 @@ class WPSEO_News {
 
 		// When WPSEO_VERSION isn't defined.
 		if ( $wordpress_seo_version === false ) {
-			add_action( 'all_admin_notices', array( $this, 'error_missing_wpseo' ) );
+			add_action( 'all_admin_notices', [ $this, 'error_missing_wpseo' ] );
 
 			return false;
 		}
 
 		// At least 12.6.1, in which we implemented the new HelpScout Beacon.
 		if ( version_compare( $wordpress_seo_version, '12.6.1-RC0', '<' ) ) {
-			add_action( 'all_admin_notices', array( $this, 'error_upgrade_wpseo' ) );
+			add_action( 'all_admin_notices', [ $this, 'error_upgrade_wpseo' ] );
 
 			return false;
 		}
@@ -163,15 +163,15 @@ class WPSEO_News {
 
 		$admin_page = new WPSEO_News_Admin_Page();
 
-		$submenu_pages[] = array(
+		$submenu_pages[] = [
 			'wpseo_dashboard',
 			'Yoast SEO: News SEO',
 			'News SEO',
 			'wpseo_manage_options',
 			'wpseo_news',
-			array( $admin_page, 'display' ),
-			array( array( $this, 'enqueue_admin_page' ) ),
-		);
+			[ $admin_page, 'display' ],
+			[ [ $this, 'enqueue_admin_page' ] ],
+		];
 
 		return $submenu_pages;
 	}
@@ -198,7 +198,7 @@ class WPSEO_News {
 		global $pagenow;
 
 		if ( $pagenow === 'post.php' || $pagenow === 'post-new.php' ) {
-			wp_enqueue_style( 'wpseo-news-admin-metabox-css', plugins_url( 'css/dist/admin-metabox-' . $this->flatten_version( WPSEO_NEWS_VERSION ) . WPSEO_CSSJS_SUFFIX . '.css', WPSEO_NEWS_FILE ), array(), WPSEO_NEWS_VERSION );
+			wp_enqueue_style( 'wpseo-news-admin-metabox-css', plugins_url( 'css/dist/admin-metabox-' . $this->flatten_version( WPSEO_NEWS_VERSION ) . WPSEO_CSSJS_SUFFIX . '.css', WPSEO_NEWS_FILE ), [], WPSEO_NEWS_VERSION );
 		}
 	}
 
@@ -212,7 +212,7 @@ class WPSEO_News {
 		wp_enqueue_script(
 			'wpseo-news-admin-page',
 			plugins_url( 'assets/admin-page.min.js', WPSEO_NEWS_FILE ),
-			array( 'jquery' ),
+			[ 'jquery' ],
 			self::VERSION,
 			true
 		);
@@ -308,9 +308,9 @@ class WPSEO_News {
 
 		if ( $post_types === null ) {
 			// Get supported post types.
-			$post_types          = array();
-			$included_post_types = (array) WPSEO_Options::get( 'news_sitemap_include_post_types', array() );
-			foreach ( get_post_types( array( 'public' => true ), 'names' ) as $post_type ) {
+			$post_types          = [];
+			$included_post_types = (array) WPSEO_Options::get( 'news_sitemap_include_post_types', [] );
+			foreach ( get_post_types( [ 'public' => true ], 'names' ) as $post_type ) {
 				if ( array_key_exists( $post_type, $included_post_types ) && $included_post_types[ $post_type ] === 'on' ) {
 					$post_types[] = $post_type;
 				}
@@ -331,7 +331,7 @@ class WPSEO_News {
 	 * @return array
 	 */
 	public static function list_genres() {
-		return array(
+		return [
 			'none'          => __( 'None', 'wordpress-seo-news' ),
 			'pressrelease'  => __( 'Press Release', 'wordpress-seo-news' ),
 			'satire'        => __( 'Satire', 'wordpress-seo-news' ),
@@ -339,7 +339,7 @@ class WPSEO_News {
 			'oped'          => __( 'Op-Ed', 'wordpress-seo-news' ),
 			'opinion'       => __( 'Opinion', 'wordpress-seo-news' ),
 			'usergenerated' => __( 'User Generated', 'wordpress-seo-news' ),
-		);
+		];
 	}
 
 	/**
@@ -363,7 +363,7 @@ class WPSEO_News {
 	 */
 	public static function is_excluded_through_terms( $post_id, $post_type ) {
 		$terms          = self::get_terms_for_post( $post_id, $post_type );
-		$excluded_terms = (array) WPSEO_Options::get( 'news_sitemap_exclude_terms', array() );
+		$excluded_terms = (array) WPSEO_Options::get( 'news_sitemap_exclude_terms', [] );
 		foreach ( $terms as $term ) {
 			$option_key = $term->taxonomy . '_' . $term->slug . '_for_' . $post_type;
 			if ( array_key_exists( $option_key, $excluded_terms ) && $excluded_terms[ $option_key ] === 'on' ) {
@@ -383,7 +383,7 @@ class WPSEO_News {
 	 * @return array The terms for the item.
 	 */
 	public static function get_terms_for_post( $post_id, $post_type ) {
-		$terms                 = array();
+		$terms                 = [];
 		$excludable_taxonomies = new WPSEO_News_Excludable_Taxonomies( $post_type );
 
 		foreach ( $excludable_taxonomies->get() as $taxonomy ) {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "yoast/i18n-module": "^3.1.1"
     },
     "require-dev": {
-        "yoast/yoastcs": "^1.3.0",
+        "yoast/yoastcs": "^2.0.0",
         "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
         "brain/monkey": "^2.4"
     },
@@ -43,7 +43,7 @@
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set ignore_warnings_on_exit 1"
         ],
         "fix-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f00bf6d462d0a52b42a98a739c0e32f",
+    "content-hash": "8001a8efee79a9d82802ee5dd0ed3214",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -444,16 +444,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.4",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1"
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1f37659196e4f3113ea506a7efba201c52303bf1",
-                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
                 "shasum": ""
             },
             "require": {
@@ -498,7 +498,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-11-15T04:12:02+00:00"
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -1981,26 +1981,28 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca"
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
                 "php": ">=5.4",
-                "phpcompatibility/phpcompatibility-wp": "^2.0.0",
-                "squizlabs/php_codesniffer": "^3.4.2",
-                "wp-coding-standards/wpcs": "^2.1.1"
+                "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+                "squizlabs/php_codesniffer": "^3.5.0",
+                "wp-coding-standards/wpcs": "^2.2.0"
             },
             "require-dev": {
+                "jakub-onderka/php-console-highlighter": "^0.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
                 "phpcompatibility/php-compatibility": "^9.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "roave/security-advisories": "dev-master"
@@ -2025,7 +2027,7 @@
                 "wordpress",
                 "yoast"
             ],
-            "time": "2019-07-31T12:06:40+00:00"
+            "time": "2019-12-17T07:40:59+00:00"
         }
     ],
     "aliases": [],

--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -21,9 +21,9 @@ if ( getenv( 'WP_PLUGIN_DIR' ) !== false ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 }
 
-$GLOBALS['wp_tests_options'] = array(
-	'active_plugins' => array( 'wordpress-seo/wp-seo.php', 'wpseo-news/wpseo-news.php' ),
-);
+$GLOBALS['wp_tests_options'] = [
+	'active_plugins' => [ 'wordpress-seo/wp-seo.php', 'wpseo-news/wpseo-news.php' ],
+];
 
 if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;

--- a/integration-tests/framework/unittestcase.php
+++ b/integration-tests/framework/unittestcase.php
@@ -57,7 +57,7 @@ class WPSEO_News_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @return mixed Method return.
 	 */
-	public function invoke_method( &$object, $method_name, array $parameters = array() ) {
+	public function invoke_method( &$object, $method_name, array $parameters = [] ) {
 		$reflection = new ReflectionClass( get_class( $object ) );
 		$method     = $reflection->getMethod( $method_name );
 

--- a/integration-tests/meta-box-test.php
+++ b/integration-tests/meta-box-test.php
@@ -21,19 +21,19 @@ class WPSEO_News_Meta_Box_Test extends WPSEO_News_UnitTestCase {
 		$stub = $this
 			->getMockBuilder( 'WPSEO_News_Meta_Box_Double' )
 			->setMethods(
-				array(
+				[
 					'is_post_type_supported',
 					'get_meta_boxes',
 					'do_meta_box',
-				)
+				]
 			)
 			->getMock();
 
 		$stub->method( 'is_post_type_supported' )->willReturn( true );
-		$stub->method( 'get_meta_boxes' )->willReturn( array( 'metakey' => 'metabox' ) );
+		$stub->method( 'get_meta_boxes' )->willReturn( [ 'metakey' => 'metabox' ] );
 		$stub->method( 'do_meta_box' )->willReturn( '[content]' );
 
-		$sections = $stub->add_metabox_section( array() );
+		$sections = $stub->add_metabox_section( [] );
 
 		$this->assertEquals( count( $sections ), 1 );
 
@@ -50,12 +50,12 @@ class WPSEO_News_Meta_Box_Test extends WPSEO_News_UnitTestCase {
 	public function test_add_metabox_section_unsupported_posttype() {
 		$stub = $this
 			->getMockBuilder( 'WPSEO_News_Meta_Box_Double' )
-			->setMethods( array( 'is_post_type_supported' ) )
+			->setMethods( [ 'is_post_type_supported' ] )
 			->getMock();
 
 		$stub->method( 'is_post_type_supported' )->willReturn( false );
 
-		$sections = $stub->add_metabox_section( array() );
+		$sections = $stub->add_metabox_section( [] );
 
 		$this->assertEquals( count( $sections ), 0 );
 	}

--- a/integration-tests/schema-test.php
+++ b/integration-tests/schema-test.php
@@ -35,7 +35,7 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 
 		$this->default_mock = $this
 			->getMockBuilder( 'WPSEO_News_Schema_Double' )
-			->setMethods( array( 'get_post', 'is_post_excluded' ) )
+			->setMethods( [ 'get_post', 'is_post_excluded' ] )
 			->getMock();
 
 		$this->default_mock
@@ -43,12 +43,12 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 			->will(
 				$this->returnValue(
 					self::factory()->post->create_and_get(
-						array(
+						[
 							'post_title'    => 'Newest post',
 							'post_date'     => $date_string,
 							'post_date_gmt' => $date_string,
 							'post_type'     => 'post',
-						)
+						]
 					)
 				)
 			);
@@ -65,9 +65,9 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_post' );
 
-		$actual = $this->default_mock->article_post_types( array() );
+		$actual = $this->default_mock->article_post_types( [] );
 
-		$this->assertEquals( array( 'post' ), $actual );
+		$this->assertEquals( [ 'post' ], $actual );
 	}
 
 	/**
@@ -86,9 +86,9 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 			->method( 'is_post_excluded' )
 			->willReturn( $this->returnValue( true ) );
 
-		$actual = $this->default_mock->article_post_types( array() );
+		$actual = $this->default_mock->article_post_types( [] );
 
-		$this->assertEquals( array(), $actual );
+		$this->assertEquals( [], $actual );
 	}
 
 	/**
@@ -102,14 +102,14 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_post' );
 
-		$expected = array(
+		$expected = [
 			'@type'           => 'NewsArticle',
 			'copyrightYear'   => $this->date->format( 'Y' ),
-			'copyrightHolder' => array(
+			'copyrightHolder' => [
 				'@id' => 'http://example.org/#organization',
-			),
-		);
-		$actual   = $this->default_mock->change_article( array() );
+			],
+		];
+		$actual   = $this->default_mock->change_article( [] );
 
 		$this->assertEquals( $expected, $actual );
 	}
@@ -135,13 +135,13 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 		 * Note there is no `@type` expected here. This is because we do not __override__ it.
 		 * Yoast SEO is setting the default of `Article` in the output of the actual page.
 		 */
-		$expected = array(
+		$expected = [
 			'copyrightYear'   => $this->date->format( 'Y' ),
-			'copyrightHolder' => array(
+			'copyrightHolder' => [
 				'@id' => 'http://example.org/#organization',
-			),
-		);
-		$actual   = $this->default_mock->change_article( array() );
+			],
+		];
+		$actual   = $this->default_mock->change_article( [] );
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/integration-tests/sitemap-images-test.php
+++ b/integration-tests/sitemap-images-test.php
@@ -55,7 +55,7 @@ class WPSEO_News_Sitemap_Images_Test extends WPSEO_News_UnitTestCase {
 	 * @param string $expected Expected result.
 	 */
 	public function test_parse_image_source( $src, $expected ) {
-		$url = $this->invoke_method( $this->instance, 'parse_image_source', array( $src ) );
+		$url = $this->invoke_method( $this->instance, 'parse_image_source', [ $src ] );
 		$this->assertSame( $expected, $url );
 	}
 
@@ -65,31 +65,31 @@ class WPSEO_News_Sitemap_Images_Test extends WPSEO_News_UnitTestCase {
 	 * @see WPSEO_News_Sitemap_Images_Test::parse_image_source()
 	 */
 	public function provider_parse_image_source() {
-		return array(
+		return [
 			// HTTP.
-			array(
+			[
 				'http://example.org/wp-content/uploads/2018/01/image1.jpg',
 				'http://example.org/wp-content/uploads/2018/01/image1.jpg',
-			),
+			],
 			// HTTPS.
-			array(
+			[
 				'https://example.org/wp-content/uploads/2018/01/image1.jpg',
 				'https://example.org/wp-content/uploads/2018/01/image1.jpg',
-			),
+			],
 			// Relative URL.
-			array(
+			[
 				'/wp-content/uploads/2018/01/image1.jpg',
 				'http://example.org/wp-content/uploads/2018/01/image1.jpg',
-			),
-			array(
+			],
+			[
 				'wp-content/uploads/2018/01/image1.jpg',
 				null,
-			),
+			],
 			// Protocol relative URL.
-			array(
+			[
 				'//example.org/wp-content/uploads/2018/01/image1.jpg',
 				'//example.org/wp-content/uploads/2018/01/image1.jpg',
-			),
-		);
+			],
+		];
 	}
 }

--- a/integration-tests/sitemap-item-test.php
+++ b/integration-tests/sitemap-item-test.php
@@ -20,12 +20,12 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$timezone_format = DateTime::W3C;
 
 		$test_post_date_gmt = self::factory()->post->create_and_get(
-			array(
+			[
 				'post_title'    => 'Newest post',
 				'post_date'     => gmdate( $timezone_format, $base_time ),
 				'post_date_gmt' => gmdate( $timezone_format, $base_time ),
 				'post_type'     => 'post',
-			)
+			]
 		);
 
 		$instance = new WPSEO_News_Sitemap_Item_Double( $test_post_date_gmt );
@@ -51,11 +51,11 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 		$timezone_format = DateTime::W3C;
 
 		$test_post_date = self::factory()->post->create_and_get(
-			array(
+			[
 				'post_title'    => 'Newest post',
 				'post_date'     => gmdate( $timezone_format, $base_time ),
 				'post_type'     => 'post',
-			)
+			]
 		);
 
 		// Manually set post_date_gmt to an invalid string, because at creation WP forces a valid string.
@@ -78,10 +78,10 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 */
 	public function test_get_publication_date_with_invalid_datetime() {
 		$test_post_date_gmt = self::factory()->post->create_and_get(
-			array(
+			[
 				'post_title'    => 'Newest post',
 				'post_type'     => 'post',
-			)
+			]
 		);
 
 		$test_post_date_gmt->post_date     = -10;
@@ -102,10 +102,10 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap_Item::get_item_title
 	 */
 	public function test_get_item_title_when_no_seo_title_set() {
-		$post_details   = array(
+		$post_details   = [
 			'post_title' => 'Post without SEO title',
 			'post_type'  => 'post',
-		);
+		];
 		$test_seo_title = self::factory()->post->create_and_get( $post_details );
 
 		$instance     = new WPSEO_News_Sitemap_Item_Double( $test_seo_title );
@@ -121,10 +121,10 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap_Item::get_item_title
 	 */
 	public function test_get_item_title_when_post_is_null() {
-		$post_details   = array(
+		$post_details   = [
 			'post_title' => 'title',
 			'post_type'  => 'post',
-		);
+		];
 		$test_seo_title = self::factory()->post->create_and_get( $post_details );
 
 		$instance = new WPSEO_News_Sitemap_Item_Double( $test_seo_title );
@@ -141,10 +141,10 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	 * @covers WPSEO_News_Sitemap_Item::get_item_title
 	 */
 	public function test_get_item_title_when_seo_title_set() {
-		$post_details   = array(
+		$post_details   = [
 			'post_title' => 'Post with SEO title',
 			'post_type'  => 'post',
-		);
+		];
 		$test_seo_title = self::factory()->post->create_and_get( $post_details );
 		$instance       = new WPSEO_News_Sitemap_Item_Double( $test_seo_title );
 

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -52,9 +52,9 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		 * We need an item to be present to get output.
 		 */
 		$this->factory->post->create(
-			array(
+			[
 				'post_title' => 'generate rss',
-			)
+			]
 		);
 
 		$output = $this->instance->add_to_index( '' );
@@ -91,7 +91,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	public function test_sitemap_NOT_empty() {
 		WPSEO_Options::set( 'news_sitemap_name', 'Test Blog' );
 
-		$post_id = $this->factory->post->create( array( 'post_title' => 'generate rss' ) );
+		$post_id = $this->factory->post->create( [ 'post_title' => 'generate rss' ] );
 
 		$output = $this->instance->build_sitemap();
 
@@ -142,10 +142,10 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	public function test_sitemap_WITH_image() {
 
 		$image        = home_url( 'tests/assets/yoast.png' );
-		$post_details = array(
+		$post_details = [
 			'post_title'   => 'with images',
 			'post_content' => '<img src="' . $image . '" />',
-		);
+		];
 		$this->factory->post->create( $post_details );
 
 		$output = $this->instance->build_sitemap();
@@ -166,10 +166,10 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	public function test_sitemap_WITHOUT_featured_image_restricted() {
 
 		$image        = home_url( 'tests/assets/yoast.png' );
-		$post_details = array(
+		$post_details = [
 			'post_title'   => 'featured image',
 			'post_content' => '<img src="' . $image . '" />',
-		);
+		];
 		$post_id      = $this->factory->post->create( $post_details );
 
 		$featured_image = home_url( 'tests/assets/yoast_featured.png' );
@@ -231,31 +231,31 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	public function test_sitemap_only_showing_recent_items() {
 		$base_time = time();
 		$this->factory->post->create(
-			array(
+			[
 				'post_title'    => 'Newest post',
 				'post_date'     => gmdate( 'Y-m-d H:i:s', $base_time ),
 				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $base_time ),
-			)
+			]
 		);
 
 		$two_days_ago = strtotime( '-48 hours' );
 
 		$this->factory->post->create(
-			array(
+			[
 				'post_title'    => 'New-ish post',
 				'post_date'     => gmdate( 'Y-m-d H:i:s', $two_days_ago ),
 				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $two_days_ago ),
-			)
+			]
 		);
 
 		$two_days_ago_one_minute = strtotime( '-48 hours -1 minute' );
 
 		$this->factory->post->create(
-			array(
+			[
 				'post_title'    => 'Too old Post',
 				'post_date'     => gmdate( 'Y-m-d H:i:s', $two_days_ago_one_minute ),
 				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $two_days_ago_one_minute ),
-			)
+			]
 		);
 
 		$output = $this->instance->build_sitemap();
@@ -277,14 +277,14 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	 */
 	private function create_attachment( $image, $post_id = 0 ) {
 		return $this->factory->post->create(
-			array(
+			[
 				'post_title'     => 'attachment',
 				'post_name'      => 'attachment',
 				'guid'           => $image,
 				'post_type'      => 'attachment',
 				'post_mime_type' => 'image/png',
 				'parent_id'      => $post_id,
-			)
+			]
 		);
 	}
 }

--- a/integration-tests/wpseo-news-test.php
+++ b/integration-tests/wpseo-news-test.php
@@ -26,7 +26,7 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 		$class_instance = $this
 			->getMockBuilder( 'WPSEO_News_Double' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'get_wordpress_seo_version' ) )
+			->setMethods( [ 'get_wordpress_seo_version' ] )
 			->getMock();
 
 		$class_instance
@@ -49,13 +49,13 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 	 * @return array[]
 	 */
 	public function check_dependencies_data() {
-		return array(
-			array( false, '12.7', '3.0', 'WordPress is below the minimal required version.' ),
-			array( false, '12.7', '5.1', 'WordPress is below the minimal required version.' ),
-			array( false, false, '5.3', 'WordPress SEO is not installed.' ),
-			array( false, '8.1', '5.3', 'WordPress SEO is below the minimal required version.' ),
-			array( true, '12.6.1-RC1', '5.2', 'WordPress (5.2) and WordPress SEO have the minimal required versions.' ),
-			array( true, '12.7', '5.3', 'WordPress (5.3) and WordPress SEO have the minimal required versions.' ),
-		);
+		return [
+			[ false, '12.7', '3.0', 'WordPress is below the minimal required version.' ],
+			[ false, '12.7', '5.1', 'WordPress is below the minimal required version.' ],
+			[ false, false, '5.3', 'WordPress SEO is not installed.' ],
+			[ false, '8.1', '5.3', 'WordPress SEO is below the minimal required version.' ],
+			[ true, '12.6.1-RC1', '5.2', 'WordPress (5.2) and WordPress SEO have the minimal required versions.' ],
+			[ true, '12.7', '5.3', 'WordPress (5.3) and WordPress SEO have the minimal required versions.' ],
+		];
 	}
 }

--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -68,7 +68,7 @@ add_action( 'plugins_loaded', '__wpseo_news_main' );
  */
 function yoast_wpseo_news_clear_sitemap_cache() {
 	if ( class_exists( 'WPSEO_Sitemaps_Cache' ) && method_exists( 'WPSEO_Sitemaps_Cache', 'clear' ) ) {
-		WPSEO_Sitemaps_Cache::clear( array( WPSEO_News_Sitemap::get_sitemap_name() ) );
+		WPSEO_Sitemaps_Cache::clear( [ WPSEO_News_Sitemap::get_sitemap_name() ] );
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* This deprecates  the `wpseo_news_head` action hook in favour of the `Yoast\WP\News\head` hook.
* This deprecates  the `wpseo_news_head_display_noindex` filter hook in favour of the `Yoast\WP\News\head_display_noindex` hook.
* This deprecates  the `wpseo_news_sitemap_name` filter hook in favour of the `Yoast\WP\News\sitemap_name` hook.

## Relevant technical choices:


### PHPCS: Update to YoastCS 2.0.0

This updates the dependency in `composer.json`, as well as the PHPCS ruleset for YoastCS 2.0.0.

Includes:
* A selective update of the `composer.lock` for just YoastCS and its dependencies.
* Removing the tweaks to the Composer `check-cs` script to change the minimum required PHP version.
    As of YoastCS 2.0, PHP 5.6 is now the default minimum PHP version.

Ref: https://github.com/Yoast/yoastcs/releases/tag/2.0.0


### CS: deprecate old-style hook and add new-style hook [1]

This deprecates  the `wpseo_news_head` action hook in favour of the `Yoast\WP\News\head` hook.

[This needs a changelog entry]


### CS: deprecate old-style hook and add new-style hook [2]

This deprecates  the `wpseo_news_head_display_noindex` filter hook in favour of the `Yoast\WP\News\head_display_noindex` hook.

[This needs a changelog entry]


### CS: deprecate old-style hook and add new-style hook [3]

This deprecates  the `wpseo_news_sitemap_name` filter hook in favour of the `Yoast\WP\News\sitemap_name` hook.

[This needs a changelog entry]

### CS: use short arrays (everywhere)



## Test instructions

This PR can be tested by following these steps:

See the test instructions in the Yoast/wpseo-woocommerce#451 PR for guidance on how to test this PR.