### PR TITLE
Enables tracking on plugin activation.

### DIFF
--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -76,6 +76,8 @@ function yoast_wpseo_news_clear_sitemap_cache() {
  * Clear the news sitemap when we activate the plugin.
  */
 function yoast_wpseo_news_activate() {
+	// Enable tracking.
+	WPSEO_Options::set( 'tracking', true );
 	yoast_wpseo_news_clear_sitemap_cache();
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enables tracking when activating the plugin. It can be disabled in the Yoast SEO configuration wizard.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

 * Make sure that the plugin is deactivated.
 * Make sure that you have tracking disabled.
   * You can do this in the Yoast SEO configuration wizard.
      * Go to the Yoast SEO admin dashboard (click on _SEO_ in the admin sidebar menu).
      * Click on the link titled _reopen the configuration wizard_.
      * Open step 7 (_Help us improve Yoast SEO_).
      * Select _No, I don't want to allow you to track my site data_.
 * In your site's database, check the `wpseo` option in the `wp-options` table.
   * Its `tracking` parameter in the serialized `option_value` should be set to `0` (no tracking).
   * [You can use an online deserializer to check the contents more easily](https://www.unserialize.com/).
 * Activate the plugin.
 * Check the `wpseo` option in your database again.
   * Its `tracking` parameter should be set to `1` (tracking).

Fixes [P2-199](https://yoast.atlassian.net/browse/P2-199)
