### PR TITLE
Allow filtering of decision to skip building sitemap item

### DIFF
--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -94,7 +94,9 @@ class WPSEO_News_Sitemap_Item {
 		 *
 		 * @since 12.8.0
 		 */
-		return apply_filters( 'Yoast\WP\News\skip_build_item', $skip_build_item, $this->item->ID );
+		$skip_build_item = apply_filters( 'Yoast\WP\News\skip_build_item', $skip_build_item, $this->item->ID );
+
+		return is_bool( $skip_build_item ) && $skip_build_item;
 	}
 
 	/**

--- a/classes/sitemap-item.php
+++ b/classes/sitemap-item.php
@@ -66,25 +66,35 @@ class WPSEO_News_Sitemap_Item {
 	 * @return bool True if the item has to be skipped.
 	 */
 	private function skip_build_item() {
+		$skip_build_item = false;
+
 		if ( WPSEO_News::is_excluded_through_sitemap( $this->item->ID ) ) {
-			return true;
+			$skip_build_item = true;
 		}
 
 		$item_noindex = WPSEO_Meta::get_value( 'meta-robots-noindex', $this->item->ID );
 
 		if ( $item_noindex === '1' ) {
-			return true;
+			$skip_build_item = true;
 		}
 
 		if ( $item_noindex === '0' && WPSEO_Options::get( 'noindex-' . $this->item->post_type ) === true ) {
-			return true;
+			$skip_build_item = true;
 		}
 
 		if ( WPSEO_News::is_excluded_through_terms( $this->item->ID, $this->item->post_type ) ) {
-			return true;
+			$skip_build_item = true;
 		}
 
-		return apply_filters( 'Yoast\WP\News\skip_build_item', false, $this->item->ID );
+		/**
+		 * Filter: 'Yoast\WP\News\skip_build_item' - Allow override of decision to skip adding this item to the news sitemap.
+		 *
+		 * @param bool $skip_build_item Whether this item should be built for the sitemap.
+		 * @param int  $item_id         ID of the current item to be skipped or not.
+		 *
+		 * @since 12.8.0
+		 */
+		return apply_filters( 'Yoast\WP\News\skip_build_item', $skip_build_item, $this->item->ID );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Some users have additional criteria to include/exclude items from the news sitemap. Therefore, we make the decision to include an item filterable.
* From joneslloyd: We have a requirement to skip all posts that _don't_ have a specific taxonomy term( "News"). Adding this filter would give us the ability to add our required functionality, and we'd therefore be able to purchase this add-on (otherwise we have to implement the same functionality in-house).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a filter to override the decision to omit an item from the news sitemap. Props to [joneslloyd](https://github.com/joneslloyd)

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In news-seo, go to the news settings and add posts to news sitemap.
* find the id of a post appearing on the sitemap (your-site/news-sitemap.xml).
* Add this function to your `functions.php` in the appearance/theme-editor.
```php
function test_skip_build( $should_build, $post_id ) {
	// For the item with this ID
	if ( $post_id === "120" ) {
		if ( $should_build === false ) {
			// If we actually should not build it into the sitemap (so skip it), flip it to build.
			return true;
		}
		// If we actually should build it into the sitemap, flip it to skip.
		return false;
	};
}
add_filter( 'Yoast\WP\News\skip_build_item', 'test_skip_build', 10, 2 );
```
* replace the number in `if ( $post_id === "120" ) {` with the id you found.
* save and hard reload the sitemap. The post should now be gone.
* Open the post in the editor, and in news select "exclude from the sitemap".
* It should now appear again, because the function you added overrides the skip.
* Remove the function from your functions.php, reload the sitemap, and the post should be gone from the sitemap.
* Untick "exclude from sitemap" and the post should reappear on the sitemap on reload.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
