### PR TITLE
Modernize: use nowdoc instead of heredoc

### DIFF
--- a/integration-tests/admin-page-test.php
+++ b/integration-tests/admin-page-test.php
@@ -49,7 +49,7 @@ class WPSEO_News_Admin_Page_Test extends WPSEO_News_UnitTestCase {
 		ob_end_clean();
 
 		// We expect this part in the generated HTML.
-		$expected_output = <<<EOT
+		$expected_output = <<<'EOT'
 <p>You will generally only need a News Sitemap when your website is included in Google News.</p><p><a target="_blank" href="http://example.org/news-sitemap.xml">View your News Sitemap</a>.</p>
 EOT;
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Nowdoc (PHP 5.3+) equates to heredoc as single quoted strings to double quoted strings: no variable interpolation will be done.

As the text string in the heredoc did not contain any variables, nowdoc is the more appropriate construct to use for this text snippet.

Ref: https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.nowdoc



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.