### PR TITLE
QA: declare static closures as static

### DIFF
--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -32,15 +32,15 @@ abstract class TestCase extends PHPUnit_TestCase {
 				'is_admin'       => false,
 				'is_multisite'   => false,
 				'site_url'       => 'https://www.example.org',
-				'wp_json_encode' => function( $data, $options = 0, $depth = 512 ) {
+				'wp_json_encode' => static function( $data, $options = 0, $depth = 512 ) {
 					// phpcs:ignore Yoast.Yoast.AlternativeFunctions -- Mocks the wp_json_encode function.
 					return \json_encode( $data, $options, $depth );
 				},
 				'wp_slash'       => null,
-				'absint'         => function( $value ) {
+				'absint'         => static function( $value ) {
 					return abs( intval( $value ) );
 				},
-				'wp_parse_args'  => function ( $settings, $defaults ) {
+				'wp_parse_args'  => static function ( $settings, $defaults ) {
 					return \array_merge( $defaults, $settings );
 				},
 			]


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* No functional changes.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.