### PR TITLE
Unit Tests: make the testsuite compatible with PHPUnit 9 and test against PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ phpunit.xml
 phpcs.xml
 .phpcs.xml
 .cache/phpcs.cache
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - php: 7.4
       env: WP_VERSION=latest PHPLINT=1 PHPUNIT=1
     - php: "nightly"
-      env:  PHPLINT=1
+      env: PHPLINT=1
     - stage: deploy-to-github-dist
       env: WP_VERSION=latest
       if: tag IS present
@@ -77,17 +77,17 @@ before_install:
 
 install:
 - |
-  if [[ $TRAVIS_PHP_VERSION == "nightly" && "$PHPLINT" == "1" ]]; then
-    composer install --no-interaction --ignore-platform-reqs
+  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    travis_retry composer install --no-interaction --ignore-platform-reqs
   elif [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" || "$COVERAGE" == "1" || "$PHPLINT" == "1" ]]; then
-    composer install --no-interaction
+    travis_retry composer install --no-interaction
   elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "deploy-to-github-dist" ]]; then
-    composer install --no-dev --no-interaction
+    travis_retry composer install --no-dev --no-interaction
   fi
 - |
   if [[ "$COVERAGE" == "1" ]]; then
     # Install phpcov so we can combine the coverage results of unit and integration tests.
-    composer require phpunit/phpcov ^3.1
+    travis_retry composer require phpunit/phpcov ^3.1
   fi
 - if [[ "$SECURITY" == "1" ]]; then wget -P $SECURITYCHECK_DIR https://get.sensiolabs.org/security-checker.phar && chmod +x $SECURITYCHECK_DIR/security-checker.phar;fi
 
@@ -125,7 +125,7 @@ before_script:
   if [[ "$PHPUNIT" == "1" || "$COVERAGE" == "1" ]]; then
     git clone --depth=1 --branch="trunk" https://github.com/Yoast-dist/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
     cd /tmp/wordpress/src/wp-content/plugins/wordpress-seo
-    composer install --no-dev --no-scripts --no-interaction --ignore-platform-reqs
+    travis_retry composer install --no-dev --no-scripts --no-interaction --ignore-platform-reqs
     cd -
   fi
 
@@ -177,6 +177,13 @@ script:
 - |
   if [[ "$PHPUNIT" == "1" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
+    composer test
+    travis_time_finish && travis_fold end "PHP.tests"
+  fi
+- |
+  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    travis_fold start "PHP.tests" && travis_time_start
+    travis_retry composer update yoast/wp-test-utils --with-dependencies --ignore-platform-reqs --no-interaction &&
     composer test
     travis_time_finish && travis_fold end "PHP.tests"
   fi

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,9 @@
     },
     "require-dev": {
         "yoast/yoastcs": "^2.1.0",
-        "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
-        "brain/monkey": "^2.5",
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
-        "php-parallel-lint/php-console-highlighter": "^0.5"
+        "php-parallel-lint/php-console-highlighter": "^0.5",
+        "yoast/wp-test-utils": "^0.1.0"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd375f45adf454734feb85852dc9cffd",
+    "content-hash": "f8da6bc47c4ffe58d8f91526196a66fc",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -895,38 +895,38 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -954,7 +954,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1914,16 +1914,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.13.1",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/aed596913b70fae57be53d86faa2e9ef85a2297b",
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b",
                 "shasum": ""
             },
             "require": {
@@ -1935,7 +1935,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-main": "1.19-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -1968,20 +1972,34 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T09:01:57+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.27",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996"
+                "reference": "88289caa3c166321883f67fe5130188ebbb47094"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/212a27b731e5bfb735679d1ffaac82bd6a1dc996",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/88289caa3c166321883f67fe5130188ebbb47094",
+                "reference": "88289caa3c166321883f67fe5130188ebbb47094",
                 "shasum": ""
             },
             "require": {
@@ -1998,11 +2016,6 @@
                 "symfony/console": "For validating YAML files using the lint command"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
@@ -2027,36 +2040,48 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-25T07:48:46+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
+                "php": "^5.3.3 || ^7.0 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -2078,7 +2103,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2020-07-08T17:02:28+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2125,6 +2150,127 @@
                 "wordpress"
             ],
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "cf3da76ae146f28050a7c4c879634c8b4c26d3d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/cf3da76ae146f28050a7c4c879634c8b4c26d3d7",
+                "reference": "cf3da76ae146f28050a7c4c879634c8b4c26d3d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "yoast/yoastcs": "^2.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "time": "2020-10-26T10:59:22+00:00"
+        },
+        {
+            "name": "yoast/wp-test-utils",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/wp-test-utils.git",
+                "reference": "e918d919800175f0a2489ed1631844831653836b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/e918d919800175f0a2489ed1631844831653836b",
+                "reference": "e918d919800175f0a2489ed1631844831653836b",
+                "shasum": ""
+            },
+            "require": {
+                "brain/monkey": "^2.5.0",
+                "php": ">=5.6",
+                "yoast/phpunit-polyfills": "^0.1.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/wp-test-utils/graphs/contributors"
+                }
+            ],
+            "description": "PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress",
+            "homepage": "https://github.com/Yoast/wp-test-utils/",
+            "keywords": [
+                "brainmonkey",
+                "integration-testing",
+                "phpunit",
+                "unit-testing",
+                "wordpress"
+            ],
+            "time": "2020-11-13T12:03:02+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
 		convertErrorsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"
+		forceCoversAnnotation="true"
 		processIsolation="false"
 		stopOnError="false"
 		stopOnFailure="false"
@@ -23,7 +24,7 @@
 	</testsuites>
 
 	<filter>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
 			<directory>./classes</directory>
 			<file>./wpseo-news.php</file>
 		</whitelist>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,28 +5,12 @@
  * @package WPSEO/WooCommerce/Tests
  */
 
-define( 'ABSPATH', true );
 define( 'WPSEO_INDEXABLES', true );
-
-define( 'MINUTE_IN_SECONDS', 60 );
-define( 'HOUR_IN_SECONDS', 3600 );
-define( 'DAY_IN_SECONDS', 86400 );
-define( 'WEEK_IN_SECONDS', 604800 );
-define( 'MONTH_IN_SECONDS', 2592000 );
-define( 'YEAR_IN_SECONDS', 31536000 );
-
-define( 'DB_HOST', 'nowhere' );
-define( 'DB_NAME', 'none' );
-define( 'DB_USER', 'nobody' );
-define( 'DB_PASSWORD', 'nothing' );
-
-if ( function_exists( 'opcache_reset' ) ) {
-	opcache_reset();
-}
 
 if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;
 	exit( 1 );
 }
 
+require_once __DIR__ . '/../vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/googlebot-news-presenter-test.php
+++ b/tests/googlebot-news-presenter-test.php
@@ -47,8 +47,8 @@ class Googlebot_News_Presenter_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		Mockery::mock( 'overload:\Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter' );
 

--- a/tests/option-test.php
+++ b/tests/option-test.php
@@ -20,8 +20,8 @@ class Option_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$external_mock              = Mockery::mock( 'overload:\WPSEO_Option' );
 		$external_mock->option_name = 'wpseo_news';

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -4,46 +4,25 @@ namespace Yoast\WP\News\Tests;
 
 use Brain\Monkey;
 use Mockery;
-use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
+use Yoast\WPTestUtils\BrainMonkey\YoastTestCase;
 
 /**
  * TestCase base class.
  */
-abstract class TestCase extends PHPUnit_TestCase {
+abstract class TestCase extends YoastTestCase {
 
 	/**
 	 * Test setup.
 	 */
-	protected function setUp() {
+	protected function set_up() {
+		parent::set_up();
 
-		parent::setUp();
-		Monkey\setUp();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
 
 		Monkey\Functions\stubs(
 			[
-				// Passing "null" makes the function return it's first argument.
-				'esc_attr'       => null,
-				'esc_html'       => null,
-				'esc_textarea'   => null,
-				'__'             => null,
-				'_x'             => null,
-				'esc_html__'     => null,
-				'esc_html_x'     => null,
-				'esc_attr_x'     => null,
 				'is_admin'       => false,
-				'is_multisite'   => false,
-				'site_url'       => 'https://www.example.org',
-				'wp_json_encode' => static function( $data, $options = 0, $depth = 512 ) {
-					// phpcs:ignore Yoast.Yoast.AlternativeFunctions -- Mocks the wp_json_encode function.
-					return \json_encode( $data, $options, $depth );
-				},
-				'wp_slash'       => null,
-				'absint'         => static function( $value ) {
-					return \abs( \intval( $value ) );
-				},
-				'wp_parse_args'  => static function ( $settings, $defaults ) {
-					return \array_merge( $defaults, $settings );
-				},
 			]
 		);
 
@@ -56,13 +35,5 @@ abstract class TestCase extends PHPUnit_TestCase {
 			->zeroOrMoreTimes()
 			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
 			->andReturn( [] );
-	}
-
-	/**
-	 * Test tear down.
-	 */
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
 	}
 }

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -17,9 +17,6 @@ abstract class TestCase extends YoastTestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->stubEscapeFunctions();
-		$this->stubTranslationFunctions();
-
 		Monkey\Functions\stubs(
 			[
 				'is_admin'       => false,


### PR DESCRIPTION
## Context

* Preparation for compatibility with PHP 8

## Summary

This PR can be summarized in the following changelog entry:

* Preparation for compatibility with PHP 8

## Relevant technical choices:

### Composer: require Yoast/wp-test-utils

* Adds a dev dependency to the `yoast/wp-test-utils` package, which will also  make the PHPUnit Polyfills available.
* As that package already requires and manages the installable versions for  BrainMonkey and PHPUnit, remove these as explicit requirements from `require- dev` in favour of letting the WP Test Utils package manage the versions.

The install is done based on PHP 5.6 and includes updating the dependencies  from PHPUnit itself within the constraints of maintaining compatibility with  PHP 5.6.

This new package adds the following features:
* Polyfills for various PHPUnit cross-version changes.
* Basic test cases for use by the plugins.

Refs:
* https://github.com/Yoast/wp-test-utils
* https://github.com/Yoast/PHPUnit-Polyfills/

### Tests: use the bootstrap file from WP Test Utils

... and remove everything which is already done within that file.

### Tests: switch over to the Yoast\WPTestUtils\BrainMonkey\YoastTestCase

All test classes for the BrainMonkey based unit tests in the NewsSEO test suite have a NewsSEO native `TestCase` as a parent class.

This switches the parent of that `TestCase` from the PHPUnit native TestCase to the `Yoast\WPTestUtils\BrainMonkey\YoastTestCase`.

The `YoastTestCase`:
* Inherits PHPUnit cross-version compatibility from the PHPUnit Polyfills TestCase.
* Inherits the BrainMonkey set up and teardown and Mockery expectation counting as assertions from the BrainMonkey TestCase.
* And natively adds a number of stubs for commonly used WP functions.

This switch over includes:
* Removing the addition of function stubs which are already added via the `YoastTestCase` class.
* Removing the `tearDown()` method. This will be inherited from the `YoastTestCase` now.
* Renaming the `setUp()` method to `set_up()` in various test classes for PHPUnit cross-version compatibility.

### TestCase: remove the generic stubbing of the translation and escaping functions

Turns out that none of the (current) tests need these stubs, so we may as well not load them.

### Travis: run the unit tests against PHP 8/nightly

Now the BrainMonkey based tests are fully compatible with PHPUnit 9, the test suite can be run on PHP 8.

However, as the integration tests are not (yet) compatible with PHPUnit > 5.7, we need to add a separate condition block to the `script` section.

In this block, we run a `composer update` for just and only the test dependencies on PHP 8 to make sure that the test dependencies available are compatible with PHP 8.
And as the `composer.json` contains a hard-coded `platform.php` setting, we use `ignore-platform-reqs`  to get round that setting.

Includes:
* Adding `travis_retry` to `composer install`-like commands to get round builds stalling on the connection with Packagist, especially on older PHP versions.
* Adding the PHPUnit cache file which is generated when using PHPUnit 8/9 to `.gitignore`.

### PHPUnit config: minor tweaks

* Improve the code coverage configuration:
    - Add `addUncoveredFilesFromWhitelist` and  `processUncoveredFilesFromWhitelist` directives with sensible values.
    - Add the `forceCoversAnnotation` attribute to only record code coverage for the method under test as annotated via a `@covers` annotation.

Based on this configuration, the strict code coverage for the BrainMonkey based unit testsuite alone is currently **7.11%**.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the output of all builds for this PR, making sure that 1) the installation via Composer works without issues, 2) the tests are being run and 3) the tests pass.

To test locally, it will be simplest to:
1. Run `composer install`.
2. Run `composer test` on any PHP version below 8.0 and see the tests pass, including a more accurate assertion count (48 compared to 10 previously, due to Mockery expectations now being counted).
    This confirms that the changes to the `TestCase` works correctly cross-version as the PHPUnit version installed based on the `composer.lock` file will be PHPUnit 5.7.27.
3. Switch to PHP 8.
4. Run `composer update yoast/wp-test-utils --with-dependencies --ignore-platform-reqs`
5. Run `composer test` to see the tests running and passing on PHP 8 in combination with PHPUnit 9.x.
    This confirms that the tests can now run cross-version on all PHPUnit versions between PHPUnit 5.7 and PHPUnit 9.x and that the tests run and pass on PHP 8.

Note: this doesn't confirm full PHP 8 compatibility yet as the test code coverage base on the BrainMonkey based tests alone, as noted above, is only ~7%.

