### PR TITLE
Docs: various fixes

### DIFF
--- a/classes/excludable-taxonomies.php
+++ b/classes/excludable-taxonomies.php
@@ -65,7 +65,8 @@ class WPSEO_News_Excludable_Taxonomies {
 	 *
 	 * @param WP_Taxonomy $taxonomy The taxonomy to get the terms for.
 	 *
-	 * @return array An array containing both the taxonomy and its terms.
+	 * @return array|null An array containing both the taxonomy and its terms or null
+	 *                    if no terms are associated with the taxonomy.
 	 */
 	protected function get_terms_for_taxonomy( $taxonomy ) {
 		$terms = get_terms(

--- a/classes/head.php
+++ b/classes/head.php
@@ -42,7 +42,7 @@ class WPSEO_News_Head {
 	/**
 	 * Shows the meta-tag with noindex when it has been decided to exclude the post from Google News.
 	 *
-	 * @see: https://support.google.com/news/publisher/answer/93977?hl=en
+	 * @see https://support.google.com/news/publisher/answer/93977?hl=en
 	 */
 	private function display_noindex() {
 		/**

--- a/classes/javascript-strings.php
+++ b/classes/javascript-strings.php
@@ -13,7 +13,7 @@ class WPSEO_News_Javascript_Strings {
 	/**
 	 * Strings to be made available to javascript.
 	 *
-	 * @var null|array
+	 * @var array|null
 	 */
 	private static $strings = null;
 

--- a/classes/javascript-strings.php
+++ b/classes/javascript-strings.php
@@ -13,7 +13,7 @@ class WPSEO_News_Javascript_Strings {
 	/**
 	 * Strings to be made available to javascript.
 	 *
-	 * @var array|null
+	 * @var string[]|null
 	 */
 	private static $strings = null;
 
@@ -30,7 +30,7 @@ class WPSEO_News_Javascript_Strings {
 	/**
 	 * Returns the array with strings.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public static function strings() {
 		if ( self::$strings === null ) {

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -32,7 +32,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	 *
 	 * @param string $post_type The post type to get metaboxes for.
 	 *
-	 * @return array $mbs
+	 * @return array Multi-level array with information on each metabox to display.
 	 */
 	public function get_meta_boxes( $post_type = 'post' ) {
 		$mbs = array(

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -32,7 +32,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	 *
 	 * @param string $post_type The post type to get metaboxes for.
 	 *
-	 * @return array Multi-level array with information on each metabox to display.
+	 * @return array[] Multi-level array with information on each metabox to display.
 	 */
 	public function get_meta_boxes( $post_type = 'post' ) {
 		$mbs = array(

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -34,7 +34,7 @@ class WPSEO_News_Schema {
 	 *
 	 * @param array $post_types Supported post types.
 	 *
-	 * @return array $post_types Supported post types.
+	 * @return array Supported post types.
 	 */
 	public function article_post_types( $post_types ) {
 		$post = $this->get_post();
@@ -51,7 +51,7 @@ class WPSEO_News_Schema {
 	 *
 	 * @param array $data Schema Article data.
 	 *
-	 * @return array $data Schema Article data.
+	 * @return array Schema Article data.
 	 */
 	public function change_article( $data ) {
 		$post = $this->get_post();

--- a/classes/sitemap-images.php
+++ b/classes/sitemap-images.php
@@ -188,7 +188,7 @@ class WPSEO_News_Sitemap_Images {
 	/**
 	 * Getting the featured image.
 	 *
-	 * @param integer $post_thumbnail_id Thumbnail ID.
+	 * @param int $post_thumbnail_id Thumbnail ID.
 	 *
 	 * @return void
 	 */

--- a/classes/sitemap-images.php
+++ b/classes/sitemap-images.php
@@ -137,7 +137,7 @@ class WPSEO_News_Sitemap_Images {
 	 *
 	 * @param string $img Image HTML.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	private function parse_image( $img ) {
 		$image = array();

--- a/classes/sitemap-images.php
+++ b/classes/sitemap-images.php
@@ -107,7 +107,7 @@ class WPSEO_News_Sitemap_Images {
 	 *
 	 * @param string $src Image Source.
 	 *
-	 * @return string|void
+	 * @return string|null
 	 */
 	private function parse_image_source( $src ) {
 

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -154,7 +154,7 @@ class WPSEO_News_Sitemap_Item {
 	/**
 	 * Gets the SEO title of the item, with a fallback to the item title.
 	 *
-	 * @param WP_Post $item The post object.
+	 * @param WP_Post|null $item The post object.
 	 *
 	 * @return string The formatted title or, if no formatted title can be created, the post_title.
 	 */

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -209,7 +209,7 @@ class WPSEO_News_Sitemap {
 	 *
 	 * @param int $limit The limit for the query, default is 1000 items.
 	 *
-	 * @return array|null|object
+	 * @return array|object|null
 	 */
 	private function get_items( $limit = 1000 ) {
 		global $wpdb;

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -263,7 +263,7 @@ class WPSEO_News_Sitemap {
 	 *
 	 * @param bool $full_path Generate a full path.
 	 *
-	 * @return string mixed
+	 * @return string
 	 */
 	public static function get_sitemap_name( $full_path = true ) {
 		// This filter is documented in classes/sitemap.php.

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -88,7 +88,7 @@ class WPSEO_News_Sitemap {
 	/**
 	 * Method to invalidate the sitemap.
 	 *
-	 * @param integer $post_id Post ID to invalidate for.
+	 * @param int $post_id Post ID to invalidate for.
 	 */
 	public function invalidate_sitemap( $post_id ) {
 		// If this is just a revision, don't invalidate the sitemap cache yet.

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -247,7 +247,7 @@ class WPSEO_News_Sitemap {
 	 *
 	 * @param array $items Items to convert to sitemap output.
 	 *
-	 * @return string $output
+	 * @return string
 	 */
 	private function build_items( $items ) {
 		$output = '';
@@ -284,7 +284,7 @@ class WPSEO_News_Sitemap {
 	 *
 	 * @since 3.1
 	 *
-	 * @return string $basename
+	 * @return string Basename for the news sitemap.
 	 */
 	public static function news_sitemap_basename() {
 		$basename = 'news';

--- a/classes/upgrade-manager.php
+++ b/classes/upgrade-manager.php
@@ -242,9 +242,9 @@ class WPSEO_News_Upgrade_Manager {
 	/**
 	 * Deletes post meta fields by key.
 	 *
-	 * @param string $key The key to delete post meta fields for.
-	 *
 	 * @link https://codex.wordpress.org/Class_Reference/wpdb#DELETE_Rows
+	 *
+	 * @param string $key The key to delete post meta fields for.
 	 */
 	private function delete_meta_by_key( $key ) {
 		global $wpdb;

--- a/classes/upgrade-manager.php
+++ b/classes/upgrade-manager.php
@@ -5,9 +5,10 @@
  * @package WPSEO_News
  */
 
+// Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
-} // Exit if accessed directly.
+}
 
 /**
  * Represents the update routine when a newer version has been installed.

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -9,6 +9,12 @@
  * Represents the news extension for Yoast SEO.
  */
 class WPSEO_News {
+
+	/**
+	 * Version number of the plugin.
+	 *
+	 * @var string
+	 */
 	const VERSION = WPSEO_NEWS_VERSION;
 
 	/**

--- a/integration-tests/doubles/sitemap-item-double.php
+++ b/integration-tests/doubles/sitemap-item-double.php
@@ -11,14 +11,14 @@
 class WPSEO_News_Sitemap_Item_Double extends WPSEO_News_Sitemap_Item {
 
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 */
 	public function get_publication_date( $item ) {
 		return parent::get_publication_date( $item );
 	}
 
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 */
 	public function get_item_title( $item = null ) {
 		return parent::get_item_title( $item );

--- a/integration-tests/doubles/wpseo-news-double.php
+++ b/integration-tests/doubles/wpseo-news-double.php
@@ -11,7 +11,7 @@
 class WPSEO_News_Double extends WPSEO_News {
 
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 */
 	public function check_dependencies( $wp_version ) {
 		return parent::check_dependencies( $wp_version );

--- a/integration-tests/framework/unittestcase.php
+++ b/integration-tests/framework/unittestcase.php
@@ -61,7 +61,7 @@ class WPSEO_News_UnitTestCase extends WP_UnitTestCase {
 		$reflection = new ReflectionClass( get_class( $object ) );
 		$method     = $reflection->getMethod( $method_name );
 
-		$method->setAccessible( true ); // PHP 5.3.2.
+		$method->setAccessible( true );
 
 		return $method->invokeArgs( $object, $parameters );
 	}

--- a/integration-tests/sitemap-item-test.php
+++ b/integration-tests/sitemap-item-test.php
@@ -40,10 +40,11 @@ class WPSEO_News_Sitemap_Item_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Checks if the time output for the sitemap is correct when there is no post_date_gmt set.
 	 *
-	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
-	 *
 	 * Prior to PHP 5.5.10, timezone offsets were not supported by `DateTimeZone` causing the test to fail.
+	 *
 	 * @requires PHP 5.5.10
+	 *
+	 * @covers WPSEO_News_Sitemap_Item::get_publication_date
 	 */
 	public function test_get_publication_date_returning_correct_post_date_when_no_gmt_set() {
 		$base_time       = time();

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -40,10 +40,11 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Verifies that the news sitemap is correctly added to the sitemap index when there are news items.
 	 *
-	 * @covers WPSEO_News_Sitemap::add_to_index
-	 *
 	 * Prior to PHP 5.5.10, timezone offsets were not supported by `DateTimeZone` causing the test to fail.
+	 *
 	 * @requires PHP 5.5.10
+	 *
+	 * @covers WPSEO_News_Sitemap::add_to_index
 	 */
 	public function test_add_to_index() {
 

--- a/integration-tests/wpseo-news-test.php
+++ b/integration-tests/wpseo-news-test.php
@@ -46,7 +46,7 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 	 * [2]: WordPress Version
 	 * [3]: Message for PHPUnit.
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	public function check_dependencies_data() {
 		return array(

--- a/integration-tests/wpseo-news-test.php
+++ b/integration-tests/wpseo-news-test.php
@@ -15,12 +15,12 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 	 *
 	 * @dataProvider check_dependencies_data
 	 *
+	 * @covers WPSEO_News::check_dependencies
+	 *
 	 * @param bool   $expected              The expected value.
 	 * @param string $wordpress_seo_version The WordPress SEO version to check.
 	 * @param string $wordpress_version     The WordPress version to check.
 	 * @param string $message               Message given by PHPUnit after assertion.
-	 *
-	 * @covers WPSEO_News::check_dependencies
 	 */
 	public function test_check_dependencies( $expected, $wordpress_seo_version, $wordpress_version, $message ) {
 		$class_instance = $this

--- a/tests/option-test.php
+++ b/tests/option-test.php
@@ -34,15 +34,15 @@ class Option_Test extends TestCase {
 	/**
 	 * Tests the validation of the option.
 	 *
+	 * @dataProvider validate_option_provider
+	 *
+	 * @covers WPSEO_News_Option::validate_option
+	 *
 	 * @param string $option_name The option name.
 	 * @param array  $clean       The clean data.
 	 * @param array  $dirty       The data to validate.
 	 * @param array  $expected    The expected value.
 	 * @param string $message     Message to show when test fails.
-	 *
-	 * @dataProvider validate_option_provider
-	 *
-	 * @covers WPSEO_News_Option::validate_option
 	 */
 	public function test_validate_option( $option_name, $clean, $dirty, $expected, $message ) {
 		$clean    = [ $option_name => $clean ];

--- a/tests/option-test.php
+++ b/tests/option-test.php
@@ -14,7 +14,7 @@ class Option_Test extends TestCase {
 	/**
 	 * The instance.
 	 *
-	 * @var Doubles\Option_Double
+	 * @var \Yoast\WP\News\Tests\Doubles\Option_Double
 	 */
 	protected $instance;
 

--- a/tests/option-test.php
+++ b/tests/option-test.php
@@ -56,7 +56,7 @@ class Option_Test extends TestCase {
 	/**
 	 * Data provider for test_validate_option.
 	 *
-	 * @return array The options.
+	 * @return array[] The options.
 	 */
 	public function validate_option_provider() {
 		return [


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

### Docs: remove redundant comment

No need to annotate minimum PHP version when it's below PHP 5.6, now that's the minimum version.

### Docs: add missing class constant docblock

### Docs: move comment to more appropriate place

### Docs: fix tag name

### Docs: fix expected case of tag

### Docs: fix tag order

### Docs: use short form types

### Docs: add missing parameter type

The function parameter can also be `null` (default).

### Docs: add missing return type

The function returns an explicit `null` in certain circumstances, so this should be documented as a valid return type.

### Docs: fix return tags

PHP has no concept of named return variables, so the name of the variable has no value in the `@return` tag.

### Docs: remove redundant/incorrect type

### Docs: `void` can not be combined with other types

`void` means the function returns nothing. This type cannot be combined with other types. It is an absolute.

If a function returns either something or nothing, this should be documented as `type|null` and functions calling this function should check the return value for type.

### Docs: null should be last when there are multiple types

### Docs: improve type specificity

### Docs: use FQN in docs



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.