### PR TITLE
P1 113 Page does not output NewsArticle

### DIFF
--- a/classes/schema.php
+++ b/classes/schema.php
@@ -59,7 +59,7 @@ class WPSEO_News_Schema {
 			// Change the `@type` to `NewsArticle` only when the news article is not excluded.
 			if ( ! $this->is_post_excluded( $post ) ) {
 				// Make sure that we are dealing with an array of types.
-				if ( ! is_array( $data['@type'] ) ) {
+				if ( array_key_exists( '@type', $data ) && ! is_array( $data['@type'] ) ) {
 					$data['@type'] = [ $data['@type'] ];
 				}
 				$data['@type'][] = 'NewsArticle';

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -58,7 +58,11 @@ class WPSEO_News_Schema {
 		if ( $post !== null && in_array( $post->post_type, WPSEO_News::get_included_post_types(), true ) ) {
 			// Change the `@type` to `NewsArticle` only when the news article is not excluded.
 			if ( ! $this->is_post_excluded( $post ) ) {
-				$data['@type'] = 'NewsArticle';
+				// Make sure that we are dealing with an array of types.
+				if ( ! is_array( $data['@type'] ) ) {
+					$data['@type'] = [ $data['@type'] ];
+				}
+				$data['@type'][] = 'NewsArticle';
 			}
 
 			$data['copyrightYear']   = $this->date->format( $post->post_date_gmt, 'Y' );

--- a/integration-tests/schema-test.php
+++ b/integration-tests/schema-test.php
@@ -103,7 +103,7 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 			->method( 'get_post' );
 
 		$expected = [
-			'@type'           => 'NewsArticle',
+			'@type'           => [ 'NewsArticle' ],
 			'copyrightYear'   => $this->date->format( 'Y' ),
 			'copyrightHolder' => [
 				'@id' => 'http://example.org/#organization',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* WPSEO News should output `NewsArticle` for all posts / pages / terms where it is enabled.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the schema article type would be overwritten instead of added to.

## Relevant technical choices:

* We need to check whether the types object is an array, if not, we convert it to one and add `NewsArticle` to it.

## Test instructions

This PR can be tested by following these steps:

* Install latest WordPress SEO and WPSEO News
* Enable WPSEO News
* Make sure that you have a valid `Knowledge graph & Schema.org` section.
![image](https://user-images.githubusercontent.com/8782235/89864776-d86b7400-dbac-11ea-8463-ec1341b71ff2.png)
* Enable News SEO for the type you want to test (i.e. Pages)
* Make sure that the output contains `NewsArticle`.
* If you overwrite the default Article Type (`Article`) with something else (i.e. `ScholaryArticle`) the output should contain an array with `Article`, `ScholaryArticle` and `NewsArticle`.

Fixes P1-113
