### PR TITLE
Adapts the presenter interface changed made in Yoast SEO

### DIFF
--- a/classes/googlebot-news-presenter.php
+++ b/classes/googlebot-news-presenter.php
@@ -5,22 +5,20 @@
  * @package WPSEO_News
  */
 
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 
 /**
  * Represents the Googlebot-News tag presenter.
  */
-class WPSEO_News_Googlebot_News_Presenter {
+class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Presenter {
 
 	/**
 	 * Renders the Googlebot-News noindex tag when applicable.
 	 *
-	 * @param Indexable_Presentation $presentation Presentation to use.
-	 *
 	 * @return string The rendered meta tag.
 	 */
-	public function present( Indexable_Presentation $presentation ) {
-		if ( $presentation->model->object_type !== 'post' ) {
+	public function present() {
+		if ( $this->presentation->model->object_type !== 'post' ) {
 			return '';
 		}
 
@@ -38,8 +36,8 @@ class WPSEO_News_Googlebot_News_Presenter {
 		 */
 		do_action( 'Yoast\WP\News\head' );
 
-		if ( $this->display_noindex( $presentation->source ) ) {
-			return '<meta name="Googlebot-News" content="noindex" />' . PHP_EOL;
+		if ( $this->display_noindex( $this->presentation->source ) ) {
+			return '<meta name="Googlebot-News" content="noindex" />';
 		}
 
 		return '';

--- a/tests/googlebot-news-presenter-test.php
+++ b/tests/googlebot-news-presenter-test.php
@@ -10,6 +10,8 @@ use WPSEO_News_Googlebot_News_Presenter;
  * Test the WPSEO_News class.
  *
  * @coversDefaultClass WPSEO_News_Googlebot_News_Presenter
+ *
+ * @runTestsInSeparateProcesses
  */
 class Googlebot_News_Presenter_Test extends TestCase {
 
@@ -47,13 +49,16 @@ class Googlebot_News_Presenter_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		Mockery::mock( 'overload:\Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter' );
+
 		$this->instance     = new WPSEO_News_Googlebot_News_Presenter();
-		$this->presentation = Mockery::mock( 'Yoast\WP\SEO\Presentations\Indexable_Presentation' );
+		$this->presentation = Mockery::mock();
 		$this->model        = Mockery::mock();
 		$this->source       = Mockery::mock();
 
-		$this->presentation->model  = $this->model;
-		$this->presentation->source = $this->source;
+		$this->presentation->model    = $this->model;
+		$this->presentation->source   = $this->source;
+		$this->instance->presentation = $this->presentation;
 	}
 
 	/**
@@ -64,7 +69,7 @@ class Googlebot_News_Presenter_Test extends TestCase {
 	public function test_present_for_non_post() {
 		$this->model->object_type = 'term';
 
-		$this->assertSame( '', $this->instance->present( $this->presentation ) );
+		$this->assertSame( '', $this->instance->present() );
 	}
 
 	/**
@@ -109,7 +114,7 @@ class Googlebot_News_Presenter_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'Yoast\WP\News\head_display_noindex' )
 			->andReturn( true );
 
-		$this->assertSame( '', $this->instance->present( $this->presentation ) );
+		$this->assertSame( '', $this->instance->present() );
 	}
 
 	/**
@@ -148,7 +153,7 @@ class Googlebot_News_Presenter_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'Yoast\WP\News\head_display_noindex' )
 			->andReturn( false );
 
-		$this->assertSame( '', $this->instance->present( $this->presentation ) );
+		$this->assertSame( '', $this->instance->present() );
 	}
 
 	/**
@@ -193,6 +198,6 @@ class Googlebot_News_Presenter_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'Yoast\WP\News\head_display_noindex' )
 			->andReturn( true );
 
-		$this->assertSame( '<meta name="Googlebot-News" content="noindex" />' . PHP_EOL, $this->instance->present( $this->presentation ) );
+		$this->assertSame( '<meta name="Googlebot-News" content="noindex" />', $this->instance->present() );
 	}
 }

--- a/tests/news-test.php
+++ b/tests/news-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\News\Tests;
 
 use WPSEO_News;
-use Yoast\WP\News\Tests\TestCase;
 use Mockery;
 
 use function Brain\Monkey\Functions\expect;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There are changes made in the abstract interface (https://github.com/Yoast/wordpress-seo/pull/14706). This allows us to extend that interface, but it also needs a couple of change to make it work 100%.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It's a logic wise change.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Make sure the noindex tag is still outputted. 
* It should be rendered between the debug markers.

Fixes #
