### PR TITLE
Update (fix) test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,20 +171,26 @@ script:
     travis_time_finish && travis_fold end "PHP.code-style"
   fi
 # PHP Integration Tests
-
 - |
-  if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
+  if [[ "$PHPUNIT" == "1" && "$WP_VERSION" != "latest" ]] && [[ "$WP_VERSION" == "5.9" || "${WP_VERSION:0:1}" == "6" || "$WP_VERSION" == "master" ]]; then
+    travis_fold start "PHP.integration-tests" && travis_time_start
+    composer config --unset platform.php &&
+    travis_retry composer update yoast/wp-test-utils --with-all-dependencies --no-interaction &&
+    vendor/bin/phpunit -c phpunit-integration.xml.dist
+    travis_time_finish && travis_fold end "PHP.integration-tests"
+  elif [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
     travis_fold start "PHP.integration-tests" && travis_time_start
     composer integration-test
     travis_time_finish && travis_fold end "PHP.integration-tests"
-  fi
-- |
-  if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
+  elif [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_fold start "PHP.integration-tests" && travis_time_start
     travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
     composer integration-test
     travis_time_finish && travis_fold end "PHP.integration-tests"
   fi
+# Reset Composer dependencies between the different test setups.
+- git checkout composer.lock composer.json
+- travis_retry composer install --no-interaction
 # PHP Unit Tests
 - |
   if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
@@ -195,7 +201,6 @@ script:
 - |
   if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
-    travis_retry composer remove --dev phpunit/phpunit --no-update &&
     travis_retry composer update yoast/wp-test-utils --with-dependencies --ignore-platform-reqs --no-interaction &&
     composer test
     travis_time_finish && travis_fold end "PHP.tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ jobs:
       env: WP_VERSION=latest PHPLINT=1 PHPUNIT=1
     - php: 8.0
       env: WP_VERSION=latest PHPLINT=1 PHPUNIT=1
-    - php: "nightly"
-      env: PHPLINT=1
     - stage: deploy-to-github-dist
       env: WP_VERSION=latest
       if: tag IS present
@@ -70,7 +68,6 @@ jobs:
           all_branches: true
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "nightly"
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "yoast/yoastcs": "^2.2.0",
-        "yoast/wp-test-utils": "^0.2.1",
+        "yoast/wp-test-utils": "^1.0.0",
         "yoast/wordpress-seo": "dev-trunk@dev"
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc9dbbe41919561109638e695ccf0a06",
+    "content-hash": "42223620a892d22d0c1e57570b58fb36",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -59,16 +59,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.12",
+            "version": "2.1.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea"
+                "reference": "0430ceaac7f447f1778c199ec19d7e4362a6f961"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/b98e046dd4c0acc34a0846604f06f6111654d9ea",
-                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/0430ceaac7f447f1778c199ec19d7e4362a6f961",
+                "reference": "0430ceaac7f447f1778c199ec19d7e4362a6f961",
                 "shasum": ""
             },
             "require": {
@@ -101,9 +101,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.12"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.15"
             },
-            "time": "2019-12-22T17:52:09+00:00"
+            "time": "2021-08-22T08:00:13+00:00"
         },
         {
             "name": "brain/monkey",
@@ -506,16 +506,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "31467aeb3ca3188158613322d66df81cedd86626"
+                "reference": "472fa8ca4e55483d55ee1e73c963718c4393791d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/31467aeb3ca3188158613322d66df81cedd86626",
-                "reference": "31467aeb3ca3188158613322d66df81cedd86626",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/472fa8ca4e55483d55ee1e73c963718c4393791d",
+                "reference": "472fa8ca4e55483d55ee1e73c963718c4393791d",
                 "shasum": ""
             },
             "require": {
@@ -569,9 +569,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.3.4"
+                "source": "https://github.com/mockery/mockery/tree/1.3.5"
             },
-            "time": "2021-02-24T09:51:00+00:00"
+            "time": "2021-09-13T15:33:03+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2472,16 +2472,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "5d257d5a6977137016f3df440ce640ce72ffd61a"
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5d257d5a6977137016f3df440ce640ce72ffd61a",
-                "reference": "5d257d5a6977137016f3df440ce640ce72ffd61a",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
                 "shasum": ""
             },
             "require": {
@@ -2489,9 +2489,7 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.3.0",
-                "yoast/yoastcs": "^2.1.0"
+                "yoast/yoastcs": "^2.2.0"
             },
             "type": "library",
             "extra": {
@@ -2531,7 +2529,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-06-21T03:13:22+00:00"
+            "time": "2021-10-03T08:40:26+00:00"
         },
         {
             "name": "yoast/wordpress-seo",
@@ -2687,27 +2685,25 @@
         },
         {
             "name": "yoast/wp-test-utils",
-            "version": "0.2.2",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wp-test-utils.git",
-                "reference": "896f7640d86162ff7a0dc6ce59f8837f284521c5"
+                "reference": "21df3a08974ee62f489f64e34be7f26a32ec872c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/896f7640d86162ff7a0dc6ce59f8837f284521c5",
-                "reference": "896f7640d86162ff7a0dc6ce59f8837f284521c5",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/21df3a08974ee62f489f64e34be7f26a32ec872c",
+                "reference": "21df3a08974ee62f489f64e34be7f26a32ec872c",
                 "shasum": ""
             },
             "require": {
                 "brain/monkey": "^2.6.0",
                 "php": ">=5.6",
-                "yoast/phpunit-polyfills": "^1.0.0"
+                "yoast/phpunit-polyfills": "^1.0.1"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.3.0",
-                "yoast/yoastcs": "^2.1.0"
+                "yoast/yoastcs": "^2.2.0"
             },
             "type": "library",
             "extra": {
@@ -2719,6 +2715,10 @@
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "exclude-from-classmap": [
+                    "/src/WPIntegration/TestCase.php",
+                    "/src/WPIntegration/TestCaseNoPolyfills.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2749,7 +2749,7 @@
                 "issues": "https://github.com/Yoast/wp-test-utils/issues",
                 "source": "https://github.com/Yoast/wp-test-utils"
             },
-            "time": "2021-06-21T03:45:02+00:00"
+            "time": "2021-09-27T05:50:36+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/integration-tests/admin-page-test.php
+++ b/integration-tests/admin-page-test.php
@@ -20,8 +20,8 @@ class WPSEO_News_Admin_Page_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Setting up the instance of WPSEO_News_Admin_Page.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Because is a global $wpseo_admin_pages we have to fill this one with an instance of WPSEO_Admin_Pages.
 		global $wpseo_admin_pages;

--- a/integration-tests/schema-test.php
+++ b/integration-tests/schema-test.php
@@ -27,8 +27,8 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Setting up the instance of WPSEO_News_Schema.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->date = date_create();
 

--- a/integration-tests/sitemap-images-test.php
+++ b/integration-tests/sitemap-images-test.php
@@ -22,8 +22,8 @@ class WPSEO_News_Sitemap_Images_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Setting up the instance of WPSEO_News_Sitemap_Images.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Create a post, so the new object can actually be created.
 		// Neither is actually used for the current unit tests.
@@ -36,10 +36,10 @@ class WPSEO_News_Sitemap_Images_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Clean up after all tests in this class have run.
 	 */
-	public function tearDown() {
+	public function tear_down() {
 		$this->instance = null;
 
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	/**

--- a/integration-tests/sitemap-test.php
+++ b/integration-tests/sitemap-test.php
@@ -20,8 +20,8 @@ class WPSEO_News_Sitemap_Test extends WPSEO_News_UnitTestCase {
 	/**
 	 * Setting up the instance of WPSEO_News_Sitemap.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->instance = new WPSEO_News_Sitemap();
 	}

--- a/phpunit-integration.xml.dist
+++ b/phpunit-integration.xml.dist
@@ -6,6 +6,7 @@
 		backupStaticAttributes="false"
 		bootstrap="integration-tests/bootstrap.php"
 		colors="true"
+		convertDeprecationsToExceptions="true"
 		convertErrorsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
 		backupStaticAttributes="false"
 		bootstrap="tests/bootstrap.php"
 		colors="true"
+		convertDeprecationsToExceptions="true"
 		convertErrorsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"


### PR DESCRIPTION
## Context

* Update test setup

## Summary

This PR can be summarized in the following changelog entry:

* Updates test setup

## Relevant technical choices:

See the [Make Core dev-note about the test changes](https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/) for the context of these changes.

### PHPUnit: update configuration

PHPUnit recently released version 9.5.10 and 8.5.21.

This contains a particular (IMO breaking) change:

> * PHPUnit no longer converts PHP deprecations to exceptions by default (configure `convertDeprecationsToExceptions="true"` to enable this)

Let's unpack this:

Previously (PHPUnit < 9.5.10/8.5.21), if PHPUnit would encounter a PHP native deprecation notice, it would:
1. Show a test which causes a deprecation notice to be thrown as **"errored"**,
2. Show the **first** deprecation notice it encountered and
3. PHPUnit would exit with a **non-0 exit code** (2), which will fail a CI build.

As of PHPUnit 9.5.10/8.5.21, if PHPUnit encounters a PHP native deprecation notice, it will no longer do so. Instead PHPUnit will:
1. Show a test which causes a PHP deprecation notice to be thrown as **"risky"**,
2. Show the **all** deprecation notices it encountered and
3. PHPUnit will exit with a **0 exit code**, which will show a CI build as passing.

This commit reverts PHPUnit to the previous behaviour by adding `convertDeprecationsToExceptions="true"` to the PHPUnit configuration.

Refs:
* https://github.com/sebastianbergmann/phpunit/blob/9.5/ChangeLog-8.5.md
* https://github.com/sebastianbergmann/phpunit/blob/9.5/ChangeLog-9.5.md

### Composer: update to WP Test Utils 1.0.0

WP Test Utils 1.0.0 provides cross-version compatibility with the test setup from WP < 5.9 and WP 5.9+.

Includes updating the dependencies of WP Test Utils.

Refs:
* https://github.com/Yoast/wp-test-utils/releases/
* https://github.com/Yoast/PHPUnit-Polyfills/releases/
* https://github.com/mockery/mockery/releases/tag/1.3.5
* https://github.com/antecedent/patchwork/releases

### Integration tests: switch to snake_case fixtures

Switches over:
* `setUpBeforeClass()` to `set_up_before_class()`.
* `setUp()` to `set_up()`.
* `tearDown()` to `tear_down()`.
* `tearDownAfterClass()` to `tear_down_after_class()`.

### Travis: update for using correct PHPUnit version with WP 5.9+

As of WP 5.9, the integration tests can run on PHPUnit 5.7 - 9.x and should use the most appropriate PHPUnit version for the PHP version on which the tests are being run.

For WP < 5.9, the range of supported PHPUnit versions is still PHPUnit 5.7 - 7.x.

With that in mind and with there being a) a `config - platform - php` setting and b) a committed `composer.lock` file, some version juggling needs to be done.

For WP < 5.9, the logic previously used remains in place.
For WP 5.9, new logic is introduced.

As the conditions if they were to be made stand-alone would get pretty complicated, I've resorted to using `if - elif` conditions instead of stand-alone conditions.

Note:
* To make sure the various composer changes don't interfere with each between the test runs for the integration tests and the brainmonkey tests, a git reset of the `composer.lock` and the `composer.json` files is done and a `composer install` is run at the end of select test runs.

### Travis: remove nightly

At this time, the current PHP 8.0 version is `8.0.11`. The Travis PHP `8.0` image yields PHP `8.0.9`, which is good enough for PHP 8.0.

`nightly` however is PHP `8.0.3` and hasn't been updated since Feb 2021, so running tests against that image is completely useless at this time.

Notes:
    * Tested `nightly` against all relevant `dist`s - `xenial`, `bionic` and `focal` and none have a more current image.
    * The [PHP Build project](https://github.com/php-build/php-build/tree/master/share/php-build/definitions), which Travis pulls its images from, _does_ have a PHP `8.1snapshot` image available.
        I've tested to see if that image is available on Travis, but unfortunately, no luck there either.




## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See that the last build against `trunk` failed: https://app.travis-ci.com/github/Yoast/wpseo-news/builds/237591535
* See that it passes again with this PR.
    - Verify that builds against WP 5.9 / `master` are run against the most appropriate PHPUnit version.