### PR TITLE
Add the ability to filter News Sitemap items for exclusion

### DIFF
--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -89,7 +89,7 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
-		return apply_filters( 'Yoast\WP\News\skip_build_item', $this->item->ID );
+		return apply_filters( 'Yoast\WP\News\skip_build_item', false, $this->item->ID );
 	}
 
 	/**

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -89,7 +89,7 @@ class WPSEO_News_Sitemap_Item {
 			return true;
 		}
 
-		return false;
+		return apply_filters( 'Yoast\WP\News\skip_build_item', $this->item->ID );
 	}
 
 	/**


### PR DESCRIPTION
## Context
We have a requirement to skip all posts that _don't_ have a specific taxonomy term( "News"). Adding this filter would give us the ability to add our required functionality, and we'd therefore be able to purchase this add-on (otherwise we have to implement the same functionality in-house).

## Summary
This PR can be summarized in the following changelog entry:
changelog: enhancement

## Relevant technical choices:
N/A(?)

## Test instructions
Use the `Yoast\WP\News\skip_build_item` filter to exclude a CPT that has passed the other requirements for not being excluded. The two params are the current exclude status (`false`), and the item ID.

### Test instructions for the acceptance test before the PR gets merged
N/A

### Test instructions for QA when the code is in the RC
N/A

## Impact check
N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
