### PR TITLE
P1-301 reactify editor

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,8 @@
       {
         "pragma": "wp.element.createElement"
       }
-    ]
+    ],
+    "transform-object-rest-spread"
   ],
   "env": {
     "test": {

--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -27,7 +27,7 @@ class WPSEO_News_Admin_Page {
 		Yoast_Form::get_instance()->admin_header( true, 'wpseo_news' );
 
 		// Introduction.
-		echo '<div id="wpseo-news-genre-removal-alert"></div>';
+		echo '<div id="wpseo-news-genre-removal-alert" style="max-width: 600px;"></div>';
 		echo '<p>', esc_html__( 'You will generally only need a News Sitemap when your website is included in Google News.', 'wordpress-seo-news' ), '</p>';
 		echo '<p>';
 		printf(

--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -27,8 +27,8 @@ class WPSEO_News_Admin_Page {
 		Yoast_Form::get_instance()->admin_header( true, 'wpseo_news' );
 
 		// Introduction.
-		echo '<p id="wpseo-news-genre-removal-alert"></p>';
-		echo '<p>' . esc_html__( 'You will generally only need a News Sitemap when your website is included in Google News.', 'wordpress-seo-news' ) . '</p>';
+		echo '<div id="wpseo-news-genre-removal-alert"></div>';
+		echo '<p>', esc_html__( 'You will generally only need a News Sitemap when your website is included in Google News.', 'wordpress-seo-news' ), '</p>';
 		echo '<p>';
 		printf(
 			/* translators: %1$s opening tag of the link to the News Sitemap, %2$s closing tag for the link. */
@@ -38,9 +38,9 @@ class WPSEO_News_Admin_Page {
 		);
 		echo '</p>';
 
-		echo '<h2>' . esc_html__( 'General settings', 'wordpress-seo-news' ) . '</h2>';
+		echo '<h2>', esc_html__( 'General settings', 'wordpress-seo-news' ), '</h2>';
 
-		echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'News Sitemap settings', 'wordpress-seo-news' ) . '</legend>';
+		echo '<fieldset><legend class="screen-reader-text">', esc_html__( 'News Sitemap settings', 'wordpress-seo-news' ), '</legend>';
 
 		// Google News Publication Name.
 		Yoast_Form::get_instance()->textinput( 'news_sitemap_name', __( 'Google News Publication Name', 'wordpress-seo-news' ) );

--- a/classes/integrations/editor-changes-alert.php
+++ b/classes/integrations/editor-changes-alert.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Yoast SEO News plugin file.
+ *
+ * @package Yoast\NewsSEO
+ */
+
+use Yoast\WP\SEO\Integrations\Alerts\Abstract_Dismissable_Alert;
+
+/**
+ * Class WPSEO_News_Editor_Changes_Alert.
+ */
+class WPSEO_News_Editor_Changes_Alert extends Abstract_Dismissable_Alert {
+
+	/**
+	 * Holds the alert identifier.
+	 *
+	 * @var string
+	 */
+	public $alert_identifier = 'news-editor-changes-alert';
+}

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -141,7 +141,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 		$sections[] = [
 			'name'         => 'news',
 			'link_content' => '<span class="dashicons dashicons-admin-plugins"></span>' . esc_html__( 'News', 'wordpress-seo-news' ),
-			'content'      => '<div class="wpseo-meta-section-content"><div id="wpseo-news-metabox-root"></div></div>',
+			'content'      => '<div id="wpseo-news-metabox-root" class="wpseo-meta-section-content"></div>',
 		];
 
 		return $sections;

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -190,10 +190,14 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 		$javascript_strings = new WPSEO_News_Javascript_Strings();
 		$javascript_strings->localize_script( $script_handle );
 
-		\wp_localize_script( $script_handle, 'wpseoNewsScriptData', [
-			'isBlockEditor'        => WP_Screen::get()->is_block_editor(),
-			'newsChangesAlertLink' => WPSEO_Shortlinker::get( 'https://yoa.st/news-changes' ),
-		] );
+		\wp_localize_script(
+			$script_handle,
+			'wpseoNewsScriptData',
+			[
+				'isBlockEditor'        => WP_Screen::get()->is_block_editor(),
+				'newsChangesAlertLink' => WPSEO_Shortlinker::get( 'https://yoa.st/news-changes' ),
+			]
+		);
 	}
 
 	/**

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -61,6 +61,10 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 		if ( $is_elementor_edit_page ) {
 			add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 		}
+
+		// Register the dismissible alert.
+		$editor_changes_alert = new WPSEO_News_Editor_Changes_Alert();
+		$editor_changes_alert->register_hooks();
 	}
 
 	/**

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -76,22 +76,15 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	 */
 	public function get_meta_boxes( $post_type = 'post' ) {
 		return [
-			'newssitemap-exclude'      => [
-				'name'  => 'newssitemap-exclude',
-				'type'  => 'checkbox',
-				'std'   => 'on',
-				'title' => __( 'News Sitemap', 'wordpress-seo-news' ),
-				'expl'  => __( 'Exclude from News Sitemap', 'wordpress-seo-news' ),
-			],
 			'newssitemap-stocktickers' => [
 				'name'        => 'newssitemap-stocktickers',
 				'std'         => '',
-				'type'        => 'text',
+				'type'        => 'hidden',
 				'title'       => __( 'Stock Tickers', 'wordpress-seo-news' ),
 				'description' => __( 'A comma-separated list of up to 5 stock tickers of the companies, mutual funds, or other financial entities that are the main subject of the article. Each ticker must be prefixed by the name of its stock exchange, and must match its entry in Google Finance. For example, "NASDAQ:AMAT" (but not "NASD:AMAT"), or "BOM:500325" (but not "BOM:RIL").', 'wordpress-seo-news' ),
 			],
 			'newssitemap-robots-index' => [
-				'type'          => 'radio',
+				'type'          => 'hidden',
 				'default_value' => '0', // The default value will be 'index'; See the list of options.
 				'std'           => '',
 				'options'       => [

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -140,7 +140,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 
 		$sections[] = [
 			'name'         => 'news',
-			'link_content' => '<span class="dashicons dashicons-admin-plugins"></span>' . esc_html__( 'Google News', 'wordpress-seo-news' ),
+			'link_content' => '<span class="dashicons dashicons-admin-plugins"></span>' . esc_html__( 'News', 'wordpress-seo-news' ),
 			'content'      => '<div class="wpseo-meta-section-content"><div id="wpseo-news-metabox-root"></div></div>',
 		];
 

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -80,11 +80,6 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
-		// Check the specific WordPress SEO News no-index value.
-		if ( WPSEO_Meta::get_value( 'newssitemap-robots-index', $this->item->ID ) === '1' ) {
-			return true;
-		}
-
 		if ( WPSEO_News::is_excluded_through_terms( $this->item->ID, $this->item->post_type ) ) {
 			return true;
 		}

--- a/classes/upgrade-manager.php
+++ b/classes/upgrade-manager.php
@@ -255,6 +255,9 @@ class WPSEO_News_Upgrade_Manager {
 
 		// Remove the genre settings from the database.
 		$this->delete_meta_by_key( '_yoast_wpseo_newssitemap-genre' );
+
+		// Remove the News sitemap exclude settings from the database.
+		$this->delete_meta_by_key( '_yoast_wpseo_newssitemap-exclude' );
 	}
 
 	/**

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -344,7 +344,8 @@ class WPSEO_News {
 	 * @return bool Whether or not the post is excluded.
 	 */
 	public static function is_excluded_through_sitemap( $post_id ) {
-		return WPSEO_Meta::get_value( 'newssitemap-exclude', $post_id ) === 'on';
+		// Check the specific WordPress SEO News no-index value.
+		return WPSEO_Meta::get_value( 'newssitemap-robots-index', $post_id ) === '1';
 	}
 
 	/**

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -32,7 +32,8 @@ class WPSEO_News {
 		$this->set_hooks();
 
 		// Meta box.
-		new WPSEO_News_Meta_Box();
+		$meta_box = new WPSEO_News_Meta_Box( $this->get_version() );
+		$meta_box->register_hooks();
 
 		// Sitemap.
 		new WPSEO_News_Sitemap();

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -224,7 +224,7 @@ class WPSEO_News {
 
 		wp_enqueue_script(
 			'wpseo-news-admin-page',
-			plugins_url( 'js/dist/yoast-seo-news-plugin-' . $version . '.js', WPSEO_NEWS_FILE ),
+			plugins_url( 'js/dist/yoast-seo-news-settings-' . $version . '.js', WPSEO_NEWS_FILE ),
 			$dependencies,
 			self::VERSION,
 			true

--- a/config/webpack/externals.js
+++ b/config/webpack/externals.js
@@ -6,14 +6,22 @@ const externals = {
 	"react-dom": "ReactDOM",
 };
 
+const yoastExternals = {
+	"@yoast/components": "window.yoast.componentsNew",
+};
+
 /**
  * WordPress dependencies.
  */
 const wordpressPackages = [
+	"@wordpress/components",
+	"@wordpress/compose",
 	"@wordpress/data",
 	"@wordpress/dom-ready",
 	"@wordpress/element",
+	'@wordpress/hooks',
 	"@wordpress/i18n",
+	"@wordpress/plugins",
 ];
 
 const wordpressExternals = wordpressPackages.reduce( ( memo, packageName ) => {
@@ -29,4 +37,5 @@ const wordpressExternals = wordpressPackages.reduce( ( memo, packageName ) => {
 module.exports = {
 	externals,
 	wordpressExternals,
+	yoastExternals,
 };

--- a/config/webpack/externals.js
+++ b/config/webpack/externals.js
@@ -6,10 +6,6 @@ const externals = {
 	"react-dom": "ReactDOM",
 };
 
-const yoastExternals = {
-	"@yoast/components": "window.yoast.componentsNew",
-};
-
 /**
  * WordPress dependencies.
  */
@@ -30,6 +26,10 @@ const wordpressExternals = wordpressPackages.reduce( ( memo, packageName ) => {
 	memo[ packageName ] = `window.wp.${ name }`;
 	return memo;
 }, {} );
+
+const yoastExternals = {
+	"@yoast/components": "window.yoast.componentsNew",
+};
 
 /**
  * Export the data.

--- a/config/webpack/paths.js
+++ b/config/webpack/paths.js
@@ -6,7 +6,8 @@ const jsSrcPath = path.resolve( "js", "src" );
 
 // Output filename: Entry file (relative to jsSrcPath)
 const entry = {
-	"yoast-seo-news-plugin": "./yoast-seo-news-plugin.js",
+	"yoast-seo-news-editor": "./yoast-seo-news-editor.js",
+	"yoast-seo-news-settings": "./yoast-seo-news-settings.js",
 };
 
 module.exports = {

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -2,7 +2,7 @@ const CaseSensitivePathsPlugin = require( "case-sensitive-paths-webpack-plugin" 
 const path = require( "path" );
 const { isString, mapValues } = require( "lodash" );
 const webpack = require( "webpack" );
-const { externals, wordpressExternals } = require( "./externals" );
+const { externals, wordpressExternals, yoastExternals } = require( "./externals" );
 const { flattenVersionForFile } = require( "../grunt/lib/version.js" );
 const paths = require( "./paths" );
 
@@ -63,6 +63,7 @@ module.exports = function( env ) {
 		externals: {
 			...externals,
 			...wordpressExternals,
+			...yoastExternals,
 		},
 		optimization: {
 			minimize: true,

--- a/integration-tests/meta-box-test.php
+++ b/integration-tests/meta-box-test.php
@@ -37,7 +37,7 @@ class WPSEO_News_Meta_Box_Test extends WPSEO_News_UnitTestCase {
 		$this->assertCount( 1, $sections );
 
 		$this->assertSame( 'news', $sections[0]['name'] );
-		$this->assertSame( '<span class="dashicons dashicons-admin-plugins"></span>Google News', $sections[0]['link_content'] );
+		$this->assertSame( '<span class="dashicons dashicons-admin-plugins"></span>News', $sections[0]['link_content'] );
 		$this->assertSame( '<div class="wpseo-meta-section-content"><div id="wpseo-news-metabox-root"></div></div>', $sections[0]['content'] );
 	}
 

--- a/integration-tests/meta-box-test.php
+++ b/integration-tests/meta-box-test.php
@@ -20,6 +20,7 @@ class WPSEO_News_Meta_Box_Test extends WPSEO_News_UnitTestCase {
 	public function test_add_metabox_section() {
 		$stub = $this
 			->getMockBuilder( 'WPSEO_News_Meta_Box_Double' )
+			->setConstructorArgs( [ '1260' ] )
 			->setMethods(
 				[
 					'is_post_type_supported',
@@ -30,8 +31,6 @@ class WPSEO_News_Meta_Box_Test extends WPSEO_News_UnitTestCase {
 			->getMock();
 
 		$stub->method( 'is_post_type_supported' )->willReturn( true );
-		$stub->method( 'get_meta_boxes' )->willReturn( [ 'metakey' => 'metabox' ] );
-		$stub->method( 'do_meta_box' )->willReturn( '[content]' );
 
 		$sections = $stub->add_metabox_section( [] );
 
@@ -39,7 +38,7 @@ class WPSEO_News_Meta_Box_Test extends WPSEO_News_UnitTestCase {
 
 		$this->assertSame( 'news', $sections[0]['name'] );
 		$this->assertSame( '<span class="dashicons dashicons-admin-plugins"></span>Google News', $sections[0]['link_content'] );
-		$this->assertSame( '<div class="wpseo-meta-section-content">[content]</div>', $sections[0]['content'] );
+		$this->assertSame( '<div class="wpseo-meta-section-content"><div id="wpseo-news-metabox-root"></div></div>', $sections[0]['content'] );
 	}
 
 	/**
@@ -50,6 +49,7 @@ class WPSEO_News_Meta_Box_Test extends WPSEO_News_UnitTestCase {
 	public function test_add_metabox_section_unsupported_posttype() {
 		$stub = $this
 			->getMockBuilder( 'WPSEO_News_Meta_Box_Double' )
+			->setConstructorArgs( [ '1260' ] )
 			->setMethods( [ 'is_post_type_supported' ] )
 			->getMock();
 

--- a/integration-tests/meta-box-test.php
+++ b/integration-tests/meta-box-test.php
@@ -38,7 +38,7 @@ class WPSEO_News_Meta_Box_Test extends WPSEO_News_UnitTestCase {
 
 		$this->assertSame( 'news', $sections[0]['name'] );
 		$this->assertSame( '<span class="dashicons dashicons-admin-plugins"></span>News', $sections[0]['link_content'] );
-		$this->assertSame( '<div class="wpseo-meta-section-content"><div id="wpseo-news-metabox-root"></div></div>', $sections[0]['content'] );
+		$this->assertSame( '<div id="wpseo-news-metabox-root" class="wpseo-meta-section-content"></div>', $sections[0]['content'] );
 	}
 
 	/**

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -122,7 +122,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 		$post_id = $this->factory->post->create();
 
 		// Set meta value to exclude.
-		update_post_meta( $post_id, '_yoast_wpseo_newssitemap-exclude', 'on' );
+		update_post_meta( $post_id, '_yoast_wpseo_newssitemap-robots-index', '1' );
 
 		$output = $this->instance->build_sitemap();
 

--- a/js/src/components/Editor.js
+++ b/js/src/components/Editor.js
@@ -1,0 +1,74 @@
+import { createInterpolateElement, useEffect } from "@wordpress/element";
+import { __, sprintf } from "@wordpress/i18n";
+import { Checkbox, TextInput } from "@yoast/components";
+import * as PropTypes from "prop-types";
+
+const { location: { LocationConsumer } } = window.yoast.editorModules.components.contexts;
+const { PersistentDismissableAlert } = window.yoast.editorModules.containers;
+
+/**
+ * The NewsEditor component.
+ *
+ * @param {Object} props The props.
+ *
+ * @returns {ReactElement} The NewsEditor element.
+ */
+export default function Editor( props ) {
+	useEffect( () => {
+		props.onLoad();
+	}, [] );
+
+	/* eslint-disable jsx-a11y/anchor-has-content */
+	const alertContent = createInterpolateElement(
+		/* Translators: %s expands to an opening anchor tag, %s expands to a closing anchor tag */
+		sprintf( __( "We've made some changes to Yoast SEO News. %sLearn more about what has changed%s", "wordpress-seo-news" ), "<a>", "</a>" ),
+		{
+			a: <a
+				href={ props.changesAlertLink }
+				target="_blank"
+				rel="noopener noreferrer"
+			/>,
+		},
+	);
+	/* eslint-enable jsx-a11y/anchor-has-content */
+
+	/* Translators: %s expands to the name of the post type */
+	const excludeLabel = sprintf( __( "Exclude this %s from Google News", "wordpress-seo-news" ), props.postTypeName );
+
+	return (
+		<LocationConsumer>
+			{ location => {
+				return (
+					<div className="yoast">
+						<PersistentDismissableAlert alertKey="news-editor-changes-alert" type="info">
+							{ alertContent }
+						</PersistentDismissableAlert>
+						<Checkbox
+							id={ `yoast-news-exclude-${ location }` }
+							label={ excludeLabel }
+							checked={ props.isExcluded }
+							onChange={ props.toggleIsExcluded }
+						/>
+						<TextInput
+							id={ `yoast-news-stock-tickers-${ location }` }
+							label={ __( "Stock tickers", "wordpress-seo-news" ) }
+							description={ __( "A comma-separated list of up to 5 stock tickers of the companies, mutual funds, or other financial entities that are the main subject of the article. Each ticker must be prefixed by the name of its stock exchange, and must match its entry in Google Finance. For example, \"NASDAQ:AMAT\" (but not \"NASD:AMAT\"), or \"BOM:500325\" (but not \"BOM:RIL\").", "wordpress-seo-news" ) }
+							value={ props.stockTickers }
+							onChange={ props.setStockTickers }
+						/>
+					</div>
+				);
+			} }
+		</LocationConsumer>
+	);
+}
+
+Editor.propTypes = {
+	changesAlertLink: PropTypes.string.isRequired,
+	isExcluded: PropTypes.bool.isRequired,
+	postTypeName: PropTypes.string.isRequired,
+	stockTickers: PropTypes.string.isRequired,
+	onLoad: PropTypes.func.isRequired,
+	toggleIsExcluded: PropTypes.func.isRequired,
+	setStockTickers: PropTypes.func.isRequired,
+};

--- a/js/src/components/Metabox.js
+++ b/js/src/components/Metabox.js
@@ -1,0 +1,16 @@
+import NewsEditorContainer from "../containers/EditorContainer";
+
+const { location: { LocationProvider } } = window.yoast.editorModules.components.contexts;
+
+/**
+ * Wraps the NewsEditorContainer in required Metabox components.
+ *
+ * @returns {ReactElement} The NewsMetabox.
+ */
+export default function Metabox() {
+	return (
+		<LocationProvider value="metabox">
+			<NewsEditorContainer />
+		</LocationProvider>
+	);
+}

--- a/js/src/components/Sidebar.js
+++ b/js/src/components/Sidebar.js
@@ -1,0 +1,21 @@
+import { Fill } from "@wordpress/components";
+import NewsEditorContainer from "../containers/EditorContainer";
+
+const { SidebarItem, SidebarCollapsible } = window.yoast.editorModules.components;
+
+/**
+ * Wraps the NewsEditorContainer in required Sidebar components.
+ *
+ * @returns {ReactElement} The VideoSidebar
+ */
+export default function Sidebar( { fillName = "YoastSidebar" } ) {
+	return (
+		<Fill name={ fillName }>
+			<SidebarItem renderPriority={ 33 }>
+				<SidebarCollapsible title="News">
+					<NewsEditorContainer />
+				</SidebarCollapsible>
+			</SidebarItem>
+		</Fill>
+	);
+}

--- a/js/src/containers/EditorContainer.js
+++ b/js/src/containers/EditorContainer.js
@@ -1,0 +1,29 @@
+import { compose } from "@wordpress/compose";
+import { withDispatch, withSelect } from "@wordpress/data";
+import Editor from "../components/Editor";
+
+const newsEditorStore = "yoast-seo-news/editor";
+
+export default compose( [
+	withSelect( select => {
+		const { getChangesAlertLink, getIsExcluded, getStockTickers } = select( newsEditorStore );
+		const { getPostOrPageString } = select( "yoast-seo/editor" );
+
+		return {
+			changesAlertLink: getChangesAlertLink(),
+			isExcluded: getIsExcluded(),
+			postTypeName: getPostOrPageString(),
+			stockTickers: getStockTickers(),
+		};
+	} ),
+
+	withDispatch( dispatch => {
+		const { loadEditorData, toggleIsExcluded, setStockTickers } = dispatch( newsEditorStore );
+
+		return {
+			onLoad: loadEditorData,
+			toggleIsExcluded,
+			setStockTickers,
+		};
+	} ),
+] )( Editor );

--- a/js/src/helpers/fields/EditorFields.js
+++ b/js/src/helpers/fields/EditorFields.js
@@ -1,0 +1,80 @@
+const prefix = "yoast_wpseo_newssitemap-";
+
+/**
+ * This class is responsible for handling the interaction with the hidden fields for News SEO.
+ */
+export default class EditorFields {
+	/**
+	 * Getter for the isExcludedElement.
+	 *
+	 * @returns {HTMLElement} The isExcludedElement.
+	 */
+	static get isExcludedElement() {
+		/*
+		 * The `exclude` and `robots-index` options merged into the latter.
+		 * The interface is still saying `Excluded`.
+		 * That is why this is called Excluded but gets the value from `robots-index`.
+		 */
+		return document.getElementById( this.prefixElementId( "robots-index" ) );
+	}
+
+	/**
+	 * Getter for the stockTickersElement.
+	 *
+	 * @returns {HTMLElement} The stockTickersElement.
+	 */
+	static get stockTickersElement() {
+		return document.getElementById( this.prefixElementId( "stocktickers" ) );
+	}
+
+	/**
+	 * Getter for the isExcluded setting.
+	 *
+	 * @returns {Boolean} The isExcluded setting.
+	 */
+	static get isExcluded() {
+		return EditorFields.isExcludedElement && EditorFields.isExcludedElement.value === "1" || false;
+	}
+
+	/**
+	 * Setter for the isExcluded setting.
+	 *
+	 * @param {boolean} value The value to set.
+	 *
+	 * @returns {void}
+	 */
+	static set isExcluded( value ) {
+		EditorFields.isExcludedElement.value = value ? "1" : "0";
+	}
+
+	/**
+	 * Getter for the stockTickers.
+	 *
+	 * @returns {string} The stockTickers.
+	 */
+	static get stockTickers() {
+		return EditorFields.stockTickersElement && EditorFields.stockTickersElement.value;
+	}
+
+	/**
+	 * Setter for the stockTickers.
+	 *
+	 * @param {string} value The value to set.
+	 *
+	 * @returns {void}
+	 */
+	static set stockTickers( value ) {
+		EditorFields.stockTickersElement.value = value;
+	}
+
+	/**
+	 * Prefixes the passed id with the prefix.
+	 *
+	 * @param {string} partialId The id to prefix.
+	 *
+	 * @returns {string} The prefixed id.
+	 */
+	static prefixElementId( partialId ) {
+		return prefix + partialId;
+	}
+}

--- a/js/src/initializers/initializeEditorPage.js
+++ b/js/src/initializers/initializeEditorPage.js
@@ -1,0 +1,49 @@
+/* global wpseoNewsScriptData */
+import { render } from "@wordpress/element";
+import { addAction } from "@wordpress/hooks";
+import { registerPlugin } from "@wordpress/plugins";
+import Metabox from "../components/Metabox";
+import Sidebar from "../components/Sidebar";
+
+/**
+ * Initializes the metabox.
+ */
+function initializeMetabox() {
+	const element = document.getElementById( "wpseo-news-metabox-root" );
+
+	if ( element ) {
+		render( <Metabox />, element );
+	}
+}
+
+/**
+ * Initializes the sidebar.
+ */
+function initializeSidebar() {
+	if ( wpseoNewsScriptData.isBlockEditor ) {
+		registerPlugin( "yoast-seo-news", { render: Sidebar } );
+	}
+}
+
+/**
+ * Initializes the sidebar in Elementor.
+ */
+function initializeElementorSidebar() {
+	/**
+	 * @returns {ReactElement} The Sidebar for Elementor.
+	 */
+	const ElementorSidebar = () => <Sidebar fillName="YoastElementor" />;
+
+	addAction( "yoast.elementor.loaded", "yoast/yoast-news-seo/load-news-in-elementor", () => {
+		window.YoastSEO._registerReactComponent( "yoast-seo-news", ElementorSidebar );
+	} );
+}
+
+/**
+ * Initializes the content on the editor page.
+ */
+export default function initializeEditorPage() {
+	initializeMetabox();
+	initializeSidebar();
+	initializeElementorSidebar();
+}

--- a/js/src/initializers/initializeSettingsPage.js
+++ b/js/src/initializers/initializeSettingsPage.js
@@ -10,15 +10,13 @@ const genreRemovalAlertElement = document.getElementById( "wpseo-news-genre-remo
  */
 export default function initializeSettingsPage() {
 	render(
-		<li style={{ listStyle: "none", }}>
-			<PersistentDismissableAlert
-				store="yoast-seo/settings"
-				type="info"
-				alertKey="news-settings-genre-removal-alert"
-			>
-				{ __( "Google no longer supports 'Genres' for articles in Google News, therefore we decided to remove the 'Default genre' setting below.", "wordpress-seo-news" ) }
-			</PersistentDismissableAlert>
-		</li>,
-		genreRemovalAlertElement
+		<PersistentDismissableAlert
+			store="yoast-seo/settings"
+			type="info"
+			alertKey="news-settings-genre-removal-alert"
+		>
+			{ __( "Google no longer supports 'Genres' for articles in Google News, therefore we decided to remove the 'Default genre' setting below.", "wordpress-seo-news" ) }
+		</PersistentDismissableAlert>,
+		genreRemovalAlertElement,
 	);
 }

--- a/js/src/initializers/initializeSettingsPage.js
+++ b/js/src/initializers/initializeSettingsPage.js
@@ -1,23 +1,24 @@
 import { render } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
+
 const PersistentDismissableAlert = window.yoast.editorModules.containers.PersistentDismissableAlert;
 
 const genreRemovalAlertElement = document.getElementById( "wpseo-news-genre-removal-alert" );
 
 /**
  * Renders the React content on the Settings pages.
- *
- * @returns {Object} React Element.
  */
 export default function initializeSettingsPage() {
 	render(
-		<PersistentDismissableAlert
-			store="yoast-seo/settings"
-			type="info"
-			alertKey="news-settings-genre-removal-alert"
-		>
-			{ __( "Google no longer supports 'Genres' for articles in Google News, therefore we decided to remove the 'Default genre' setting below.", "wordpress-seo-news" ) }
-		</PersistentDismissableAlert>,
+		<li style={{ listStyle: "none", }}>
+			<PersistentDismissableAlert
+				store="yoast-seo/settings"
+				type="info"
+				alertKey="news-settings-genre-removal-alert"
+			>
+				{ __( "Google no longer supports 'Genres' for articles in Google News, therefore we decided to remove the 'Default genre' setting below.", "wordpress-seo-news" ) }
+			</PersistentDismissableAlert>
+		</li>,
 		genreRemovalAlertElement
 	);
 }

--- a/js/src/redux/actions/editor.js
+++ b/js/src/redux/actions/editor.js
@@ -1,0 +1,48 @@
+import { get } from "lodash";
+import EditorFields from "../../helpers/fields/EditorFields";
+import { INITIAL_STATE } from "../reducers/editor";
+
+export const LOAD_EDITOR_DATA = "LOAD_EDITOR_DATA";
+export const TOGGLE_IS_EXCLUDED = "TOGGLE_IS_EXCLUDED";
+export const SET_STOCK_TICKERS = "SET_STOCK_TICKERS";
+
+/**
+ * Creates an action to load the News editor data.
+ *
+ * @returns {Object} A LOAD_EDITOR_DATA action.
+ */
+export function loadEditorData() {
+	return {
+		type: LOAD_EDITOR_DATA,
+		changesAlertLink: get( window, "wpseoNewsScriptData.newsChangesAlertLink", INITIAL_STATE.changesAlertLink ),
+		isExcluded: EditorFields.isExcluded,
+		stockTickers: EditorFields.stockTickers,
+	};
+}
+
+/**
+ * Creates an action to toggle is excluded.
+ *
+ * @returns {Object} A TOGGLE_IS_EXCLUDED action.
+ */
+export function toggleIsExcluded() {
+	EditorFields.isExcluded = ! EditorFields.isExcluded;
+	return {
+		type: TOGGLE_IS_EXCLUDED,
+	};
+}
+
+/**
+ * Creates an action to set the stock tickers.
+ *
+ * @param {string} stockTickers The stockTickers to set.
+ *
+ * @returns {Object} A SET_STOCK_TICKERS action.
+ */
+export function setStockTickers( stockTickers ) {
+	EditorFields.stockTickers = stockTickers;
+	return {
+		type: SET_STOCK_TICKERS,
+		stockTickers,
+	};
+}

--- a/js/src/redux/reducers/editor.js
+++ b/js/src/redux/reducers/editor.js
@@ -1,2 +1,40 @@
-export default function editorReducer() {
+import { LOAD_EDITOR_DATA, SET_STOCK_TICKERS, TOGGLE_IS_EXCLUDED } from "../actions";
+
+export const INITIAL_STATE = {
+	isLoaded: false,
+	changesAlertLink: "https://yoa.st/news-changes",
+	isExcluded: false,
+	stockTickers: "",
+};
+
+/**
+ * A reducer for the News editor reducer.
+ *
+ * @param {Object} state  The current state of the object.
+ * @param {Object} action The current action received.
+ *
+ * @returns {Object} The state.
+ */
+export default function editorReducer( state = INITIAL_STATE, action ) {
+	switch ( action.type ) {
+		case LOAD_EDITOR_DATA:
+			return {
+				...state,
+				changesAlertLink: action.changesAlertLink,
+				isExcluded: action.isExcluded,
+				stockTickers: action.stockTickers,
+			};
+		case TOGGLE_IS_EXCLUDED:
+			return {
+				...state,
+				isExcluded: ! state.isExcluded,
+			};
+		case SET_STOCK_TICKERS:
+			return {
+				...state,
+				stockTickers: action.stockTickers,
+			};
+		default:
+			return state;
+	}
 }

--- a/js/src/redux/selectors/editor.js
+++ b/js/src/redux/selectors/editor.js
@@ -1,0 +1,35 @@
+import { get } from "lodash";
+import { INITIAL_STATE } from "../reducers/editor";
+
+/**
+ * Selects the changes alert link.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {string} The changes alert link.
+ */
+export function getChangesAlertLink( state ) {
+	return get( state, "editor.changesAlertLink", INITIAL_STATE.changesAlertLink );
+}
+
+/**
+ * Selects the is excluded.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {boolean} The is excluded.
+ */
+export function getIsExcluded( state ) {
+	return get( state, "editor.isExcluded", INITIAL_STATE.isExcluded );
+}
+
+/**
+ * Selects the stock tickers.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {string} The stock tickers.
+ */
+export function getStockTickers( state ) {
+	return get( state, "editor.stockTickers", INITIAL_STATE.stockTickers );
+}

--- a/js/src/yoast-seo-news-editor.js
+++ b/js/src/yoast-seo-news-editor.js
@@ -1,0 +1,10 @@
+import domReady from "@wordpress/dom-ready";
+import initializeEditorStore from "./initializers/initializeEditorStore";
+import initializeTranslations from "./initializers/initializeTranslations";
+import initializeEditorPage from "./initializers/initializeEditorPage";
+
+domReady( () => {
+	initializeTranslations();
+	initializeEditorStore();
+	initializeEditorPage();
+} );

--- a/js/src/yoast-seo-news-settings.js
+++ b/js/src/yoast-seo-news-settings.js
@@ -1,10 +1,8 @@
 import domReady from "@wordpress/dom-ready";
-import initializeEditorStore from "./initializers/initializeEditorStore";
 import initializeTranslations from "./initializers/initializeTranslations";
 import initializeSettingsPage from "./initializers/initializeSettingsPage";
 
 domReady( () => {
 	initializeTranslations();
-	initializeEditorStore();
 	initializeSettingsPage();
 } );

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.7.0",
     "case-sensitive-paths-webpack-plugin": "^2.3.0",
@@ -37,5 +38,8 @@
   },
   "yoast": {
     "pluginVersion": "12.6"
+  },
+  "dependencies": {
+    "prop-types": "^15.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,11 @@ babel-plugin-syntax-jsx@^6.8.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+  integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -1193,6 +1198,14 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  integrity sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-react-jsx@^6.24.1:
   version "6.24.1"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Use React for the News tab in the editor.
* Add News to the sidebar in the block editor and in Elementor.
* Merge the `Exclude` and `Google News`'s (no)index options into one (the latter).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add News to the sidebar in the block editor and in Elementor.
* Changes News in the metabox.
* NON-USER-FACING Fixes an unreleased bug where a JS error would be shown on the settings pages when you have the debug flag on.

## Relevant technical choices:

* Move hook calls from constructor to `register_hooks`, preventing immediate side effects.
* Now always registering extra meta fields. There was a post edit/new and sitemap check around this. The fields can always be registered for simplicity.
* I tried to DRY up the supported post type check, by putting it outside of the hook methods. But the post object is not available on new post pages.
* I could've split WPSEO_News_Meta_Box up in integrations: Post and Elementor split for the script loading. But the concept of integrations and loadables does not exist in News. Decided to keep it simple.
* The merging of the two options: `newssitemap-exclude` and `newssitemap-robots-index` has been done by removing the first (also from the database) and using the second where the first was used. This has been discussed and it is better this way because the `exclude` only influenced the News sitemap, and that is only for a while, since then it is not news anymore. While the `robots-index` has a more permanent effect in the meta tag being output.
  * Removing the `exclude` option from the database in a `12.7` upgrade routine.
* Added `transform-object-rest-spread` to the babel possibilities. Used in the reducer.
* JS error bugfix caused in a previous PR on this epic: https://github.com/Yoast/wpseo-news/pull/676
   * Fixed in collaboration with Marijn and improved by Josee, the width was smaller in the design
     * Tried to add `max-width` to the Alert, but the SEMrush related keyphrases modal uses the Alert slightly wider than 600px.
     * Now added inline style of `max-width: 600px` to the News settings alert wrapper. Inline to prevent having to load a separate stylesheet on this page.
   * Added commas in the echo as codescout, no string concatenation needed
* Deprecated the `add_tab_hooks` method. This was some extra methods wrapping that we don't need. We add the content with the filter in that function directly now (`yoast_free_additional_metabox_sections`).
* Add a JS window object `wpseoNewsScriptData` to use for passing data from PHP to JS in News.
* Added the 3 editors initialization in one JS file. Each have their own "check". This could be nicer in own integrations maybe. But I didn't because we don't have the PHP side split up either. If we did, it makes more sense.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Setup
* Important to test in the block, classic and elementor editor!
* Important to test post/page and a custom post type
* Install & activate:
  * Yoast SEO `16.0-RC4` (or newer / trunk or release branch)
    * For developer from this branch: Please link and build it with the code of this PR: https://github.com/Yoast/javascript/pull/1078 
  * Yoast SEO News `12.7-RC1` (or newer / this branch)
  * Elementor `3.1.1` (and optionally Elementor Pro `3.1.1`)
* Include post types in the News sitemap: SEO -> News SEO -> Post Types to include in News Sitemap
* Enable Elementor for those post types too: Elementor -> Settings -> Post Types
* Set your knowledge graph being represented to a company: SEO -> Search appearance -> Knowledge Graph & Schema.org and set an Organization name and Organization logo

#### Instructions to repeat per editor and post type
* Create a new post/page/CPT
* Check out the design: https://www.sketch.com/s/91b3eccb-1ec9-43c6-b705-b5bbedfdf512/a/Ze1Pav/play
  * The name of the tab no longer has the `Google` part
  * The Google news index has been visually removed
  * **Difference**: you can dismiss the information alert, which is why it has the `X`, unlike the design
  * (the genre already was removed)
* If possible (classic & block), check the metabox: there should be a tab called `News`. It should look like the design
* If possible (block & elementor), check the sidebar: there should be a collapsible called `News`. It should look like the design
* Add something in the stock ticker field
  * When in the block editor, check that when you type this, the metabox/sidebar are in sync.
* Publish the post/page/CPT and visit the frontend of it
* Check the schema output. When it contains an `Article` (not true for the Yoast Test Helper books/movies), the `@type` should have `NewsArticle` added to it
* Check the news sitemap: `http://basic.wordpress.test/news-sitemap.xml` (hint: open in new tab so you can refresh it later). There should be an entry for your post/page/CPT
* View the source of the news sitemap, you should see a `<news:stock_tickers>` entry with your content in between. Something like: `<news:stock_tickers><![CDATA[HELLO]]></news:stock_tickers>` that is part of the post/page/CPT you made
* Go back to the editor
* Change it to be excluded from Google News
* Save and visit the frontend again
* Check that:
  * Schema output no longer adds `NewsArticle` as type (if it was before)
  * There is a meta tag on the page: `<meta name="Googlebot-News" content="noindex">` (for me it was just below the schema output)
  * The post/page/CPT is no longer included in the news sitemap

#### Dismiss alert
* Go to an editor of a post/page/CPT that is News
* Go to the News tab/collapsible
* Dismiss the alert: click on the `X`
* The alert should've disappeared
* Refresh the page and verify the alert is still gone

#### Unreleased alert fix in settings
* Ensure you have `SCRIPT_DEBUG` defined in your WP configuration. Default if you are on our plugin development docker.
* Go to the News settings: SEO -> News SEO
* Do you see the alert here?
  * If not, you should reset it in your database: `wp_usermeta` -> `_yoast_alerts_dismissed` and there remove the `news-settings-genre-removal-alert` part... tricky to do correctly, or remove the whole row. (but then the one in the editor is back also).
  * Then refresh the page
* There should not be any JS warnings in the console. At least not from React.
* The alert should be 600px wide (about as wide as the publication name input).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

![block editor](https://user-images.githubusercontent.com/35524806/109500240-47031700-7a96-11eb-8113-f621679b0294.png)


## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-301
