### PR TITLE
Update travis matrix because of new WP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,13 @@ jobs:
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
     - php: 7.2
-      env: WP_VERSION=5.3 WP_MULTISITE=1 PHPCS=1 SECURITY=1 COVERAGE=1
+      env: WP_VERSION=5.4 WP_MULTISITE=1 PHPCS=1 SECURITY=1 COVERAGE=1
     - php: 5.6
-      env: WP_VERSION=5.2 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
+      env: WP_VERSION=5.3 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
       dist: trusty
     - php: 7.4
-      env: WP_VERSION=5.3 PHPLINT=1 PHPUNIT=1
+      env: WP_VERSION=5.4 PHPLINT=1 PHPUNIT=1
     - php: "nightly"
       env:  PHPLINT=1
     - stage: deploy-to-github-dist


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the Travis matrix to reflect the newest WP release. From now on, Travis will run against WordPress 5.4 and 5.3, instead of 5.3 and 5.2.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

Fixes #
