### PR TITLE
QA: remove redundant variable assignment

### DIFF
--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -145,7 +145,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 			'post_title'   => 'with images',
 			'post_content' => '<img src="' . $image . '" />',
 		);
-		$post_id      = $this->factory->post->create( $post_details );
+		$this->factory->post->create( $post_details );
 
 		$output = $this->instance->build_sitemap();
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

This variable is not used anywhere, so no need to assign the return of the function call to a variable.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.