### PR TITLE
Modernize: use `__DIR__` instead of `dirname( __FILE__ )`

### DIFF
--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -25,7 +25,7 @@ $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( 'wordpress-seo/wp-seo.php', 'wpseo-news/wpseo-news.php' ),
 );
 
-if ( file_exists( dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php' ) === false ) {
+if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;
 	exit( 1 );
 }
@@ -53,4 +53,4 @@ if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/wpseo-news/w
 }
 
 // Include unit test base class.
-require_once dirname( __FILE__ ) . '/framework/unittestcase.php';
+require_once __DIR__ . '/framework/unittestcase.php';

--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -39,8 +39,8 @@ if ( ! defined( 'WPSEO_NEWS_FILE' ) ) {
 
 define( 'WPSEO_NEWS_VERSION', '12.4.1' );
 
-if ( file_exists( dirname( __FILE__ ) . '/vendor/autoload.php' ) ) {
-	require dirname( __FILE__ ) . '/vendor/autoload.php';
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require __DIR__ . '/vendor/autoload.php';
 }
 
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Minor code simplification which is possible now PHP 5.6 is the minimum version.

Ref: https://www.php.net/manual/en/language.constants.predefined.php


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.