### PR TITLE
QA: add missing `use` statements

### DIFF
--- a/tests/doubles/option-double.php
+++ b/tests/doubles/option-double.php
@@ -2,10 +2,12 @@
 
 namespace Yoast\WP\News\Tests\Doubles;
 
+use WPSEO_News_Option;
+
 /**
  * Class Option_Double
  */
-class Option_Double extends \WPSEO_News_Option {
+class Option_Double extends WPSEO_News_Option {
 
 	/**
 	 * Expose the constructor.

--- a/tests/news-test.php
+++ b/tests/news-test.php
@@ -3,6 +3,9 @@
 namespace Yoast\WP\News\Tests;
 
 use WPSEO_News;
+use Yoast\WP\News\Tests\TestCase;
+use Mockery;
+
 use function Brain\Monkey\Functions\expect;
 
 /**
@@ -18,7 +21,7 @@ class News_Test extends TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function test_get_included_post_types() {
-		$options = \Mockery::mock( 'overload:\WPSEO_Options' );
+		$options = Mockery::mock( 'overload:\WPSEO_Options' );
 		$options
 			->shouldReceive( 'get' )
 			->with( 'news_sitemap_include_post_types', [] )
@@ -43,7 +46,7 @@ class News_Test extends TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function test_get_included_post_types_with_no_set_post_types() {
-		$options = \Mockery::mock( 'overload:\WPSEO_Options' );
+		$options = Mockery::mock( 'overload:\WPSEO_Options' );
 		$options
 			->shouldReceive( 'get' )
 			->with( 'news_sitemap_include_post_types', [] )

--- a/tests/option-test.php
+++ b/tests/option-test.php
@@ -2,6 +2,10 @@
 
 namespace Yoast\WP\News\Tests;
 
+use Mockery;
+use Yoast\WP\News\Tests\TestCase;
+use Yoast\WP\News\Tests\Doubles\Option_Double;
+
 /**
  * Test the News Option class.
  */
@@ -20,11 +24,11 @@ class Option_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$external_mock              = \Mockery::mock( 'overload:\WPSEO_Option' );
+		$external_mock              = Mockery::mock( 'overload:\WPSEO_Option' );
 		$external_mock->option_name = 'wpseo_news';
 		$external_mock->defaults    = [];
 
-		$this->instance = new Doubles\Option_Double();
+		$this->instance = new Option_Double();
 	}
 
 	/**

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\News\Tests;
 
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 use Brain\Monkey;
+use Mockery;
 
 /**
  * TestCase base class.
@@ -48,12 +49,12 @@ abstract class TestCase extends PHPUnit_TestCase {
 
 		Monkey\Functions\expect( 'get_option' )
 			->zeroOrMoreTimes()
-			->with( \Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
+			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
 			->andReturn( [] );
 
 		Monkey\Functions\expect( 'get_site_option' )
 			->zeroOrMoreTimes()
-			->with( \Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
+			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
 			->andReturn( [] );
 	}
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Always be explicit about which classes are being used in a namespaced file, even when it's a class from within the same namespace.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.