### PR TITLE
Added get method to WPSEO_News_Googlebot_News_Presenter

### DIFF
--- a/classes/googlebot-news-presenter.php
+++ b/classes/googlebot-news-presenter.php
@@ -46,10 +46,10 @@ class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Presenter {
 	/**
 	 * This method is not used, but required to fulfil the abstract class interface.
 	 *
-	 * @return string|array The raw value.
+	 * @return string The raw value.
 	 */
 	public function get() {
-		return "";
+		return '';
 	}
 
 	/**

--- a/classes/googlebot-news-presenter.php
+++ b/classes/googlebot-news-presenter.php
@@ -44,6 +44,15 @@ class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Presenter {
 	}
 
 	/**
+	 * This method is not used, but required to fulfil the abstract class interface.
+	 *
+	 * @return string|array The raw value.
+	 */
+	public function get() {
+		return "";
+	}
+
+	/**
 	 * Shows the meta-tag with noindex when it has been decided to exclude the post from Google News.
 	 *
 	 * @see https://support.google.com/news/publisher/answer/93977?hl=en


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes sure Yoast SEO News is compatible with the latest Yoast SEO.

## Relevant technical choices:

* Added a `get` function to `WPSEO_News_Googlebot_News_Presenter` to make it compatible with `Abstract_Indexable_Presenter`.

## Test instructions

This PR can be tested by following these steps:

* Create a new post.
* Make sure the editor doesn't crash.
* In the metabox, set `Google News` -> `Googlebot-News index` to `noindex`.
* Publish the post, and on the front end make sure the `Googlebot-News` meta value is set to `noindex`.

Fixes #
