### PR TITLE
P1-299 remove genre settings

### DIFF
--- a/assets/xml-news-sitemap.xsl
+++ b/assets/xml-news-sitemap.xsl
@@ -81,7 +81,6 @@
 						<thead>
 							<tr>
 								<th width="55%">Title</th>
-								<th width="15%">Genre(s)</th>
 								<th width="15%"># Images</th>
 								<th width="15%">Publication Date</th>
 							</tr>
@@ -96,9 +95,6 @@
 										<a href="{$itemURL}">
 											<xsl:value-of select="n:news/n:title"/>
 										</a>
-									</td>
-									<td>
-										<xsl:value-of select="n:news/n:genres"/>
 									</td>
 									<td>
 										<xsl:value-of select="count(image:image)"/>

--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -44,13 +44,6 @@ class WPSEO_News_Admin_Page {
 		// Google News Publication Name.
 		Yoast_Form::get_instance()->textinput( 'news_sitemap_name', __( 'Google News Publication Name', 'wordpress-seo-news' ) );
 
-		// Default Genre.
-		Yoast_Form::get_instance()->select(
-			'news_sitemap_default_genre',
-			__( 'Default Genre', 'wordpress-seo-news' ),
-			WPSEO_News::list_genres()
-		);
-
 		echo '</fieldset>';
 
 		// Post Types to include in News Sitemap.

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -43,15 +43,6 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 				'title' => __( 'News Sitemap', 'wordpress-seo-news' ),
 				'expl'  => __( 'Exclude from News Sitemap', 'wordpress-seo-news' ),
 			],
-			'newssitemap-genre'        => [
-				'name'        => 'newssitemap-genre',
-				'type'        => 'multiselect',
-				'std'         => WPSEO_Options::get( 'news_sitemap_default_genre', 'blog' ),
-				'title'       => __( 'Google News Genre', 'wordpress-seo-news' ),
-				'description' => __( 'Genre to show in Google News Sitemap.', 'wordpress-seo-news' ),
-				'options'     => WPSEO_News::list_genres(),
-				'serialized'  => true,
-			],
 			'newssitemap-stocktickers' => [
 				'name'        => 'newssitemap-stocktickers',
 				'std'         => '',

--- a/classes/option.php
+++ b/classes/option.php
@@ -24,7 +24,6 @@ class WPSEO_News_Option extends WPSEO_Option {
 	 */
 	protected $defaults = [
 		'news_sitemap_name'               => '',
-		'news_sitemap_default_genre'      => '',
 		'news_version'                    => '0',
 		'news_sitemap_include_post_types' => [],
 		'news_sitemap_exclude_terms'      => [],
@@ -71,16 +70,6 @@ class WPSEO_News_Option extends WPSEO_Option {
 					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
 						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $dirty[ $key ] );
 					}
-					break;
-				case 'news_sitemap_default_genre':
-					if ( isset( $dirty[ $key ] ) && is_array( $dirty[ $key ] ) ) {
-						$clean[ $key ] = array_map( [ 'WPSEO_Utils', 'sanitize_text_field' ], $dirty[ $key ] );
-					}
-
-					if ( isset( $dirty[ $key ] ) && is_string( $dirty[ $key ] ) ) {
-						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $dirty[ $key ] );
-					}
-
 					break;
 
 				case 'news_sitemap_include_post_types':

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -116,17 +116,12 @@ class WPSEO_News_Sitemap_Item {
 	private function build_news_tag() {
 
 		$title         = $this->get_item_title( $this->item );
-		$genre         = $this->get_item_genre();
 		$stock_tickers = $this->get_item_stock_tickers( $this->item->ID );
 
 		$this->output .= "\t<news:news>\n";
 
 		// Build the publication tag.
 		$this->build_publication_tag();
-
-		if ( ! empty( $genre ) ) {
-			$this->output .= "\t\t<news:genres><![CDATA[" . $genre . ']]></news:genres>' . "\n";
-		}
 
 		$this->output .= "\t\t<news:publication_date>" . $this->get_publication_date( $this->item ) . '</news:publication_date>' . "\n";
 		$this->output .= "\t\t<news:title><![CDATA[" . $title . ']]></news:title>' . "\n";
@@ -165,27 +160,6 @@ class WPSEO_News_Sitemap_Item {
 		}
 
 		return $item->post_title;
-	}
-
-	/**
-	 * Getting the genre for given $item_id.
-	 *
-	 * @return string
-	 */
-	private function get_item_genre() {
-		$genre = WPSEO_Meta::get_value( 'newssitemap-genre', $this->item->ID );
-		if ( is_array( $genre ) ) {
-			$genre = implode( ',', $genre );
-		}
-
-		$default_genre = WPSEO_Options::get( 'news_sitemap_default_genre' );
-		if ( $genre === '' && $default_genre ) {
-			$genre = is_array( $default_genre ) ? implode( ',', $default_genre ) : $default_genre;
-		}
-
-		$genre = trim( preg_replace( '/^none,?/', '', $genre ) );
-
-		return $genre;
 	}
 
 	/**

--- a/classes/upgrade-manager.php
+++ b/classes/upgrade-manager.php
@@ -76,6 +76,11 @@ class WPSEO_News_Upgrade_Manager {
 		if ( version_compare( $current_version, '12.4.1-RC0', '<=' ) ) {
 			$this->upgrade_1241();
 		}
+
+		// Upgrade to version 12.7.
+		if ( version_compare( $current_version, '12.7', '<=' ) ) {
+			$this->upgrade_127();
+		}
 	}
 
 	/**
@@ -237,6 +242,14 @@ class WPSEO_News_Upgrade_Manager {
 		$options['news_sitemap_exclude_terms']      = $excluded_terms;
 
 		update_option( 'wpseo_news', $options );
+	}
+
+	/**
+	 * Performs the upgrade routine for Yoast SEO News 12.7.
+	 */
+	private function upgrade_127() {
+		// Remove the genre settings from the database.
+		$this->delete_meta_by_key( '_yoast_wpseo_newssitemap-genre' );
 	}
 
 	/**

--- a/classes/upgrade-manager.php
+++ b/classes/upgrade-manager.php
@@ -248,6 +248,11 @@ class WPSEO_News_Upgrade_Manager {
 	 * Performs the upgrade routine for Yoast SEO News 12.7.
 	 */
 	private function upgrade_127() {
+		// Remove the default genre setting from the database.
+		$options = get_option( 'wpseo_news' );
+		unset( $options['news_sitemap_default_genre'] );
+		update_option( 'wpseo_news', $options );
+
 		// Remove the genre settings from the database.
 		$this->delete_meta_by_key( '_yoast_wpseo_newssitemap-genre' );
 	}

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -376,6 +376,7 @@ class WPSEO_News {
 	 * Listing the genres.
 	 *
 	 * @deprecated 12.7 News genres are deprecated.
+	 * @codeCoverageIgnore
 	 *
 	 * @return array
 	 */

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -316,23 +316,6 @@ class WPSEO_News {
 	}
 
 	/**
-	 * Listing the genres.
-	 *
-	 * @return array
-	 */
-	public static function list_genres() {
-		return [
-			'none'          => __( 'None', 'wordpress-seo-news' ),
-			'pressrelease'  => __( 'Press Release', 'wordpress-seo-news' ),
-			'satire'        => __( 'Satire', 'wordpress-seo-news' ),
-			'blog'          => __( 'Blog', 'wordpress-seo-news' ),
-			'oped'          => __( 'Op-Ed', 'wordpress-seo-news' ),
-			'opinion'       => __( 'Opinion', 'wordpress-seo-news' ),
-			'usergenerated' => __( 'User Generated', 'wordpress-seo-news' ),
-		];
-	}
-
-	/**
 	 * Determines whether the post is excluded in the news sitemap (and therefore schema) output.
 	 *
 	 * @param int $post_id The ID of the post to check for.
@@ -387,5 +370,26 @@ class WPSEO_News {
 		}
 
 		return $terms;
+	}
+
+	/**
+	 * Listing the genres.
+	 *
+	 * @deprecated 12.7 News genres are deprecated.
+	 *
+	 * @return array
+	 */
+	public static function list_genres() {
+		_deprecated_function( __METHOD__, 'WPSEO News 12.7' );
+
+		return [
+			'none'          => __( 'None', 'wordpress-seo-news' ),
+			'pressrelease'  => __( 'Press Release', 'wordpress-seo-news' ),
+			'satire'        => __( 'Satire', 'wordpress-seo-news' ),
+			'blog'          => __( 'Blog', 'wordpress-seo-news' ),
+			'oped'          => __( 'Op-Ed', 'wordpress-seo-news' ),
+			'opinion'       => __( 'Opinion', 'wordpress-seo-news' ),
+			'usergenerated' => __( 'User Generated', 'wordpress-seo-news' ),
+		];
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,9 +2384,9 @@ grunt-eslint@^21.0.0:
     chalk "^2.1.0"
     eslint "^5.16.0"
 
-"grunt-glotpress@git+https://github.com/Yoast/grunt-glotpress.git#master":
+"grunt-glotpress@https://github.com/Yoast/grunt-glotpress.git#master":
   version "0.3.0"
-  resolved "git+https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
+  resolved "https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
   dependencies:
     request "^2.88.0"
     request-promise-native "^1.0.7"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Google made their news genre obsolete: https://twitter.com/jdevalk/status/1207608446931099649

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the news genre from the News sitemap and settings.

## Relevant technical choices:

* Remove genre from the: metabox, settings, sitemap and database.
* Deprecate `WPSEO_News::list_genres`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Switch to the _previous version_ of News SEO (devs: `trunk`).
* Go to the news settings: SEO -> News SEO
  * Change the default genre to something.
  * Ensure you have news enabled for a post type.
  * Save the settings.
* Create a new post (or whatever the post type you enabled news for).
  * Change the genre in the metabox news tab.
  * Save the post.
* Check your database:
  * `wp_options` table should have a `wpseo_news` option that contains `news_sitemap_default_genre` (set to what you entered as the default genre).
  * `wp_postmeta` table should have at least one `_yoast_wpseo_newssitemap-genre` field (that is set to what you entered as genre in the metabox).
* Check your sitemap: http://basic.wordpress.test/news-sitemap.xml (there is a link in the News settings).
  * You should see your new post here, still with a `Genre(s)` header.
* Switch to the New SEO version containing this code.
  * The upgrade routine is only run on version match. To be able to test we need to ensure this will run:
    * In your database, go to the `wp_options` table.
    * Look for the `wpseo_news` field and change the `news_version` to something below `12.7`.
    * Developers/pre-RC only: Change the `WPSEO_NEWS_VERSION` in `wpseo-news.php` to `12.7` to simulate the release version we want to test.
* Check your database:
  * `wp_options` table should _no longer_ have a `wpseo_news` option that contains `news_sitemap_default_genre.
  * `wp_postmeta` table should _no longer_ any `_yoast_wpseo_newssitemap-genre` fields.
* Check your sitemap: http://basic.wordpress.test/news-sitemap.xml (there is a link in the News settings).
  * You might need to reactivate News SEO to flush the cache of the sitemap and / or flush your browsers cache. 
  * You should see your new post here, no longer with a `Genre(s)` header.
* Ensure you no longer get the default genre option in the settings: SEO -> News SEO
* Ensure you no longer get the genre option in the metabox of a post that you enabled news for.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* I did a search for `list_genres` on [GitHub in our organization](https://github.com/search?q=org%3AYoast+list_genres&type=code). The only relevant result that came up is removed in this PR.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-299
