### PR TITLE
Adjust sitemap query to improve performance

### DIFF
--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -230,7 +230,7 @@ class WPSEO_News_Sitemap {
 				"SELECT ID, post_content, post_name, post_author, post_parent, post_date_gmt, post_date, post_date_gmt, post_title, post_type
 				FROM {$wpdb->posts}
 				WHERE post_status='publish'
-					AND ( TIMESTAMPDIFF( MINUTE, post_date_gmt, UTC_TIMESTAMP() ) <= ( 48 * 60 ) )
+					AND post_date_gmt >= NOW() - INTERVAL 48 HOUR
 					AND post_type IN (" . implode( ',', array_fill( 0, count( $post_types ), '%s' ) ) . ')
 				ORDER BY post_date_gmt DESC
 				LIMIT 0, %d

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -238,7 +238,7 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 			]
 		);
 
-		$two_days_ago = strtotime( '-48 hours' );
+		$two_days_ago = strtotime( '-47 hours -59 minutes' );
 
 		$this->factory->post->create(
 			[


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve the sitemap query performance.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the performance of the news sitemap. Props to [archon810](https://github.com/archon810).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have a large selection of posts that have a valid post type for the news sitemap ( these are set in the settings ).
* This should include posts more than 2 days old ( these should not show in the sitemap ).
* The output of the news sitemap should be identical, with all valid items less than 2 days old appearing and valid items more than 2 days old not appearing.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The news sitemap.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #690 
