### PR TITLE
CS: no `use` statements for same namespace

### DIFF
--- a/tests/googlebot-news-presenter-test.php
+++ b/tests/googlebot-news-presenter-test.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\News\Tests;
 use Brain\Monkey;
 use Mockery;
 use WPSEO_News_Googlebot_News_Presenter;
-use Yoast\WP\News\Tests\TestCase;
 
 /**
  * Test the WPSEO_News class.

--- a/tests/news-test.php
+++ b/tests/news-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\News\Tests;
 
 use WPSEO_News;
-use Yoast\WP\News\Tests\TestCase;
 use Mockery;
 
 use function Brain\Monkey\Functions\expect;

--- a/tests/option-test.php
+++ b/tests/option-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\News\Tests;
 
 use Mockery;
-use Yoast\WP\News\Tests\TestCase;
 use Yoast\WP\News\Tests\Doubles\Option_Double;
 
 /**


### PR DESCRIPTION
## Context

* Code consistency

## Summary
This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

Import `use` statements for classes in the same namespace will not be allowed.

## Test instructions

This PR can be tested by following these steps:

* _N/A_