### PR TITLE
Integration Tests: make the testsuite x-version compatible and test against PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,12 @@ jobs:
     - php: 7.2
       env: WP_VERSION=latest WP_MULTISITE=1 PHPCS=1 SECURITY=1 COVERAGE=1
     - php: 5.6
-      env: WP_VERSION=5.4 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
+      env: WP_VERSION=5.5 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
       dist: trusty
     - php: 7.4
+      env: WP_VERSION=latest PHPLINT=1 PHPUNIT=1
+    - php: 8.0
       env: WP_VERSION=latest PHPLINT=1 PHPUNIT=1
     - php: "nightly"
       env: PHPLINT=1
@@ -77,7 +79,7 @@ before_install:
 
 install:
 - |
-  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+  if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_retry composer install --no-interaction --ignore-platform-reqs
   elif [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" || "$COVERAGE" == "1" || "$PHPLINT" == "1" ]]; then
     travis_retry composer install --no-interaction
@@ -167,22 +169,31 @@ script:
     travis_time_finish && travis_fold end "PHP.code-style"
   fi
 # PHP Integration Tests
+
 - |
-  if [[ "$PHPUNIT" == "1" ]]; then
+  if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
     travis_fold start "PHP.integration-tests" && travis_time_start
+    composer integration-test
+    travis_time_finish && travis_fold end "PHP.integration-tests"
+  fi
+- |
+  if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    travis_fold start "PHP.integration-tests" && travis_time_start
+    travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
     composer integration-test
     travis_time_finish && travis_fold end "PHP.integration-tests"
   fi
 # PHP Unit Tests
 - |
-  if [[ "$PHPUNIT" == "1" ]]; then
+  if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
     composer test
     travis_time_finish && travis_fold end "PHP.tests"
   fi
 - |
-  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+  if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
+    travis_retry composer remove --dev phpunit/phpunit --no-update &&
     travis_retry composer update yoast/wp-test-utils --with-dependencies --ignore-platform-reqs --no-interaction &&
     composer test
     travis_time_finish && travis_fold end "PHP.tests"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "yoast/yoastcs": "^2.1.0",
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "yoast/wp-test-utils": "^0.1.0"
+        "yoast/wp-test-utils": "^0.2.1"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8da6bc47c4ffe58d8f91526196a66fc",
+    "content-hash": "1c5739af444b02a5c346d81ab638a28c",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -99,16 +99,16 @@
         },
         {
             "name": "brain/monkey",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/BrainMonkey.git",
-                "reference": "f2295a57da59ff88621cd959dbdb4b288feefd19"
+                "reference": "7042140000b4b18034c0c0010d86274a00f25442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/f2295a57da59ff88621cd959dbdb4b288feefd19",
-                "reference": "f2295a57da59ff88621cd959dbdb4b288feefd19",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/7042140000b4b18034c0c0010d86274a00f25442",
+                "reference": "7042140000b4b18034c0c0010d86274a00f25442",
                 "shasum": ""
             },
             "require": {
@@ -161,7 +161,7 @@
                 "test",
                 "testing"
             ],
-            "time": "2020-10-09T06:55:33+00:00"
+            "time": "2020-10-13T17:56:14+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -1350,23 +1350,23 @@
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -1391,7 +1391,13 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1990,7 +1996,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.46",
+            "version": "v3.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -2153,26 +2159,26 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "cf3da76ae146f28050a7c4c879634c8b4c26d3d7"
+                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/cf3da76ae146f28050a7c4c879634c8b4c26d3d7",
-                "reference": "cf3da76ae146f28050a7c4c879634c8b4c26d3d7",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "php": ">=5.5",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^0.5",
                 "php-parallel-lint/php-parallel-lint": "^1.2.0",
-                "yoast/yoastcs": "^2.0.0"
+                "yoast/yoastcs": "^2.1.0"
             },
             "type": "library",
             "extra": {
@@ -2208,26 +2214,26 @@
                 "polyfill",
                 "testing"
             ],
-            "time": "2020-10-26T10:59:22+00:00"
+            "time": "2020-11-25T02:59:57+00:00"
         },
         {
             "name": "yoast/wp-test-utils",
-            "version": "0.1.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wp-test-utils.git",
-                "reference": "e918d919800175f0a2489ed1631844831653836b"
+                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/e918d919800175f0a2489ed1631844831653836b",
-                "reference": "e918d919800175f0a2489ed1631844831653836b",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/c5cdabd58f2aa6f2a93f734cf48125f880c90101",
+                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101",
                 "shasum": ""
             },
             "require": {
-                "brain/monkey": "^2.5.0",
+                "brain/monkey": "^2.6.0",
                 "php": ">=5.6",
-                "yoast/phpunit-polyfills": "^0.1.0"
+                "yoast/phpunit-polyfills": "^0.2.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^0.5",
@@ -2270,7 +2276,7 @@
                 "unit-testing",
                 "wordpress"
             ],
-            "time": "2020-11-13T12:03:02+00:00"
+            "time": "2020-12-09T15:26:02+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/integration-tests/admin-page-test.php
+++ b/integration-tests/admin-page-test.php
@@ -40,20 +40,13 @@ class WPSEO_News_Admin_Page_Test extends WPSEO_News_UnitTestCase {
 	 */
 	public function test_display() {
 
-		// Start buffering to get the output of display method.
-		ob_start();
-
-		$this->instance->display();
-
-		$output = ob_get_contents();
-		ob_end_clean();
-
 		// We expect this part in the generated HTML.
 		$expected_output = <<<'EOT'
 <p>You will generally only need a News Sitemap when your website is included in Google News.</p><p><a target="_blank" href="http://example.org/news-sitemap.xml">View your News Sitemap</a>.</p>
 EOT;
 
-		// Check if the $output contains the $expected_output.
-		$this->assertStringContainsString( $expected_output, $output );
+		$this->expectOutputContains( $expected_output );
+
+		$this->instance->display();
 	}
 }

--- a/integration-tests/admin-page-test.php
+++ b/integration-tests/admin-page-test.php
@@ -54,6 +54,6 @@ class WPSEO_News_Admin_Page_Test extends WPSEO_News_UnitTestCase {
 EOT;
 
 		// Check if the $output contains the $expected_output.
-		$this->assertContains( $expected_output, $output );
+		$this->assertStringContainsString( $expected_output, $output );
 	}
 }

--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -18,19 +18,53 @@ echo 'Version: 1.0' . PHP_EOL . PHP_EOL;
 if ( getenv( 'WP_PLUGIN_DIR' ) !== false ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 }
-
-$GLOBALS['wp_tests_options'] = [
-	'active_plugins' => [ 'wordpress-seo/wp-seo.php', 'wpseo-news/wpseo-news.php' ],
-];
+else {
+	define( 'WP_PLUGIN_DIR', dirname( dirname( __DIR__ ) ) );
+}
 
 require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+// Determine the WP_TEST_DIR.
+$_tests_dir = WPIntegration\get_path_to_wp_test_dir();
+
+// Give access to tests_add_filter() function.
+require_once rtrim( $_tests_dir, '/' ) . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ */
+$yoast_news_load_plugins = static function () {
+	require_once WP_PLUGIN_DIR . '/wordpress-seo/wp-seo.php';
+	require_once dirname( __DIR__ ) . '/wpseo-news.php';
+};
+
+/**
+ * Filter the plugins URL to pretend the plugin is installed in the test environment.
+ *
+ * @param string $url    The complete URL to the plugins directory including scheme and path.
+ * @param string $path   Path relative to the URL to the plugins directory. Blank string
+ *                       if no path is specified.
+ * @param string $plugin The plugin file path to be relative to. Blank string if no plugin
+ *                       is specified.
+ *
+ * @return string
+ */
+$yoast_news_filter_plugin_path = static function ( $url, $path, $plugin ) {
+	$plugin_dir = dirname( __DIR__ );
+	if ( $plugin === $plugin_dir . '/wpseo-news.php' ) {
+		$url = str_replace( dirname( $plugin_dir ), '', $url );
+	}
+
+	return $url;
+};
+
+// Add plugin to active mu-plugins - to make sure it gets loaded.
+tests_add_filter( 'muplugins_loaded', $yoast_news_load_plugins );
+
+// Overwrite the plugin URL to not include the full path.
+tests_add_filter( 'plugins_url', $yoast_news_filter_plugin_path, 10, 3 );
 
 /*
  * Load WordPress, which will load the Composer autoload file, and load the MockObject autoloader after that.
  */
 WPIntegration\bootstrap_it();
-
-if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/wpseo-news/wpseo-news.php' ) === false ) {
-	echo PHP_EOL, 'ERROR: Please check whether the WP_PLUGIN_DIR environment variable is set and set to the correct value. The unit test suite won\'t be able to run without it.', PHP_EOL;
-	exit( 1 );
-}

--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -5,6 +5,8 @@
  * @package WPSEO_News\Tests
  */
 
+use Yoast\WPTestUtils\WPIntegration;
+
 // Disable Xdebug backtrace.
 if ( function_exists( 'xdebug_disable' ) ) {
 	xdebug_disable();
@@ -12,10 +14,6 @@ if ( function_exists( 'xdebug_disable' ) ) {
 
 echo 'Welcome to the Yoast News SEO test suite' . PHP_EOL;
 echo 'Version: 1.0' . PHP_EOL . PHP_EOL;
-
-if ( getenv( 'WP_DEVELOP_DIR' ) !== false ) {
-	define( 'WP_DEVELOP_DIR', getenv( 'WP_DEVELOP_DIR' ) );
-}
 
 if ( getenv( 'WP_PLUGIN_DIR' ) !== false ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
@@ -25,32 +23,14 @@ $GLOBALS['wp_tests_options'] = [
 	'active_plugins' => [ 'wordpress-seo/wp-seo.php', 'wpseo-news/wpseo-news.php' ],
 ];
 
-if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
-	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;
-	exit( 1 );
-}
+require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 
-if ( defined( 'WP_DEVELOP_DIR' ) ) {
-	if ( file_exists( WP_DEVELOP_DIR . 'tests/phpunit/includes/bootstrap.php' ) ) {
-		require WP_DEVELOP_DIR . 'tests/phpunit/includes/bootstrap.php';
-	}
-	else {
-		echo PHP_EOL, 'ERROR: Please check the WP_DEVELOP_DIR environment variable. Based on the current value ', WP_DEVELOP_DIR, ' the WordPress native unit test bootstrap file could not be found.', PHP_EOL;
-		exit( 1 );
-	}
-}
-elseif ( file_exists( '../../../../tests/phpunit/includes/bootstrap.php' ) ) {
-	require '../../../../tests/phpunit/includes/bootstrap.php';
-}
-else {
-	echo PHP_EOL, 'ERROR: The WordPress native unit test bootstrap file could not be found. Please set the WP_DEVELOP_DIR environment variable either in your OS or in a custom phpunit.xml file.', PHP_EOL;
-	exit( 1 );
-}
+/*
+ * Load WordPress, which will load the Composer autoload file, and load the MockObject autoloader after that.
+ */
+WPIntegration\bootstrap_it();
 
 if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/wpseo-news/wpseo-news.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Please check whether the WP_PLUGIN_DIR environment variable is set and set to the correct value. The unit test suite won\'t be able to run without it.', PHP_EOL;
 	exit( 1 );
 }
-
-// Include unit test base class.
-require_once __DIR__ . '/framework/unittestcase.php';

--- a/integration-tests/framework/unittestcase.php
+++ b/integration-tests/framework/unittestcase.php
@@ -5,48 +5,12 @@
  * @package WPSEO_News\Tests
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * TestCase base class for convenience methods.
  */
-class WPSEO_News_UnitTestCase extends WP_UnitTestCase {
-
-	/**
-	 * Set up an HTTP post request.
-	 *
-	 * @param string $key   Array key.
-	 * @param mixed  $value Value.
-	 */
-	protected function set_post( $key, $value ) {
-		$_REQUEST[ $key ] = addslashes( $value );
-		$_POST[ $key ]    = $_REQUEST[ $key ];
-	}
-
-	/**
-	 * Unset an HTTP post request.
-	 *
-	 * @param string $key Array key.
-	 */
-	protected function unset_post( $key ) {
-		unset( $_POST[ $key ], $_REQUEST[ $key ] );
-	}
-
-	/**
-	 * Fake a request to the WP front page.
-	 */
-	protected function go_to_home() {
-		$this->go_to( home_url( '/' ) );
-	}
-
-	/**
-	 * Test expected output.
-	 *
-	 * @param string $string Expected output string.
-	 */
-	protected function expectOutput( $string ) {
-		$output = ob_get_contents();
-		ob_clean();
-		$this->assertSame( $output, $string );
-	}
+abstract class WPSEO_News_UnitTestCase extends TestCase {
 
 	/**
 	 * Call protected/private method of a class.

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -109,7 +109,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output .= '</url>';
 
 		// Check if the $output contains the $expected_output.
-		$this->assertContains( $expected_output, $output );
+		$this->assertStringContainsString( $expected_output, $output );
 	}
 
 	/**
@@ -155,7 +155,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output .= "\t</image:image>\n";
 
 		// Check if the $output contains the $expected_output.
-		$this->assertContains( $expected_output, $output );
+		$this->assertStringContainsString( $expected_output, $output );
 	}
 
 	/**
@@ -189,7 +189,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$expected_output .= "\t</image:image>\n";
 
 		// Check if the $output contains the $expected_output.
-		$this->assertContains( $expected_output, $output );
+		$this->assertStringContainsString( $expected_output, $output );
 	}
 
 	/**
@@ -261,10 +261,10 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$output = $this->instance->build_sitemap();
 
 		// Check if the $output contains the $expected_output.
-		$this->assertContains( "\t\t<news:title><![CDATA[Newest post]]></news:title>\n", $output );
-		$this->assertContains( "\t\t<news:title><![CDATA[New-ish post]]></news:title>\n", $output );
+		$this->assertStringContainsString( "\t\t<news:title><![CDATA[Newest post]]></news:title>\n", $output );
+		$this->assertStringContainsString( "\t\t<news:title><![CDATA[New-ish post]]></news:title>\n", $output );
 
-		$this->assertNotContains( "\t\t<news:title><![CDATA[Too old Post]]></news:title>\n", $output );
+		$this->assertStringNotContainsString( "\t\t<news:title><![CDATA[Too old Post]]></news:title>\n", $output );
 	}
 
 	/**

--- a/phpunit-integration.xml.dist
+++ b/phpunit-integration.xml.dist
@@ -9,6 +9,7 @@
 		convertErrorsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"
+		forceCoversAnnotation="true"
 		processIsolation="false"
 		stopOnError="false"
 		stopOnFailure="false"
@@ -23,7 +24,7 @@
 	</testsuites>
 
 	<filter>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
 			<directory>./classes</directory>
 			<file>./wpseo-news.php</file>
 		</whitelist>


### PR DESCRIPTION
## Context

* (Preparation for) compatibility with PHP 8

## Summary

This PR can be summarized in the following changelog entry:

* (Preparation for) compatibility with PHP 8

## Relevant technical choices:

:bulb: This PR will be easiest to review by going through the individual commits one by one.

### Composer: update Yoast/wp-test-utils to 0.2.0

A new version of the WP Test Utils package has been released which deals with the necessary work-arounds for the WP integration tests and adds utilities for this which individual plugins can use, like functions for the bootstrap and a `TestCase` which includes all the polyfills from the PHPUnit Polyfill repo.

The install is done based on PHP 5.6 (`config.platform.php` is set in the `composer.json` file).

Refs:
* https://github.com/Yoast/wp-test-utils/releases/tag/0.2.0

### WPSEO_News_UnitTestCase: switch parent class

This switches the parent class of the `WPSEO_News_UnitTestCase` to the WP Test Utils `Yoast\WPTestUtils\WPIntegration\TestCase`.

Includes:
* Removing the `expectOutput()` method.
    This method is not used in this test suite and shouldn't be needed anyway as PHPUnit has build-in `expectOutputString()` and `expectOutputRegex()` methods which should be used instead.
    Additionally, WP Test Utils contains an `expectOutputContains()` method to complement the PHPUnit native methods.
* Removing other methods which were unused in this test suite.
    This applies to all the other methods.

Lastly, this commit makes sure that the generic test case is declared as `abstract` as it doesn't contain any tests itself.

### Tests: use the bootstrap utilities from WP Test Utils

For integration tests, WP Test Utils contains a `bootstrap-functions.php` file with utility functions for a number of common patterns used in bootstrap files for WP integration tests.

As the order in which things get loaded is _**extremely**_ important for the integration tests, whenever possible, the `WPIntegration\bootstrap_it()` method should be used.

This method will:
- Verify that the Composer `autoload.php` file exists.
- Load WordPress.
    The location for WP can be configured by setting either the `WP_TESTS_DIR` or the `WP_DEVELOP_DIR` environment variable on an OS level or via a custom `phpunit.xml` file.
    If neither of these two environment variables is found, it is presumed that the plugin is installed in `src/wp-content/plugins/plugin-name`.
    _This is compatible with the old bootstrap setup and developers will not need to make any changes to their environment for this to work._
- While loading WordPress, the plugin will be loaded, including the Composer autoload file.
- And lastly, a custom autoloader will be added to handle the PHPUnit 7.x MockObject classes not being compatible with PHP 8.0.
    This custom autoloader will load the copies of the PHPUnit 9.x MockObject classes which are part of the WP native test suite as of WP 5.6 when PHP 8.x is detected, and will let the composer autoloader load the PHPUnit native versions when not on PHP 8.x.

If anything goes wrong during these steps, the WP Test Utils method will provide human readable error messages, similar to before.

### Tests: modernize used assertions

The PHPUnit Polyfills allows for using PHPUnit 9.x assertions, even when the tests are being run on older PHPUnit versions.

This updates select assertions to the modern PHPUnit syntax, most notably, it  switches out the following assertions:
* `assertContains()` with string haystacks for  `assertStringContainsString()`.

Note: the method calls switches over are based on tests run on PHPUnit 8/9 (don't ask how I did that) and only those assertions which _need_ to be switched over to prevent issues in the future, have been.

### Tests: use `expectOutputContains()`

WP Test Utils introduces a new `expectOutputContains()` method to complement the PHPUnit native `expectOutput*()` methods as it appears testing whether output contains a certain text string is a common pattern in the Yoast tests.

By default this method will ignore differences in line endings to improve the cross-OS compatibility of the tests.

This switches out the custom code to do the same in this test suite in favour of using the `expectOutputContains()` method instead.

### PHPUnit config: improve code coverage configuration

* Add `addUncoveredFilesFromWhitelist` and `processUncoveredFilesFromWhitelist` directives with sensible values.
* Add the `forceCoversAnnotation` attribute to only record code coverage for the method under test as annotated via a `@covers` annotation.

Based on this configuration, the strict code coverage for this testsuite is currently **13.34%**.

### Travis: run the tests against PHP 8.0

Now the test setup has been made compatible for allowing to run the tests on PHP 8 using PHPUnit 7.x, the integration tests can be run on PHP 8.0 in the CI runs.

However, there are still some things to take into account for running the tests on PHP 8.0:
1. The `composer.json` file contains a `config.platfom.php` setting which is set to PHP 5.6 and the repo has a committed `composer.lock` file which locks the PHPUnit version to PHPUnit 5.x.
2. WP hard limits their test suite to PHPUnit 7.x (max), which means the plugin integration tests need to be run on PHPUnit 7.x as well.
    However, PHPUnit 7.x is also _required_ for running the tests on PHP 8.0, PHPUnit 5.x won't work.
3. The BrainMonkey based tests, however, should be run on PHPUnit 9.3+, which is the first PHPUnit version officially compatible with PHP 8.0.

Other relevant information:
* Since this Friday, Travis now has a PHP 8.0 image available.
* Any PHP 8 related fixes have gone into WP 5.6. Running the integration tests against earlier WP versions is futile.

So, keeping all of that in mind, this commit:
* Adds a new build against PHP 8.0, with `WP_VERSION` set to WP `5.6` as released on Tuesday, and the `PHPUNIT` flag set to `1` (= on).
* In the `install` section: makes sure that the `composer install` with `--ignore-platform-reqs` is used for PHP 8.x as otherwise the install would fail due to PHPUnit 5.x (as per the lock file) not being allowed to be installed on PHP 8.
* In the `script` section:
    - Have a separate condition-based script for running the integration tests on PHP 8 (or `nightly`, though they currently won't be run against `nightly`).
    - Within that script **hard** require PHPUnit 7..x.
    - As the `PHPUNIT` flag has been added, the conditions for the BrainMonkey based unit tests are also adjusted.
        These tests are no longer run against `nightly`, but are run against `8.0` when the `PHPUNIT` flag is enabled.
    - Within the BrainMonkey PHP 8 script: remove the PHPUnit 7.x version which was required for the integration tests.
        This will then allow the `composer update` of the WP Test Utils (which was already in place) to install PHPUnit 9.x for running these tests.

Includes updating the matrix for the release of WP 5.6.

### Bootstrap: use a different pattern to load the plugins

This should hopefully prevent a double include of the Composer autoloader which led to fatal "Cannot redeclare composerRequire...." errors.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the output of all builds for this PR, making sure that 1) the installation via Composer works without issues, 2) the tests are being run, 3) the tests pass, 4) the BrainMonkey tests are being run and also pass.

To test locally, it will be simplest to:
1. Run `composer install`.
2. Run `composer integration-test` on any PHP version below 8.0 and see the tests pass.
    This confirms that the changes to the test bootstrap and the `TestCase` work correctly.
3. Switch to PHP 8.
4. Run `composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs`
5. If the `WP_PLUGIN_DIR` environment variable on your system points to a directory containing a dev copy WPSEO, run `composer install --no-dev --no-scripts --ignore-platform-reqs` in the WPSEO directory to make sure that the PHPUnit version from WPSEO won't interfere.
6. Run `composer integration-test` to see the tests running and passing on PHP 8 in combination with PHPUnit 7.x.
    This confirms that the tests can now run cross-version on all PHPUnit versions between PHPUnit 5.7 and PHPUnit 7.x and that the tests run and pass on PHP 8.

Note: this doesn't confirm full PHP 8 compatibility yet as the test code coverage of the BrainMonkey + integration tests combined, is nowhere near 100%.
