### PR TITLE
P2 1093 implement abstract indexable presenter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ jobs:
         - chmod 600 ./deploy_keys/wpseo_news_deploy
         - eval $(ssh-agent -s)
         - ssh-add ./deploy_keys/wpseo_news_deploy
+        - composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
       before_deploy:
         - nvm install node
         - curl -o- -L https://yarnpkg.com/install.sh | bash
@@ -76,9 +77,9 @@ jobs:
 before_install:
 - if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
 - export SECURITYCHECK_DIR=/tmp/security-checker
+- composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
 
 install:
-- composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
 - |
   if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,8 @@ before_install:
 - export SECURITYCHECK_DIR=/tmp/security-checker
 
 install:
+- composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
 - |
-  composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
   if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_retry composer install --no-interaction --ignore-platform-reqs
   elif [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" || "$COVERAGE" == "1" || "$PHPLINT" == "1" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ jobs:
         - chmod 600 ./deploy_keys/wpseo_news_deploy
         - eval $(ssh-agent -s)
         - ssh-add ./deploy_keys/wpseo_news_deploy
+        - composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
       before_deploy:
         - nvm install node
         - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ jobs:
         - chmod 600 ./deploy_keys/wpseo_news_deploy
         - eval $(ssh-agent -s)
         - ssh-add ./deploy_keys/wpseo_news_deploy
-        - composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
       before_deploy:
         - nvm install node
         - curl -o- -L https://yarnpkg.com/install.sh | bash
@@ -80,6 +79,7 @@ before_install:
 
 install:
 - |
+  composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
   if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_retry composer install --no-interaction --ignore-platform-reqs
   elif [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" || "$COVERAGE" == "1" || "$PHPLINT" == "1" ]]; then

--- a/classes/googlebot-news-presenter.php
+++ b/classes/googlebot-news-presenter.php
@@ -26,12 +26,12 @@ class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Tag_Present
 	 */
 	protected $tag_format = self::META_NAME_CONTENT;
 
-    /**
-     * The method of escaping.
-     *
-     * @var string
-     */
-    protected $escaping = 'attribute';
+	/**
+	 * The method of escaping.
+	 *
+	 * @var string
+	 */
+	protected $escaping = 'attribute';
 
 	/**
 	 * Get the value for the Googlebot-news meta value.

--- a/classes/googlebot-news-presenter.php
+++ b/classes/googlebot-news-presenter.php
@@ -26,6 +26,13 @@ class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Tag_Present
 	 */
 	protected $tag_format = self::META_NAME_CONTENT;
 
+    /**
+     * The method of escaping.
+     *
+     * @var string
+     */
+	protected $escaping = 'attribute';
+
 	/**
 	 * Get the value for the Googlebot-news meta value.
 	 *

--- a/classes/googlebot-news-presenter.php
+++ b/classes/googlebot-news-presenter.php
@@ -31,7 +31,7 @@ class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Tag_Present
      *
      * @var string
      */
-	protected $escaping = 'attribute';
+    protected $escaping = 'attribute';
 
 	/**
 	 * Get the value for the Googlebot-news meta value.

--- a/classes/googlebot-news-presenter.php
+++ b/classes/googlebot-news-presenter.php
@@ -5,13 +5,13 @@
  * @package WPSEO_News
  */
 
-use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
  * Represents the Googlebot-News tag presenter.
  */
 class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Tag_Presenter {
-	
+
 	/**
 	 * The tag key name.
 	 *

--- a/classes/googlebot-news-presenter.php
+++ b/classes/googlebot-news-presenter.php
@@ -67,21 +67,7 @@ class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Tag_Present
 	 * @return bool True when noindex tag should be rendered.
 	 */
 	protected function display_noindex( $post ) {
-		/**
-		 * Filter: 'wpseo_news_head_display_noindex' - Allow preventing of outputting noindex tag.
-		 *
-		 * @param object $post The post.
-		 *
-		 * @api        string $meta_robots The noindex tag.
-		 *
-		 * @deprecated 12.5.0. Use the {@see 'Yoast\WP\News\head_display_noindex'} filter instead.
-		 */
-		$display_noindex = apply_filters_deprecated(
-			'wpseo_news_head_display_noindex',
-			[ true, $post ],
-			'YoastSEO News 12.5.0',
-			'Yoast\WP\News\head_display_noindex'
-		);
+        $display_noindex = true;
 
 		/**
 		 * Filter: 'Yoast\WP\News\head_display_noindex' - Allow preventing of outputting noindex tag.

--- a/classes/googlebot-news-presenter.php
+++ b/classes/googlebot-news-presenter.php
@@ -67,7 +67,7 @@ class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Tag_Present
 	 * @return bool True when noindex tag should be rendered.
 	 */
 	protected function display_noindex( $post ) {
-        $display_noindex = true;
+		$display_noindex = true;
 
 		/**
 		 * Filter: 'Yoast\WP\News\head_display_noindex' - Allow preventing of outputting noindex tag.

--- a/classes/googlebot-news-presenter.php
+++ b/classes/googlebot-news-presenter.php
@@ -10,24 +10,31 @@ use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 /**
  * Represents the Googlebot-News tag presenter.
  */
-class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Presenter {
+class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Tag_Presenter {
+	
+	/**
+	 * The tag key name.
+	 *
+	 * @var string
+	 */
+	protected $key = 'Googlebot-News';
 
 	/**
-	 * Renders the Googlebot-News noindex tag when applicable.
+	 * The tag format including placeholders.
 	 *
-	 * @return string The rendered meta tag.
+	 * @var string
 	 */
-	public function present() {
+	protected $tag_format = self::META_NAME_CONTENT;
+
+	/**
+	 * Get the value for the Googlebot-news meta value.
+	 *
+	 * @return string The raw value.
+	 */
+	public function get() {
 		if ( $this->presentation->model->object_type !== 'post' ) {
 			return '';
 		}
-
-		/**
-		 * Allow for running additional code before adding the News header tags.
-		 *
-		 * @deprecated 12.5.0 Use the {@see 'Yoast\WP\News\head'} action instead.
-		 */
-		do_action_deprecated( 'wpseo_news_head', [], 'YoastSEO News 12.5.0', 'Yoast\WP\News\head' );
 
 		/**
 		 * Allow for running additional code before adding the News header tags.
@@ -37,18 +44,9 @@ class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Presenter {
 		do_action( 'Yoast\WP\News\head' );
 
 		if ( $this->display_noindex( $this->presentation->source ) ) {
-			return '<meta name="Googlebot-News" content="noindex" />';
+			return 'noindex';
 		}
 
-		return '';
-	}
-
-	/**
-	 * This method is not used, but required to fulfil the abstract class interface.
-	 *
-	 * @return string The raw value.
-	 */
-	public function get() {
 		return '';
 	}
 
@@ -61,7 +59,7 @@ class WPSEO_News_Googlebot_News_Presenter extends Abstract_Indexable_Presenter {
 	 *
 	 * @return bool True when noindex tag should be rendered.
 	 */
-	private function display_noindex( $post ) {
+	protected function display_noindex( $post ) {
 		/**
 		 * Filter: 'wpseo_news_head_display_noindex' - Allow preventing of outputting noindex tag.
 		 *

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -5,8 +5,6 @@
  * @package WPSEO_News
  */
 
-use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
-
 /**
  * Represents the news extension for Yoast SEO.
  */
@@ -147,8 +145,8 @@ class WPSEO_News {
 			return false;
 		}
 
-		// At least 16.1, which includes the @yoast/components checkbox.
-		if ( version_compare( $wordpress_seo_version, '16.1-beta0', '<' ) ) {
+		// At least 16.7, which includes the new Abstract_Indexable_Tag_Presenter.
+		if ( version_compare( $wordpress_seo_version, '16.7-RC0', '<' ) ) {
 			add_action( 'all_admin_notices', [ $this, 'error_upgrade_wpseo' ] );
 
 			return false;

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,30 @@
         "issues": "https://github.com/Yoast/wpseo-news/issues",
         "source": "https://github.com/Yoast/wpseo-news"
     },
+    "repositories": {
+        "wordpress-seo": {
+            "type": "vcs",
+            "url": "https://github.com/yoast/wordpress-seo"
+        }
+    },
     "require": {
         "php": ">=5.6",
         "yoast/i18n-module": "^3.1.1"
     },
     "require-dev": {
+        "phpunit/phpunit": "^5.7",
         "yoast/yoastcs": "^2.1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.0",
         "php-parallel-lint/php-console-highlighter": "^0.5",
         "yoast/wp-test-utils": "^0.2.1",
-        "yoast/wordpress-seo": "^16.7-RC1"
+        "yoast/wordpress-seo": "dev-trunk@dev"
+    },
+    "extra": {
+        "installer-paths": {
+            "vendor/{$vendor}/{$name}": [
+                "type:wordpress-plugin"
+            ]
+        }
     },
     "config": {
         "platform": {
@@ -56,7 +70,7 @@
             "Yoast\\WP\\News\\Composer\\Actions::check_coding_standards"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/vendor/*"
         ],
         "check-staged-cs": [
             "@check-cs --filter=GitStaged"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "yoast/i18n-module": "^3.1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
         "yoast/yoastcs": "^2.1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.0",
         "php-parallel-lint/php-console-highlighter": "^0.5",

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,15 @@
         "yoast/yoastcs": "^2.1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.0",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "yoast/wp-test-utils": "^0.2.1"
+        "yoast/wp-test-utils": "^0.2.1",
+        "yoast/wordpress-seo": "^16.7-RC1"
     },
     "config": {
         "platform": {
             "php": "5.6.40"
+        },
+        "preferred-install": {
+            "yoast/wordpress-seo": "source"
         }
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbbc220de7e5558e918b53a966d5f3cd",
+    "content-hash": "0cfad9b1562a93887962c0efba572b4f",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -174,6 +174,156 @@
                 "source": "https://github.com/Brain-WP/BrainMonkey"
             },
             "time": "2020-10-13T17:56:14+00:00"
+        },
+        {
+            "name": "composer/installers",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "ae03311f45dfe194412081526be2e003960df74b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/ae03311f45dfe194412081526be2e003960df74b",
+                "reference": "ae03311f45dfe194412081526be2e003960df74b",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.6.* || ^2.0",
+                "composer/semver": "^1 || ^3",
+                "phpstan/phpstan": "^0.12.55",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.3"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Eliasis",
+                "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
+                "MODX Evo",
+                "MantisBT",
+                "Mautic",
+                "Maya",
+                "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
+                "SMF",
+                "Starbug",
+                "Thelia",
+                "Whmcs",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "attogram",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "cockpit",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "eZ Platform",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "itop",
+                "joomla",
+                "known",
+                "kohana",
+                "laravel",
+                "lavalite",
+                "lithium",
+                "magento",
+                "majima",
+                "mako",
+                "mediawiki",
+                "miaoxing",
+                "modulework",
+                "modx",
+                "moodle",
+                "osclass",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "processwire",
+                "puppet",
+                "pxcms",
+                "reindex",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "sydes",
+                "sylius",
+                "symfony",
+                "tastyigniter",
+                "typo3",
+                "wordpress",
+                "yawik",
+                "zend",
+                "zikula"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-28T06:42:17+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -2382,6 +2532,74 @@
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
             "time": "2020-11-25T02:59:57+00:00"
+        },
+        {
+            "name": "yoast/wordpress-seo",
+            "version": "16.7-RC3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast-dist/wordpress-seo.git",
+                "reference": "bca4340144dedaaafbfd107aac3c0fb5c439639c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast-dist/wordpress-seo/zipball/bca4340144dedaaafbfd107aac3c0fb5c439639c",
+                "reference": "bca4340144dedaaafbfd107aac3c0fb5c439639c",
+                "shasum": ""
+            },
+            "require": {
+                "composer/installers": "^1.9.0",
+                "php": "^5.6.20||^7.0",
+                "yoast/i18n-module": "^3.1.1"
+            },
+            "require-dev": {
+                "humbug/php-scoper": "^0.13.4",
+                "league/oauth2-client": "2.4.1",
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
+                "phpunit/phpunit": "^5.7",
+                "psr/container": "1.0.0",
+                "psr/log": "^1.0",
+                "symfony/config": "^3.4",
+                "symfony/dependency-injection": "^3.4",
+                "yoast/php-development-environment": "^1.0",
+                "yoast/wp-test-utils": "^0.2.1",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "classmap": [
+                    "admin/",
+                    "inc/",
+                    "vendor_prefixed/",
+                    "src/",
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoa.st/1--"
+                }
+            ],
+            "description": "Improve your WordPress SEO: Write better content and have a fully optimized WordPress site using the Yoast SEO plugin.",
+            "homepage": "https://yoa.st/1ui",
+            "keywords": [
+                "seo",
+                "wordpress"
+            ],
+            "support": {
+                "forum": "https://wordpress.org/support/plugin/wordpress-seo",
+                "issues": "https://github.com/Yoast/wordpress-seo/issues",
+                "source": "https://github.com/Yoast/wordpress-seo",
+                "wiki": "https://github.com/Yoast/wordpress-seo/wiki"
+            },
+            "time": "2021-06-30T13:13:21+00:00"
         },
         {
             "name": "yoast/wp-test-utils",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0cfad9b1562a93887962c0efba572b4f",
+    "content-hash": "05c68b3cc6f9baf165bf515778d617be",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -2472,25 +2472,25 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "0.2.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab"
+                "reference": "5d257d5a6977137016f3df440ce640ce72ffd61a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c48e4cf0c44b2d892540846aff19fb0468627bab",
-                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5d257d5a6977137016f3df440ce640ce72ffd61a",
+                "reference": "5d257d5a6977137016f3df440ce640ce72ffd61a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": ">=5.4",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
                 "yoast/yoastcs": "^2.1.0"
             },
             "type": "library",
@@ -2531,20 +2531,20 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2020-11-25T02:59:57+00:00"
+            "time": "2021-06-21T03:13:22+00:00"
         },
         {
             "name": "yoast/wordpress-seo",
-            "version": "16.7-RC3",
+            "version": "dev-trunk",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Yoast-dist/wordpress-seo.git",
-                "reference": "bca4340144dedaaafbfd107aac3c0fb5c439639c"
+                "url": "https://github.com/Yoast/wordpress-seo.git",
+                "reference": "9068995f79f198a47bcc9bfb58c7ab94dd402465"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast-dist/wordpress-seo/zipball/bca4340144dedaaafbfd107aac3c0fb5c439639c",
-                "reference": "bca4340144dedaaafbfd107aac3c0fb5c439639c",
+                "url": "https://api.github.com/repos/Yoast/wordpress-seo/zipball/9068995f79f198a47bcc9bfb58c7ab94dd402465",
+                "reference": "9068995f79f198a47bcc9bfb58c7ab94dd402465",
                 "shasum": ""
             },
             "require": {
@@ -2566,6 +2566,7 @@
                 "yoast/wp-test-utils": "^0.2.1",
                 "yoast/yoastcs": "^2.1.0"
             },
+            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "classmap": [
@@ -2576,7 +2577,90 @@
                     "lib/"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "classmap": [
+                    "tests/",
+                    "config/"
+                ]
+            },
+            "scripts": {
+                "test": [
+                    "@php ./vendor/phpunit/phpunit/phpunit"
+                ],
+                "integration-test": [
+                    "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
+                ],
+                "lint": [
+                    "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude vendor_prefixed --exclude node_modules --exclude .git"
+                ],
+                "lint-files": [
+                    "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint"
+                ],
+                "lint-branch": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::lint_branch"
+                ],
+                "lint-staged": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::lint_staged"
+                ],
+                "cs": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
+                ],
+                "check-cs-thresholds": [
+                    "@putenv YOASTCS_THRESHOLD_ERRORS=276",
+                    "@putenv YOASTCS_THRESHOLD_WARNINGS=223",
+                    "Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
+                ],
+                "check-cs-summary": [
+                    "@check-cs-warnings --report=summary"
+                ],
+                "check-cs": [
+                    "@check-cs-warnings -n"
+                ],
+                "check-cs-errors": [
+                    "echo You can now just use check-cs, running that command now.",
+                    "composer check-cs"
+                ],
+                "check-cs-warnings": [
+                    "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+                ],
+                "check-staged-cs": [
+                    "@check-cs-warnings --filter=GitStaged"
+                ],
+                "check-branch-cs": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::check_branch_cs"
+                ],
+                "fix-cs": [
+                    "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+                ],
+                "prefix-dependencies": [
+                    "composer prefix-oauth2-client",
+                    "composer prefix-symfony"
+                ],
+                "prefix-oauth2-client": [
+                    "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/league/oauth2-client --config=config/php-scoper/oauth2-client.inc.php --force --quiet",
+                    "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/guzzlehttp --config=config/php-scoper/guzzlehttp.inc.php --force --quiet",
+                    "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/psr --config=config/php-scoper/psr.inc.php --force --quiet"
+                ],
+                "prefix-symfony": [
+                    "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/symfony/dependency-injection --config=config/php-scoper/dependency-injection.inc.php --force --quiet"
+                ],
+                "compile-di": [
+                    "rm -f ./src/generated/container.php",
+                    "rm -f ./src/generated/container.php.meta",
+                    "composer du --no-scripts",
+                    "Yoast\\WP\\SEO\\Composer\\Actions::compile_dependency_injection_container"
+                ],
+                "post-autoload-dump": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::prefix_dependencies",
+                    "composer compile-di"
+                ],
+                "generate-migration": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::generate_migration"
+                ],
+                "generate-unit-test": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::generate_unit_test"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
@@ -2594,35 +2678,35 @@
                 "wordpress"
             ],
             "support": {
-                "forum": "https://wordpress.org/support/plugin/wordpress-seo",
                 "issues": "https://github.com/Yoast/wordpress-seo/issues",
-                "source": "https://github.com/Yoast/wordpress-seo",
-                "wiki": "https://github.com/Yoast/wordpress-seo/wiki"
+                "forum": "https://wordpress.org/support/plugin/wordpress-seo",
+                "wiki": "https://github.com/Yoast/wordpress-seo/wiki",
+                "source": "https://github.com/Yoast/wordpress-seo"
             },
-            "time": "2021-06-30T13:13:21+00:00"
+            "time": "2021-07-02T14:18:41+00:00"
         },
         {
             "name": "yoast/wp-test-utils",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wp-test-utils.git",
-                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101"
+                "reference": "896f7640d86162ff7a0dc6ce59f8837f284521c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/c5cdabd58f2aa6f2a93f734cf48125f880c90101",
-                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/896f7640d86162ff7a0dc6ce59f8837f284521c5",
+                "reference": "896f7640d86162ff7a0dc6ce59f8837f284521c5",
                 "shasum": ""
             },
             "require": {
                 "brain/monkey": "^2.6.0",
                 "php": ">=5.6",
-                "yoast/phpunit-polyfills": "^0.2.0"
+                "yoast/phpunit-polyfills": "^1.0.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
                 "yoast/yoastcs": "^2.1.0"
             },
             "type": "library",
@@ -2665,7 +2749,7 @@
                 "issues": "https://github.com/Yoast/wp-test-utils/issues",
                 "source": "https://github.com/Yoast/wp-test-utils"
             },
-            "time": "2020-12-09T15:26:02+00:00"
+            "time": "2021-06-21T03:45:02+00:00"
         },
         {
             "name": "yoast/yoastcs",
@@ -2725,7 +2809,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "yoast/wordpress-seo": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -1,6 +1,7 @@
 // See https://github.com/sindresorhus/grunt-shell
 module.exports = function( grunt ) {
 	return {
+		
 		"composer-install": {
 			command: "composer install",
 		},

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -8,7 +8,7 @@ module.exports = function( grunt ) {
 		"php-lint": {
 			command: "composer lint",
 		},
-		phpcs: {
+		"phpcs": {
 			command: "composer check-cs",
 		},
 

--- a/integration-tests/wpseo-news-test.php
+++ b/integration-tests/wpseo-news-test.php
@@ -55,9 +55,9 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 			[ false, false, '5.3', 'WordPress SEO is not installed.' ],
 			[ false, '8.1', '5.6', 'WordPress SEO is below the minimal required version.' ],
 			[ false, '16.0-beta0', '5.7', 'WordPress SEO is below the minimal required version.' ],
-			[ true, '16.1-RC0', '5.7', 'WordPress and WordPress SEO have the minimal required versions.' ],
-			[ true, '16.1-beta0', '5.7', 'WordPress and WordPress SEO have the minimal required versions.' ],
-			[ true, '16.1-RC0', '5.6', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '16.7-RC1', '5.7', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '16.7-RC1', '5.7', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '16.7-RC1', '5.6', 'WordPress and WordPress SEO have the minimal required versions.' ],
 		];
 	}
 }

--- a/tests/googlebot-news-presenter-test.php
+++ b/tests/googlebot-news-presenter-test.php
@@ -50,8 +50,6 @@ class Googlebot_News_Presenter_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		Mockery::mock( 'overload:\Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter' );
-
 		$this->instance     = new WPSEO_News_Googlebot_News_Presenter();
 		$this->presentation = Mockery::mock();
 		$this->model        = Mockery::mock();
@@ -70,7 +68,7 @@ class Googlebot_News_Presenter_Test extends TestCase {
 	public function test_present_for_non_post() {
 		$this->model->object_type = 'term';
 
-		$this->assertSame( '', $this->instance->present() );
+		$this->assertSame( '', $this->instance->get() );
 	}
 
 	/**
@@ -89,33 +87,12 @@ class Googlebot_News_Presenter_Test extends TestCase {
 			->with( 'newssitemap-robots-index', 1337 )
 			->andReturnFalse();
 
-		Monkey\Functions\expect( 'do_action_deprecated' )
-			->once()
-			->with(
-				'wpseo_news_head',
-				[],
-				'YoastSEO News 12.5.0',
-				'Yoast\WP\News\head'
-			);
-
 		Monkey\Actions\expectDone( 'Yoast\WP\News\head' );
-
-		Monkey\Functions\expect( 'apply_filters_deprecated' )
-			->once()
-			->with(
-				'wpseo_news_head_display_noindex',
-				[
-					true,
-					$this->source,
-				],
-				'YoastSEO News 12.5.0',
-				'Yoast\WP\News\head_display_noindex'
-			);
 
 		Monkey\Filters\expectApplied( 'Yoast\WP\News\head_display_noindex' )
 			->andReturn( true );
 
-		$this->assertSame( '', $this->instance->present() );
+		$this->assertSame( '', $this->instance->get() );
 	}
 
 	/**
@@ -128,33 +105,12 @@ class Googlebot_News_Presenter_Test extends TestCase {
 		$this->model->object_type = 'post';
 		$this->source->ID         = 1337;
 
-		Monkey\Functions\expect( 'do_action_deprecated' )
-			->once()
-			->with(
-				'wpseo_news_head',
-				[],
-				'YoastSEO News 12.5.0',
-				'Yoast\WP\News\head'
-			);
-
 		Monkey\Actions\expectDone( 'Yoast\WP\News\head' );
-
-		Monkey\Functions\expect( 'apply_filters_deprecated' )
-			->once()
-			->with(
-				'wpseo_news_head_display_noindex',
-				[
-					true,
-					$this->source,
-				],
-				'YoastSEO News 12.5.0',
-				'Yoast\WP\News\head_display_noindex'
-			);
 
 		Monkey\Filters\expectApplied( 'Yoast\WP\News\head_display_noindex' )
 			->andReturn( false );
 
-		$this->assertSame( '', $this->instance->present() );
+		$this->assertSame( '', $this->instance->get() );
 	}
 
 	/**
@@ -167,34 +123,14 @@ class Googlebot_News_Presenter_Test extends TestCase {
 		$this->model->object_type = 'post';
 		$this->source->ID         = 1337;
 
+        $this->stubEscapeFunctions();
+
 		$meta = Mockery::mock( 'overload:WPSEO_Meta' );
 		$meta
 			->expects( 'get_value' )
 			->with( 'newssitemap-robots-index', 1337 )
 			->andReturnTrue();
-
-		Monkey\Functions\expect( 'do_action_deprecated' )
-			->once()
-			->with(
-				'wpseo_news_head',
-				[],
-				'YoastSEO News 12.5.0',
-				'Yoast\WP\News\head'
-			);
-
 		Monkey\Actions\expectDone( 'Yoast\WP\News\head' );
-
-		Monkey\Functions\expect( 'apply_filters_deprecated' )
-			->once()
-			->with(
-				'wpseo_news_head_display_noindex',
-				[
-					true,
-					$this->source,
-				],
-				'YoastSEO News 12.5.0',
-				'Yoast\WP\News\head_display_noindex'
-			);
 
 		Monkey\Filters\expectApplied( 'Yoast\WP\News\head_display_noindex' )
 			->andReturn( true );

--- a/tests/googlebot-news-presenter-test.php
+++ b/tests/googlebot-news-presenter-test.php
@@ -123,7 +123,7 @@ class Googlebot_News_Presenter_Test extends TestCase {
 		$this->model->object_type = 'post';
 		$this->source->ID         = 1337;
 
-        $this->stubEscapeFunctions();
+		$this->stubEscapeFunctions();
 
 		$meta = Mockery::mock( 'overload:WPSEO_Meta' );
 		$meta

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -33,4 +33,29 @@ abstract class TestCase extends YoastTestCase {
 			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
 			->andReturn( [] );
 	}
+
+    /**
+     * Stub the WP native escaping functions.
+     *
+     * The stubs created by this function return the original input string unchanged.
+     *
+     * Alternative to the BrainMonkey `Monkey\Functions\stubEscapeFunctions()` function
+     * which does apply some form of escaping to the input.
+     *
+     * @return void
+     */
+    public function stubEscapeFunctions() {
+        Monkey\Functions\stubs(
+            [
+                'esc_js',
+                'esc_sql',
+                'esc_attr',
+                'esc_html',
+                'esc_textarea',
+                'esc_url',
+                'esc_url_raw',
+                'esc_xml',
+            ]
+        );
+    }
 }

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -33,29 +33,4 @@ abstract class TestCase extends YoastTestCase {
 			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
 			->andReturn( [] );
 	}
-
-	/**
-	 * Stub the WP native escaping functions.
-	 *
-	 * The stubs created by this function return the original input string unchanged.
-	 *
-	 * Alternative to the BrainMonkey `Monkey\Functions\stubEscapeFunctions()` function
-	 * which does apply some form of escaping to the input.
-	 *
-	 * @return void
-	 */
-	public function stubEscapeFunctions() {
-		Monkey\Functions\stubs(
-			[
-				'esc_js',
-				'esc_sql',
-				'esc_attr',
-				'esc_html',
-				'esc_textarea',
-				'esc_url',
-				'esc_url_raw',
-				'esc_xml',
-			]
-		);
-	}
 }

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -34,28 +34,28 @@ abstract class TestCase extends YoastTestCase {
 			->andReturn( [] );
 	}
 
-    /**
-     * Stub the WP native escaping functions.
-     *
-     * The stubs created by this function return the original input string unchanged.
-     *
-     * Alternative to the BrainMonkey `Monkey\Functions\stubEscapeFunctions()` function
-     * which does apply some form of escaping to the input.
-     *
-     * @return void
-     */
-    public function stubEscapeFunctions() {
-        Monkey\Functions\stubs(
-            [
-                'esc_js',
-                'esc_sql',
-                'esc_attr',
-                'esc_html',
-                'esc_textarea',
-                'esc_url',
-                'esc_url_raw',
-                'esc_xml',
-            ]
-        );
-    }
+	/**
+	 * Stub the WP native escaping functions.
+	 *
+	 * The stubs created by this function return the original input string unchanged.
+	 *
+	 * Alternative to the BrainMonkey `Monkey\Functions\stubEscapeFunctions()` function
+	 * which does apply some form of escaping to the input.
+	 *
+	 * @return void
+	 */
+	public function stubEscapeFunctions() {
+		Monkey\Functions\stubs(
+			[
+				'esc_js',
+				'esc_sql',
+				'esc_attr',
+				'esc_html',
+				'esc_textarea',
+				'esc_url',
+				'esc_url_raw',
+				'esc_xml',
+			]
+		);
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Made News compatible with new Abstract Indexable Tag Presenter in free 16.7

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds News SEO data to the new json head fields.

## Relevant technical choices:

* removed a deprecated filter
* moved present logic to get method
* added key and tag format to make the presenter compatible with the `Abstract_Indexable_Tag_Presenter` that's new in free 16.7

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

by default, this PR doesn't do anything, because empty values are not output in the JSON head fields.
* access a post via the rest API; 
* visit https://basic.wordpress.test/wp-json/wp/v2/posts
   output starts with [{"id":xxxxx -> use xxxxx as the Id for the next steps.
* visit http://[your-wordpress-server]/wp-json/wp/v2/posts/xxxxx
* copy & paste the entire output in a json prettifier e.g. https://jsonformatter.curiousconcept.com/
* the json output should show a yoast_head_json property, with no `Googlebot-News` key 

To make the the Googlebot-News-Presenter output anything:
this can only be done by third party integrations using filters. we'll do it by hand here: 
* open the `classes\googlebot-news-presenter.php` file
* change the first line of the `public function get()` function to `return 'noindex';` note that this gives the exact same output as when the filter would return a positive result.
* repeat the above rest api call, visit http://[your-wordpress-server]/wp-json/wp/v2/posts/xxxxx
* note the yoast_head_json field now contains a `Googlebot_News` key with the text value `noindex`; 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA have to also test the additional item below when testing the RC:

* Confirm that the Yoast Free plugin is NOT added in the  `/vendor` dir in the RC (much like it doesn't, with already released versions).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* headless rest api

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
