### PR TITLE
CS: don't use FQN in docblocks

### DIFF
--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -5,6 +5,8 @@
  * @package WPSEO_News
  */
 
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
+
 /**
  * Represents the news extension for Yoast SEO.
  */
@@ -61,9 +63,9 @@ class WPSEO_News {
 	/**
 	 * Adds the Google Bot News presenter.
 	 *
-	 * @param \Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter[] $presenters The presenter instances.
+	 * @param Abstract_Indexable_Presenter[] $presenters The presenter instances.
 	 *
-	 * @return \Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter[] The extended presenters.
+	 * @return Abstract_Indexable_Presenter[] The extended presenters.
 	 */
 	public function add_frontend_presenter( $presenters ) {
 		if ( ! is_array( $presenters ) ) {

--- a/integration-tests/admin-page-test.php
+++ b/integration-tests/admin-page-test.php
@@ -13,7 +13,7 @@ class WPSEO_News_Admin_Page_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Instance of the WPSEO_News_Admin_Page class.
 	 *
-	 * @var \WPSEO_News_Admin_Page
+	 * @var WPSEO_News_Admin_Page
 	 */
 	private $instance;
 

--- a/integration-tests/sitemap-images-test.php
+++ b/integration-tests/sitemap-images-test.php
@@ -15,7 +15,7 @@ class WPSEO_News_Sitemap_Images_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Instance of the WPSEO_News_Sitemap_Images class.
 	 *
-	 * @var \WPSEO_News_Sitemap_Images
+	 * @var WPSEO_News_Sitemap_Images
 	 */
 	protected $instance;
 

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -13,7 +13,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Instance of the WPSEO_News_Sitemap class.
 	 *
-	 * @var \WPSEO_News_Sitemap
+	 * @var WPSEO_News_Sitemap
 	 */
 	private $instance;
 

--- a/tests/googlebot-news-presenter-test.php
+++ b/tests/googlebot-news-presenter-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\News\Tests;
 
 use Brain\Monkey;
 use Mockery;
+use Mockery\MockInterface;
 use WPSEO_News_Googlebot_News_Presenter;
 use Yoast\WP\News\Tests\TestCase;
 
@@ -19,28 +20,28 @@ class Googlebot_News_Presenter_Test extends TestCase {
 	/**
 	 * Represents the instance to test.
 	 *
-	 * @var \WPSEO_News_Googlebot_News_Presenter
+	 * @var WPSEO_News_Googlebot_News_Presenter
 	 */
 	protected $instance;
 
 	/**
 	 * Represents the presentation.
 	 *
-	 * @var \Mockery\MockInterface
+	 * @var MockInterface
 	 */
 	protected $presentation;
 
 	/**
 	 * Represents the model (indexable).
 	 *
-	 * @var \Mockery\MockInterface
+	 * @var MockInterface
 	 */
 	protected $model;
 
 	/**
 	 * Represents the source.
 	 *
-	 * @var \Mockery\MockInterface
+	 * @var MockInterface
 	 */
 	protected $source;
 

--- a/tests/option-test.php
+++ b/tests/option-test.php
@@ -14,7 +14,7 @@ class Option_Test extends TestCase {
 	/**
 	 * The instance.
 	 *
-	 * @var \Yoast\WP\News\Tests\Doubles\Option_Double
+	 * @var Option_Double
 	 */
 	protected $instance;
 


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

Use unqualified names instead.

If the file is namespaced and the docblock comment involves a class from another namespace and no `use` statement is in place yet, add an import `use` statement.

Note: PHPUnit `@covers` tags *should* still be fully qualified (PHPUnit requirement)

## Test instructions

This PR can be tested by following these steps:

* _N/A_