### PR TITLE
P3-362 Move reading of options outside functions called by options cache priming, to avoid loops

### DIFF
--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -78,7 +78,7 @@ class WPSEO_News {
 	/**
 	 * Populates static properties from options so they have to be queries each time we need them.
 	 */
-	public static function read_options(){
+	public static function read_options() {
 		self::$included_post_types = (array) WPSEO_Options::get( 'news_sitemap_include_post_types', [] );
 		self::$excluded_terms      = (array) WPSEO_Options::get( 'news_sitemap_exclude_terms', [] );
 	}

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -20,6 +20,20 @@ class WPSEO_News {
 	const VERSION = WPSEO_NEWS_VERSION;
 
 	/**
+	 * Included post types.
+	 *
+	 * @var array
+	 */
+	public static $included_post_types = [];
+
+	/**
+	 * Excluded terms.
+	 *
+	 * @var array
+	 */
+	public static $excluded_terms = [];
+
+	/**
 	 * Initializes the plugin.
 	 */
 	public function __construct() {
@@ -52,12 +66,21 @@ class WPSEO_News {
 		add_filter( 'plugin_action_links', [ $this, 'plugin_links' ], 10, 2 );
 		add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_pages' ] );
 		add_action( 'init', [ 'WPSEO_News_Option', 'register_option' ] );
+		add_action( 'init', [ 'WPSEO_News', 'read_options' ] );
 
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
 		add_filter( 'wpseo_helpscout_beacon_settings', [ $this, 'filter_helpscout_beacon' ] );
 
 		add_filter( 'wpseo_frontend_presenters', [ $this, 'add_frontend_presenter' ] );
+	}
+
+	/**
+	 * Populates static properties from options so they have to be queries each time we need them.
+	 */
+	public static function read_options(){
+		self::$included_post_types = (array) WPSEO_Options::get( 'news_sitemap_include_post_types', [] );
+		self::$excluded_terms      = (array) WPSEO_Options::get( 'news_sitemap_exclude_terms', [] );
 	}
 
 	/**
@@ -294,11 +317,9 @@ class WPSEO_News {
 		static $post_types;
 
 		if ( $post_types === null ) {
-			// Get supported post types.
-			$post_types          = [];
-			$included_post_types = (array) WPSEO_Options::get( 'news_sitemap_include_post_types', [] );
+			$post_types = [];
 			foreach ( get_post_types( [ 'public' => true ], 'names' ) as $post_type ) {
-				if ( array_key_exists( $post_type, $included_post_types ) && $included_post_types[ $post_type ] === 'on' ) {
+				if ( array_key_exists( $post_type, self::$included_post_types ) && self::$included_post_types[ $post_type ] === 'on' ) {
 					$post_types[] = $post_type;
 				}
 			}
@@ -332,11 +353,10 @@ class WPSEO_News {
 	 * @return bool True if the post is excluded.
 	 */
 	public static function is_excluded_through_terms( $post_id, $post_type ) {
-		$terms          = self::get_terms_for_post( $post_id, $post_type );
-		$excluded_terms = (array) WPSEO_Options::get( 'news_sitemap_exclude_terms', [] );
+		$terms = self::get_terms_for_post( $post_id, $post_type );
 		foreach ( $terms as $term ) {
 			$option_key = $term->taxonomy . '_' . $term->slug . '_for_' . $post_type;
-			if ( array_key_exists( $option_key, $excluded_terms ) && $excluded_terms[ $option_key ] === 'on' ) {
+			if ( array_key_exists( $option_key, self::$excluded_terms ) && self::$excluded_terms[ $option_key ] === 'on' ) {
 				return true;
 			}
 		}

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -24,14 +24,14 @@ class WPSEO_News {
 	 *
 	 * @var array
 	 */
-	public static $included_post_types = [];
+	protected static $included_post_types = [];
 
 	/**
 	 * Excluded terms.
 	 *
 	 * @var array
 	 */
-	public static $excluded_terms = [];
+	protected static $excluded_terms = [];
 
 	/**
 	 * Initializes the plugin.
@@ -76,7 +76,7 @@ class WPSEO_News {
 	}
 
 	/**
-	 * Populates static properties from options so they have to be queries each time we need them.
+	 * Populates static properties from options so they don't have to be queried each time we need them.
 	 */
 	public static function read_options() {
 		self::$included_post_types = (array) WPSEO_Options::get( 'news_sitemap_include_post_types', [] );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,7 @@
  */
 
 define( 'WPSEO_INDEXABLES', true );
+define( 'WPSEO_NEWS_VERSION', '12.6' );
 
 if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* See #660 for description of the issue

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where certain conditions (e.g. using a different admin language) would result in an endless loop.

## Relevant technical choices:

* The loop was caused by the querying of the options cache in functions called hooked to the WP `get_options`. The variables storying the options value were converted to static properties since they are accessed by static methods. This is not optimal, also for testing purposes.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* in `Settings` > `General`, install a different language from the default one. Then, switch back to the default language, but this way you will have the chance to select a different language for your user.
* In `Users` > `Profile`, change the language of your account and save
* visit `Appearance` > `Customize` and observe that everythings looks good and you don't get any fatal error for Maximum nested functions or a `Bad gateway` page.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #660, [P3-362]
