### PR TITLE
Changed direct database query into a query using WP_Query.

### DIFF
--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -222,16 +222,18 @@ class WPSEO_News_Sitemap {
 		$limit = max( 1, min( 1000, $limit ) );
 
 		// Get posts from the last two days only.
-		$query = new \WP_Query( [
-			'post_status'    => 'publish',
-			'post_type'      => [ $post_types ],
-			'date_query'     => [
-				'after' => '2 days ago',
-			],
-			'order_by'       => 'date',
-			'order'          => 'DESC',
-			'posts_per_page' => $limit
-		] );
+		$query = new \WP_Query(
+			[
+				'post_status'    => 'publish',
+				'post_type'      => [ $post_types ],
+				'date_query'     => [
+					'after' => '2 days ago',
+				],
+				'order_by'       => 'date',
+				'order'          => 'DESC',
+				'posts_per_page' => $limit,
+			]
+		);
 
 		return $query->get_posts();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We do not want to query the WordPress database directly but, when possible, use one of the abstraction layers that WordPress provides to be able to cache the results of the query.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors the database query that retrieves the items for the News SEO sitemap to use `WP_Query` instead of a direct database call.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to your News SEO settings (_SEO_ > _News SEO_ in the admin sidebar). 
* Make sure that **Post Types to include in News Sitemap** is set to _Posts (post)_.
* Create a couple of posts.
* Go to your site's News SEO sitemap (e.g. http://basic.wordpress.test/news-sitemap.xml)
* You should see the posts you created appear in the sitemap.
	* Note: only the posts created within the last two days (48 hours) should appear.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Please check if the News SEO sitemap works as expected.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #787
