### PR TITLE
[QAK-2167] Check if WPSEO_Options exists before calling one of its methods

### DIFF
--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -77,7 +77,10 @@ function yoast_wpseo_news_clear_sitemap_cache() {
  */
 function yoast_wpseo_news_activate() {
 	// Enable tracking.
-	WPSEO_Options::set( 'tracking', true );
+	if ( class_exists( 'WPSEO_Options' ) && method_exists( 'WPSEO_Options', 'set' ) ) {
+		WPSEO_Options::set( 'tracking', true );
+	}
+
 	yoast_wpseo_news_clear_sitemap_cache();
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error would be thrown when News SEO would be activated when Yoast SEO (Premium) was not activated.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Deactivate News SEO
* Deactivate Yoast SEO (premium)
* Activate News SEO
* See no fatal error
* Check that tracking is still activated.

Fixes https://yoast.atlassian.net/browse/QAK-2167
