### PR TITLE
Introduce `composer cs` command

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -60,6 +60,26 @@
 	#############################################################################
 	-->
 
+	<rule ref="Yoast.NamingConventions.NamespaceName">
+		<properties>
+			<!-- Indicate which directories should be treated as project root directories for
+				 path-to-namespace translations. -->
+			<property name="src_directory" type="array">
+				<element value="config"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Composer scripts are not WordPress and have console output. -->
+	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
+		<exclude-pattern>/config/composer/*</exclude-pattern>
+	</rule>
+
+	<!-- Composer scripts are allowed to call system functions. -->
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<exclude-pattern>/config/composer/*</exclude-pattern>
+	</rule>
+
 	<!-- Verify that all gettext calls use the correct text domain. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -70,16 +70,6 @@
 		</properties>
 	</rule>
 
-	<!-- Composer scripts are not WordPress and have console output. -->
-	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
-		<exclude-pattern>/config/composer/*</exclude-pattern>
-	</rule>
-
-	<!-- Composer scripts are allowed to call system functions. -->
-	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
-		<exclude-pattern>/config/composer/*</exclude-pattern>
-	</rule>
-
 	<!-- Verify that all gettext calls use the correct text domain. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
@@ -126,6 +116,16 @@
 	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
 	#############################################################################
 	-->
+
+	<!-- Composer scripts are not WordPress and have console output. -->
+	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
+		<exclude-pattern>/config/composer/*</exclude-pattern>
+	</rule>
+
+	<!-- Composer scripts are allowed to call system functions. -->
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<exclude-pattern>/config/composer/*</exclude-pattern>
+	</rule>
 
 	<!-- Allow for the double/mock classes to override methods just to change the visibility. -->
 	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
         ],
         "check-staged-cs": [
-            "@check-cs-warnings --filter=GitStaged"
+            "@check-cs --filter=GitStaged"
         ],
         "check-branch-cs": [
             "Yoast\\WP\\News\\Composer\\Actions::check_branch_cs"

--- a/composer.json
+++ b/composer.json
@@ -36,19 +36,25 @@
     "autoload-dev": {
         "classmap": [
             "integration-tests/",
-            "tests/"
+            "tests/",
+            "config/"
         ]
     },
     "scripts": {
         "lint": [
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude node_modules --exclude .git"
         ],
-        "config-yoastcs": [
-            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
+        "cs": [
+            "Yoast\\WP\\News\\Composer\\Actions::check_coding_standards"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set ignore_warnings_on_exit 1"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+        ],
+        "check-staged-cs": [
+            "@check-cs-warnings --filter=GitStaged"
+        ],
+        "check-branch-cs": [
+            "Yoast\\WP\\News\\Composer\\Actions::check_branch_cs"
         ],
         "fix-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -94,7 +94,7 @@ class Actions {
 			return 0;
 		}
 
-		\system( 'composer check-cs-warnings -- ' . \implode( ' ', \array_map( 'escapeshellarg', $php_files ) ), $exit_code );
+		\system( 'composer check-cs -- ' . \implode( ' ', \array_map( 'escapeshellarg', $php_files ) ), $exit_code );
 		return $exit_code;
 	}
 

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Yoast\WP\News\Composer;
+
+use Composer\Script\Event;
+
+/**
+ * Class to handle Composer actions and events.
+ */
+class Actions {
+
+	/**
+	 * Provides a coding standards option choice.
+	 *
+	 * @param Event $event Composer event.
+	 */
+	public static function check_coding_standards( Event $event ) {
+		$io = $event->getIO();
+
+		$choices = [
+			'1' => [
+				'label'   => 'Check staged files for coding standard warnings & errors.',
+				'command' => 'check-staged-cs',
+			],
+			'2' => [
+				'label'   => 'Check current branch\'s changed files for coding standard warnings & errors.',
+				'command' => 'check-branch-cs',
+			],
+			'3' => [
+				'label'   => 'Check for all coding standard errors.',
+				'command' => 'check-cs',
+			],
+			'4' => [
+				'label'   => 'Fix auto-fixable coding standards.',
+				'command' => 'fix-cs',
+			],
+		];
+
+		$args = $event->getArguments();
+		if ( empty( $args ) ) {
+			foreach ( $choices as $choice => $data ) {
+				$io->write( \sprintf( '%d. %s', $choice, $data['label'] ) );
+			}
+
+			$choice = $io->ask( 'What do you want to do? ' );
+		}
+		else {
+			$choice = $args[0];
+		}
+
+		if ( isset( $choices[ $choice ] ) ) {
+			$event_dispatcher = $event->getComposer()->getEventDispatcher();
+			$event_dispatcher->dispatchScript( $choices[ $choice ]['command'] );
+		}
+		else {
+			$io->write( 'Unknown choice.' );
+		}
+	}
+
+	/**
+	 * Runs PHPCS on the staged files.
+	 *
+	 * Used the composer check-staged-cs command.
+	 *
+	 * @param Event $event Composer event that triggered this script.
+	 *
+	 * @return void
+	 */
+	public static function check_branch_cs( Event $event ) {
+		$branch = 'trunk';
+
+		$args = $event->getArguments();
+		if ( ! empty( $args ) ) {
+			$branch = $args[0];
+		}
+
+		exit( self::check_cs_for_changed_files( $branch ) );
+	}
+
+	/**
+	 * Runs PHPCS on changed files compared to some git reference.
+	 *
+	 * @param string $compare The git reference.
+	 *
+	 * @return int Exit code passed from the coding standards check.
+	 */
+	private static function check_cs_for_changed_files( $compare ) {
+		\exec( 'git diff --name-only --diff-filter=d ' . \escapeshellarg( $compare ), $files );
+
+		$php_files = self::filter_files( $files, '.php' );
+		if ( empty( $php_files ) ) {
+			echo 'No files to compare! Exiting.' . PHP_EOL;
+
+			return 0;
+		}
+
+		\system( 'composer check-cs-warnings -- ' . \implode( ' ', \array_map( 'escapeshellarg', $php_files ) ), $exit_code );
+		return $exit_code;
+	}
+
+	/**
+	 * Filter files on extension.
+	 *
+	 * @param array  $files     List of files.
+	 * @param string $extension Extension to filter on.
+	 *
+	 * @return array Filtered list of files.
+	 */
+	private static function filter_files( $files, $extension ) {
+		return \array_filter(
+			$files,
+			function( $file ) use ( $extension ) {
+				return \substr( $file, ( 0 - \strlen( $extension ) ) ) === $extension;
+			}
+		);
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Introduces the `composer cs` command; as also present in Yoast SEO

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Tooling: introduces the `composer cs` command

## Relevant technical choices:

* Adjusted CS configuration to handle the config folder; inspired on Yoast SEO
* Created a config directory
* Removed the `yoast-configcs` command; which is no longer needed

## Test instructions

This PR can be tested by following these steps:

* Run `composer install`
* Run `composer cs` and get a menu to pick which check you want to perform
* Perform any of the menu options and see them working as expected

Fixes #
