### PR TITLE
P1-352 Remove updates notification on deactivation

### DIFF
--- a/classes/updates-notification.php
+++ b/classes/updates-notification.php
@@ -51,4 +51,14 @@ class WPSEO_News_Updates_Notification {
 		$notification_center = Yoast_Notification_Center::get();
 		$notification_center->add_notification( $notification );
 	}
+
+	/**
+	 * Removes the updates notification from the Notification Center.
+	 *
+	 * @return void
+	 */
+	public static function remove_notification() {
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->remove_notification_by_id( self::NOTIFICATION_ID );
+	}
 }

--- a/classes/updates-notification.php
+++ b/classes/updates-notification.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Yoast SEO: News plugin file.
+ *
+ * @package WPSEO_News
+ */
+
+/**
+ * Represents the news updates notification for Yoast SEO.
+ */
+class WPSEO_News_Updates_Notification {
+
+	const NOTIFICATION_ID = 'wpseo-updates-news';
+
+	/**
+	 * Adds the updates notification to the Notification Center.
+	 *
+	 * @return void
+	 */
+	public static function add_notification() {
+		$notification_msg_a = sprintf(
+			/* translators: %s expands to Yoast SEO News */
+			__( 'Changed settings in %s:', 'wordpress-seo-news' ),
+			'Yoast SEO News'
+		);
+		$notification_msg_b = sprintf(
+			/* translators: %s expands to Yoast SEO News */
+			__( 'You\'ve just updated %s, but have you already noticed that we\'ve changed some settings?', 'wordpress-seo-news' ),
+			'Yoast SEO News'
+		);
+
+		$notification_info_url      = WPSEO_Shortlinker::get( 'https://yoa.st/news-changes' );
+		$notification_info_linktext = __( 'Read everything about it here', 'wordpress-seo-news' );
+
+		$notification_message = sprintf(
+			'<b>%s</b> %s <a href="%s" target="_blank">%s</a>.',
+			$notification_msg_a,
+			$notification_msg_b,
+			$notification_info_url,
+			$notification_info_linktext
+		);
+
+		$notification = new Yoast_Notification(
+			$notification_message,
+			[
+				'id'   => self::NOTIFICATION_ID,
+				'type' => Yoast_Notification::UPDATED,
+			]
+		);
+
+		$notification_center = Yoast_Notification_Center::get();
+		$notification_center->add_notification( $notification );
+	}
+}

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -59,8 +59,7 @@ class WPSEO_News {
 
 		add_filter( 'wpseo_frontend_presenters', [ $this, 'add_frontend_presenter' ] );
 
-		// Enable notifications in notification center.
-		add_action( 'admin_init', [ $this, 'notification_center_notification' ], 15 );
+		add_action( 'admin_init', [ 'WPSEO_News_Updates_Notification', 'add_notification' ], 15 );
 	}
 
 	/**
@@ -286,46 +285,6 @@ class WPSEO_News {
 		);
 
 		$helpscout->register_hooks();
-	}
-
-	/**
-	 * Adds a Notification to the Notification Center.
-	 *
-	 * @return void
-	 */
-	public function notification_center_notification() {
-		$notification_center = Yoast_Notification_Center::get();
-
-		$notification_msg_a = sprintf(
-		/* translators: %s expands to Yoast SEO News */
-			__( 'Changed settings in %s:', 'wordpress-seo-news' ),
-			'Yoast SEO News'
-		);
-		$notification_msg_b = sprintf(
-		/* translators: %s expands to Yoast SEO News */
-			__( 'You\'ve just updated %s, but have you already noticed that we\'ve changed some settings?', 'wordpress-seo-news' ),
-			'Yoast SEO News'
-		);
-		$notification_info_url      = WPSEO_Shortlinker::get( 'https://yoa.st/news-changes' );
-		$notification_info_linktext = __( 'Read everything about it here', 'wordpress-seo-news' );
-
-		$notification_message = sprintf(
-			'<b>%s</b> %s <a href="%s" target="_blank">%s</a>.',
-			$notification_msg_a,
-			$notification_msg_b,
-			$notification_info_url,
-			$notification_info_linktext
-		);
-
-		$notification = new Yoast_Notification(
-			$notification_message,
-			[
-				'id'   => 'wpseo-updates-news',
-				'type' => Yoast_Notification::UPDATED,
-			]
-		);
-
-		$notification_center->add_notification( $notification );
 	}
 
 	/**

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -19,7 +19,8 @@ abstract class TestCase extends YoastTestCase {
 
 		Monkey\Functions\stubs(
 			[
-				'is_admin'       => false,
+				'is_admin' => false,
+				'__'       => null,
 			]
 		);
 

--- a/tests/updates-notification-test.php
+++ b/tests/updates-notification-test.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Yoast\WP\News\Tests;
+
+use Mockery;
+use WPSEO_News_Updates_Notification;
+
+/**
+ * Tests the WPSEO_News_Updates_Notification class.
+ *
+ * @coversDefaultClass WPSEO_News_Updates_Notification
+ */
+class Updates_Notification_Test extends TestCase {
+
+	/**
+	 * Tests that Yoast_Notification_Center add_notification is called.
+	 *
+	 * @covers ::add_notification
+	 */
+	public function test_add_notification() {
+		$shortlinker = Mockery::mock( 'overload:WPSEO_Shortlinker' );
+		$shortlinker
+			->shouldReceive( 'get' )
+			->with( 'https://yoa.st/news-changes' )
+			->once()
+			->andReturn( 'https://yoa.st/news-changes' );
+
+		Mockery::getConfiguration()->setConstantsMap(
+			[
+				'Yoast_Notification' => [
+					'UPDATED' => 'updated',
+				],
+			]
+		);
+		Mockery::mock( 'overload:Yoast_Notification' );
+
+		$notification_center = Mockery::mock( 'overload:Yoast_Notification_Center' );
+		$notification_center
+			->shouldReceive( 'get' )
+			->withNoArgs()
+			->once()
+			->andReturn( $notification_center );
+		$notification_center
+			->shouldReceive( 'add_notification' )
+			->withAnyArgs()
+			->once();
+
+		WPSEO_News_Updates_Notification::add_notification();
+	}
+
+	/**
+	 * Tests that Yoast_Notification_Center remove_notification_by_id is called.
+	 *
+	 * @covers ::remove_notification
+	 */
+	public function test_get_included_post_types_with_no_set_post_types() {
+		$notification_center = Mockery::mock( 'overload:Yoast_Notification_Center' );
+		$notification_center
+			->shouldReceive( 'get' )
+			->withNoArgs()
+			->once()
+			->andReturn( $notification_center );
+		$notification_center
+			->shouldReceive( 'remove_notification_by_id' )
+			->with( WPSEO_News_Updates_Notification::NOTIFICATION_ID )
+			->once();
+
+		WPSEO_News_Updates_Notification::remove_notification();
+	}
+}

--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -73,6 +73,21 @@ function yoast_wpseo_news_clear_sitemap_cache() {
 }
 
 /**
+ * Removes the News SEO notifications.
+ *
+ * @return void
+ */
+function yoast_wpseo_news_remove_notifications() {
+	if (
+		class_exists( 'Yoast_Notification_Center' ) &&
+		method_exists( 'Yoast_Notification_Center', 'get' ) &&
+		method_exists( 'Yoast_Notification_Center', 'remove_notification_by_id' )
+	) {
+		WPSEO_News_Updates_Notification::remove_notification();
+	}
+}
+
+/**
  * Clear the news sitemap when we activate the plugin.
  */
 function yoast_wpseo_news_activate() {
@@ -89,6 +104,7 @@ function yoast_wpseo_news_activate() {
  */
 function yoast_wpseo_news_deactivate() {
 	yoast_wpseo_news_clear_sitemap_cache();
+	yoast_wpseo_news_remove_notifications();
 }
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Remove the notification on News SEO deactivation. Notification was added https://github.com/Yoast/wpseo-news/pull/668

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the updates notification would not be removed when deactivating News SEO.

## Relevant technical choices:

* Added a new class to keep the code contained
* Kept the add hook in the news class because News does not have integrations
* Added the remove notification in the root class (surrounded by safety checks for if free is not active). The idea is that if there are more notifications added in news the remove should be added there.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Ensure Yoast SEO is active
* Activate News SEO (with this branch active)
* The updates notification should show up in the notification center
* Deactivate News SEO
* The updates notification should disappear (before this fix it would stay)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Partially fixes https://yoast.atlassian.net/browse/P1-352
