### PR TITLE
Set minimum WP version to 5.4 and tested up to to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,13 @@ jobs:
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
     - php: 7.2
-      env: WP_VERSION=5.4 WP_MULTISITE=1 PHPCS=1 SECURITY=1 COVERAGE=1
+      env: WP_VERSION=latest WP_MULTISITE=1 PHPCS=1 SECURITY=1 COVERAGE=1
     - php: 5.6
-      env: WP_VERSION=5.3 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
+      env: WP_VERSION=5.4 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
       dist: trusty
     - php: 7.4
-      env: WP_VERSION=5.4 PHPLINT=1 PHPUNIT=1
+      env: WP_VERSION=latest PHPLINT=1 PHPUNIT=1
     - php: "nightly"
       env:  PHPLINT=1
     - stage: deploy-to-github-dist

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Yoast News SEO for Yoast SEO
 ==========================
-Requires at least: 5.2
-Tested up to: 5.4
+Requires at least: 5.4
+Tested up to: 5.5
 Stable tag: 12.5
 Requires PHP: 5.6.20
 Depends: Yoast SEO

--- a/integration-tests/wpseo-news-test.php
+++ b/integration-tests/wpseo-news-test.php
@@ -51,11 +51,11 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 	public function check_dependencies_data() {
 		return [
 			[ false, '12.7', '3.0', 'WordPress is below the minimal required version.' ],
-			[ false, '12.7', '5.2', 'WordPress is below the minimal required version.' ],
+			[ false, '12.7', '5.3', 'WordPress is below the minimal required version.' ],
 			[ false, false, '5.3', 'WordPress SEO is not installed.' ],
 			[ false, '8.1', '5.3', 'WordPress SEO is below the minimal required version.' ],
-			[ true, '14.0-RC0', '5.4', 'WordPress (5.4) and WordPress SEO have the minimal required versions.' ],
-			[ true, '14.0', '5.3', 'WordPress (5.3) and WordPress SEO have the minimal required versions.' ],
+			[ true, '14.0-RC0', '5.5', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '14.0', '5.4', 'WordPress and WordPress SEO have the minimal required versions.' ],
 		];
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On August 11, WordPress 5.5 will be released. Because we always support the 2 latest versions, the minimum supported version needs to be updated to 5.4.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Set minimum supported WordPress version to 5.4.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

Fixes #
