### PR TITLE
Removes the no longer wanted notification

### DIFF
--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -58,9 +58,6 @@ class WPSEO_News {
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
 
 		add_filter( 'wpseo_frontend_presenters', [ $this, 'add_frontend_presenter' ] );
-
-		// Enable notifications in notification center.
-		add_action( 'admin_init', [ $this, 'notification_center_notification' ], 15 );
 	}
 
 	/**
@@ -286,46 +283,6 @@ class WPSEO_News {
 		);
 
 		$helpscout->register_hooks();
-	}
-
-	/**
-	 * Adds a Notification to the Notification Center.
-	 *
-	 * @return void
-	 */
-	public function notification_center_notification() {
-		$notification_center = Yoast_Notification_Center::get();
-
-		$notification_msg_a = sprintf(
-		/* translators: %s expands to Yoast SEO News */
-			__( 'Changed settings in %s:', 'wordpress-seo-news' ),
-			'Yoast SEO News'
-		);
-		$notification_msg_b = sprintf(
-		/* translators: %s expands to Yoast SEO News */
-			__( 'You\'ve just updated %s, but have you already noticed that we\'ve changed some settings?', 'wordpress-seo-news' ),
-			'Yoast SEO News'
-		);
-		$notification_info_url      = WPSEO_Shortlinker::get( 'https://yoa.st/news-changes' );
-		$notification_info_linktext = __( 'Read everything about it here', 'wordpress-seo-news' );
-
-		$notification_message = sprintf(
-			'<b>%s</b> %s <a href="%s" target="_blank">%s</a>.',
-			$notification_msg_a,
-			$notification_msg_b,
-			$notification_info_url,
-			$notification_info_linktext
-		);
-
-		$notification = new Yoast_Notification(
-			$notification_message,
-			[
-				'id'   => 'wpseo-updates-news',
-				'type' => Yoast_Notification::UPDATED,
-			]
-		);
-
-		$notification_center->add_notification( $notification );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Notifications about the changes needed to be removed.


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes an unreleased notification from the notification center.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Deactivate News SEO
* Remove the row `wp_yoast_notifications` from your `wp_usermeta` table in your database
* Update News SEO to this version
* Activate News SEO
* Make sure no notification about the changes is added to the notification center


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-358
