### PR TITLE
Improve how we load HelpScout

### DIFF
--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -277,7 +277,7 @@ class WPSEO_News {
 	 */
 	public function filter_helpscout_beacon( $helpscout_settings ) {
 		$helpscout_settings['pages_ids']['wpseo_news'] = '161a6b32-9360-4613-bd04-d8098b283a0f';
-		$helpscout_settings['products'][] = WPSEO_Addon_Manager::NEWS_SLUG;
+		$helpscout_settings['products'][]              = WPSEO_Addon_Manager::NEWS_SLUG;
 
 		return $helpscout_settings;
 	}

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -51,11 +51,11 @@ class WPSEO_News {
 	private function set_hooks() {
 		add_filter( 'plugin_action_links', [ $this, 'plugin_links' ], 10, 2 );
 		add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_pages' ] );
-		add_action( 'admin_init', [ $this, 'init_helpscout_beacon' ] );
 		add_action( 'init', [ 'WPSEO_News_Option', 'register_option' ] );
 
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
+		add_filter( 'wpseo_helpscout_beacon_settings', [ $this, 'filter_helpscout_beacon' ] );
 
 		add_filter( 'wpseo_frontend_presenters', [ $this, 'add_frontend_presenter' ] );
 	}
@@ -269,20 +269,17 @@ class WPSEO_News {
 	}
 
 	/**
-	 * Initializes the helpscout beacon.
+	 * Makes sure the News settings page has a HelpScout beacon.
+	 *
+	 * @param array $helpscout_settings The HelpScout settings.
+	 *
+	 * @return array $helpscout_settings The HelpScout settings with the News SEO beacon added.
 	 */
-	public function init_helpscout_beacon() {
-		if ( ! class_exists( 'WPSEO_HelpScout' ) ) {
-			return;
-		}
+	public function filter_helpscout_beacon( $helpscout_settings ) {
+		$helpscout_settings['pages_ids']['wpseo_news'] = '161a6b32-9360-4613-bd04-d8098b283a0f';
+		$helpscout_settings['products'][] = WPSEO_Addon_Manager::NEWS_SLUG;
 
-		$helpscout = new WPSEO_HelpScout(
-			'161a6b32-9360-4613-bd04-d8098b283a0f',
-			[ 'wpseo_news' ],
-			[ WPSEO_Addon_Manager::NEWS_SLUG ]
-		);
-
-		$helpscout->register_hooks();
+		return $helpscout_settings;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* As a followup to https://github.com/Yoast/wordpress-seo/pull/16615 this switches the news plugin to a filter instead of loading the HelpScout class separately.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve how we load HelpScout.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The beacon should still load with this patch applied.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
