### PR TITLE
Integration tests: bug fix / typo

### DIFF
--- a/integration-tests/admin-page-test.php
+++ b/integration-tests/admin-page-test.php
@@ -26,7 +26,7 @@ class WPSEO_News_Admin_Page_Test extends WPSEO_News_UnitTestCase {
 		// Because is a global $wpseo_admin_pages we have to fill this one with an instance of WPSEO_Admin_Pages.
 		global $wpseo_admin_pages;
 
-		if ( empty( $wpseo_admin_page ) ) {
+		if ( empty( $wpseo_admin_pages ) ) {
 			$wpseo_admin_pages = new WPSEO_Admin_Pages();
 		}
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

The variable `$wpseo_admin_page` did not exist and would therefore always be empty.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-only change. If the tests still pass, we're good.