### PR TITLE
Convert visible URLs to https

### DIFF
--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -75,10 +75,10 @@ class WPSEO_News_Admin_Page {
 				'project_slug'   => 'news-seo',
 				'plugin_name'    => 'WordPress SEO News',
 				'hook'           => 'wpseo_admin_promo_footer',
-				'glotpress_url'  => 'http://translate.yoast.com/gp/',
+				'glotpress_url'  => 'https://translate.yoast.com/gp/',
 				'glotpress_name' => 'Yoast Translate',
-				'glotpress_logo' => 'http://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',
-				'register_url'   => 'http://translate.yoast.com/gp/projects#utm_source=plugin&utm_medium=promo-box&utm_campaign=wpseo-news-i18n-promo',
+				'glotpress_logo' => 'https://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',
+				'register_url'   => 'https://translate.yoast.com/register/#utm_source=plugin&utm_medium=promo-box&utm_campaign=wpseo-news-i18n-promo',
 			]
 		);
 	}

--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -10,7 +10,7 @@
  * Plugin URI:  https://yoast.com/wordpress/plugins/news-seo/#utm_source=wpadmin&utm_medium=plugin&utm_campaign=wpseonewsplugin
  * Description: Google News plugin for the Yoast SEO plugin
  * Author:      Team Yoast
- * Author URI:  http://yoast.com/
+ * Author URI:  https://yoast.com/
  * Text Domain: wordpress-seo-news
  * Domain Path: /languages/
  * Depends:     Yoast SEO


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevent mixed content warnings, needless redirections and improve security.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes "mixed content" warnings on the News SEO options page.

## Relevant technical choices:

* I changed the registration URL to point directly to the registration page.
* The `'glotpress_url'  => 'https://translate.yoast.com/gp/',` URL does not seem to be used. This URL itself goes to a 302 redirected page to `https://translate.yoast.com/gp/projects/`. I contemplated changing the complete URL like I did with the registration URL, but since I could not find it being used I did not see a direct impact by not changing this.
* All these URLs should probably get converted to `yoa.st` links at some point.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Change the language to Dutch or anything else except English;
1. Go to News SEO dashboard (SEO -> News SEO);
1. Confirm that the "Translation of WordPress SEO News" notification is showing.
1. Confirm all links in this notification still work.
1. Confirm that the browser is not mentioning "mixed content" warnings due to the image and links in this notification.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2533
