### PR TITLE
P1-300 Add notification for changes in News SEO

### DIFF
--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -296,12 +296,12 @@ class WPSEO_News {
 	public function notification_center_notification() {
 		$notification_center = Yoast_Notification_Center::get();
 
-		$notification_msg_a         = sprintf(
+		$notification_msg_a = sprintf(
 		/* translators: %s expands to Yoast SEO News */
 			__( 'Changed settings in %s:', 'yoast-news-seo' ),
 			'Yoast SEO News'
 		);
-		$notification_msg_b         = sprintf(
+		$notification_msg_b = sprintf(
 		/* translators: %s expands to Yoast SEO News */
 			__( 'You\'ve just updated %s, but have you already noticed that we\'ve changed some settings?', 'yoast-news-seo' ),
 			'Yoast SEO News'

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -298,16 +298,16 @@ class WPSEO_News {
 
 		$notification_msg_a = sprintf(
 		/* translators: %s expands to Yoast SEO News */
-			__( 'Changed settings in %s:', 'yoast-news-seo' ),
+			__( 'Changed settings in %s:', 'wordpress-seo-news' ),
 			'Yoast SEO News'
 		);
 		$notification_msg_b = sprintf(
 		/* translators: %s expands to Yoast SEO News */
-			__( 'You\'ve just updated %s, but have you already noticed that we\'ve changed some settings?', 'yoast-news-seo' ),
+			__( 'You\'ve just updated %s, but have you already noticed that we\'ve changed some settings?', 'wordpress-seo-news' ),
 			'Yoast SEO News'
 		);
 		$notification_info_url      = WPSEO_Shortlinker::get( 'https://yoa.st/news-changes' );
-		$notification_info_linktext = __( 'Read everything about it here', 'yoast-news-seo' );
+		$notification_info_linktext = __( 'Read everything about it here', 'wordpress-seo-news' );
 
 		$notification_message = sprintf(
 			'<b>%s</b> %s <a href="%s" target="_blank">%s</a>.',

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -289,7 +289,9 @@ class WPSEO_News {
 	}
 
 	/**
+	 * Adds a Notification to the Notification Center.
 	 *
+	 * @return void
 	 */
 	public function notification_center_notification() {
 		$notification_center = Yoast_Notification_Center::get();

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -58,6 +58,9 @@ class WPSEO_News {
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
 
 		add_filter( 'wpseo_frontend_presenters', [ $this, 'add_frontend_presenter' ] );
+
+		// Enable notifications in notification center.
+		add_action( 'admin_init', [ $this, 'notification_center_notification' ], 15 );
 	}
 
 	/**
@@ -283,6 +286,44 @@ class WPSEO_News {
 		);
 
 		$helpscout->register_hooks();
+	}
+
+	/**
+	 *
+	 */
+	public function notification_center_notification() {
+		$notification_center = Yoast_Notification_Center::get();
+
+		$notification_msg_a         = sprintf(
+		/* translators: %s expands to Yoast SEO Video */
+			__( 'Changed settings in %s:', 'yoast-video-seo', 'wordpress-seo-news' ),
+			'Yoast SEO Video'
+		);
+		$notification_msg_b         = sprintf(
+		/* translators: %s expands to Yoast SEO Video */
+			__( 'You\'ve just updated %s, but have you already noticed that we\'ve changed some settings?', 'yoast-video-seo', 'wordpress-seo-news' ),
+			'Yoast SEO Video'
+		);
+		$notification_info_url      = WPSEO_Shortlinker::get( 'https://yoa.st/video-changes' );
+		$notification_info_linktext = __( 'Read everything about it here', 'yoast-video-seo', 'wordpress-seo-news' );
+
+		$notification_message = sprintf(
+			'<b>%s</b> %s <a href="%s" target="_blank">%s</a>.',
+			$notification_msg_a,
+			$notification_msg_b,
+			$notification_info_url,
+			$notification_info_linktext
+		);
+
+		$notification = new Yoast_Notification(
+			$notification_message,
+			[
+				'id'   => 'wpseo-updates-video',
+				'type' => Yoast_Notification::UPDATED,
+			]
+		);
+
+		$notification_center->add_notification( $notification );
 	}
 
 	/**

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -297,17 +297,17 @@ class WPSEO_News {
 		$notification_center = Yoast_Notification_Center::get();
 
 		$notification_msg_a         = sprintf(
-		/* translators: %s expands to Yoast SEO Video */
-			__( 'Changed settings in %s:', 'yoast-video-seo', 'wordpress-seo-news' ),
-			'Yoast SEO Video'
+		/* translators: %s expands to Yoast SEO News */
+			__( 'Changed settings in %s:', 'yoast-news-seo' ),
+			'Yoast SEO News'
 		);
 		$notification_msg_b         = sprintf(
-		/* translators: %s expands to Yoast SEO Video */
-			__( 'You\'ve just updated %s, but have you already noticed that we\'ve changed some settings?', 'yoast-video-seo', 'wordpress-seo-news' ),
-			'Yoast SEO Video'
+		/* translators: %s expands to Yoast SEO News */
+			__( 'You\'ve just updated %s, but have you already noticed that we\'ve changed some settings?', 'yoast-news-seo' ),
+			'Yoast SEO News'
 		);
-		$notification_info_url      = WPSEO_Shortlinker::get( 'https://yoa.st/video-changes' );
-		$notification_info_linktext = __( 'Read everything about it here', 'yoast-video-seo', 'wordpress-seo-news' );
+		$notification_info_url      = WPSEO_Shortlinker::get( 'https://yoa.st/news-changes' );
+		$notification_info_linktext = __( 'Read everything about it here', 'yoast-news-seo' );
 
 		$notification_message = sprintf(
 			'<b>%s</b> %s <a href="%s" target="_blank">%s</a>.',
@@ -320,7 +320,7 @@ class WPSEO_News {
 		$notification = new Yoast_Notification(
 			$notification_message,
 			[
-				'id'   => 'wpseo-updates-video',
+				'id'   => 'wpseo-updates-news',
 				'type' => Yoast_Notification::UPDATED,
 			]
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* As some settings are changed in News SEO our users need to be informed. So we need to add a notification to the notification center for that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* In this version changes are made to the settings. We added a notification to inform our users about those changes.

## Relevant technical choices:

*

## Images
### Design
![news changes notification](https://user-images.githubusercontent.com/35524806/105957978-454ec980-607a-11eb-9251-f6c8d285e849.png)
### Screenshot
![screenshot](https://user-images.githubusercontent.com/35524806/105958781-5ba95500-607b-11eb-886b-5f243b33ea11.png)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* With Yoast SEO or Yoast SEO Premium and News SEO active, a new notification should show up in the notification center
* Check that the notification is the same as in the design
* When an URL to the post about this changes has been given, make sure that the link points to that url instead of yoast.com



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* With Yoast SEO or Yoast SEO Premium and Video SEO active, a new notification should show up in the notification center
* Check that the notification is the same as in the design
* The link needs to point to an url with a post about this changes, not to yoast.com


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-300
