### PR TITLE
Add Schema Article News subtypes

### DIFF
--- a/classes/schema.php
+++ b/classes/schema.php
@@ -51,7 +51,6 @@ class WPSEO_News_Schema {
 		return $post_types;
 	}
 
-
 	/**
 	 * Adds copyright information.
 	 *
@@ -120,14 +119,17 @@ class WPSEO_News_Schema {
 	 * @return array $schema_article_types Schema article types.
 	 */
 	public function schema_add_news_types( $schema_article_types ) {
-		return array_merge( $schema_article_types, [
-			'AnalysisNewsArticle'   => '',
-			'AskPublicNewsArticle'  => '',
-			'BackgroundNewsArticle' => '',
-			'OpinionNewsArticle'    => '',
-			'ReportageNewsArticle'  => '',
-			'ReviewNewsArticle'     => '',
-		] );
+		return array_merge(
+			$schema_article_types,
+			[
+				'AnalysisNewsArticle'   => '',
+				'AskPublicNewsArticle'  => '',
+				'BackgroundNewsArticle' => '',
+				'OpinionNewsArticle'    => '',
+				'ReportageNewsArticle'  => '',
+				'ReviewNewsArticle'     => '',
+			]
+		);
 	}
 
 	/**
@@ -138,31 +140,32 @@ class WPSEO_News_Schema {
 	 * @return array $schema_article_types_labels Schema article types with labels.
 	 */
 	public function schema_add_news_types_labels( $schema_article_types_labels ) {
-		return array_merge( $schema_article_types_labels,
+		return array_merge(
+			$schema_article_types_labels,
 			[
 				[
 					'name'  => __( 'News: Analysis article', 'wordpress-seo-news' ),
-					'value' => 'AnalysisNewsArticle'
+					'value' => 'AnalysisNewsArticle',
 				],
 				[
 					'name'  => __( 'News: Ask The Public article', 'wordpress-seo-news' ),
-					'value' => 'AskPublicNewsArticle'
+					'value' => 'AskPublicNewsArticle',
 				],
 				[
 					'name'  => __( 'News: Background article', 'wordpress-seo-news' ),
-					'value' => 'BackgroundNewsArticle'
+					'value' => 'BackgroundNewsArticle',
 				],
 				[
 					'name'  => __( 'News: Opinion article', 'wordpress-seo-news' ),
-					'value' => 'OpinionNewsArticle'
+					'value' => 'OpinionNewsArticle',
 				],
 				[
 					'name'  => __( 'News: Reportage article', 'wordpress-seo-news' ),
-					'value' => 'ReportageNewsArticle'
+					'value' => 'ReportageNewsArticle',
 				],
 				[
 					'name'  => __( 'News: Review article', 'wordpress-seo-news' ),
-					'value' => 'ReviewNewsArticle'
+					'value' => 'ReviewNewsArticle',
 				],
 			]
 		);

--- a/classes/schema.php
+++ b/classes/schema.php
@@ -27,8 +27,10 @@ class WPSEO_News_Schema {
 	public function __construct() {
 		$this->date = new WPSEO_Date_Helper();
 
+		add_filter( 'wpseo_schema_article_types', [ $this, 'schema_add_news_types' ] );
+		add_filter( 'wpseo_schema_article_types_labels', [ $this, 'schema_add_news_types_labels' ] );
+
 		add_filter( 'wpseo_schema_article_post_types', [ $this, 'article_post_types' ] );
-		add_filter( 'wpseo_schema_article_type', [ $this, 'add_news_article_type' ] );
 		add_filter( 'wpseo_schema_article', [ $this, 'add_copyright_information' ] );
 	}
 
@@ -49,43 +51,6 @@ class WPSEO_News_Schema {
 		return $post_types;
 	}
 
-	/**
-	 * Adds the NewsArticle type.
-	 *
-	 * @param array|string $type Schema Article type.
-	 *
-	 * @return array Schema Article type.
-	 */
-	public function add_news_article_type( $type ) {
-		$post = $this->get_post();
-
-		if ( ! $this->is_post_type_included( $post ) ) {
-			return $type;
-		}
-		if ( $this->is_post_excluded( $post ) ) {
-			return $type;
-		}
-
-		// Make sure that we are dealing with an array of types.
-		if ( ! is_array( $type ) ) {
-			$type = [ $type ];
-		}
-
-		/*
-		 * Replace `None` with `Article` if included.
-		 * This is to keep it consistent with post types that already include an Article.
-		 */
-		$type = array_map(
-			static function ( $value ) {
-				return ( $value === 'None' ) ? 'Article' : $value;
-			},
-			$type
-		);
-
-		$type[] = 'NewsArticle';
-
-		return $type;
-	}
 
 	/**
 	 * Adds copyright information.
@@ -145,5 +110,61 @@ class WPSEO_News_Schema {
 	 */
 	protected function get_post( $post = null ) {
 		return get_post( $post );
+	}
+
+	/**
+	 * Add schema article types.
+	 *
+	 * @param array $schema_article_types Schema article types.
+	 *
+	 * @return array $schema_article_types Schema article types.
+	 */
+	public function schema_add_news_types( $schema_article_types ) {
+		return array_merge( $schema_article_types, [
+			'AnalysisNewsArticle'   => '',
+			'AskPublicNewsArticle'  => '',
+			'BackgroundNewsArticle' => '',
+			'OpinionNewsArticle'    => '',
+			'ReportageNewsArticle'  => '',
+			'ReviewNewsArticle'     => '',
+		] );
+	}
+
+	/**
+	 * Add schema article types with labels.
+	 *
+	 * @param array $schema_article_types_labels Schema article types with labels.
+	 *
+	 * @return array $schema_article_types_labels Schema article types with labels.
+	 */
+	public function schema_add_news_types_labels( $schema_article_types_labels ) {
+		return array_merge( $schema_article_types_labels,
+			[
+				[
+					'name'  => __( 'News: Analysis article', 'wordpress-seo-news' ),
+					'value' => 'AnalysisNewsArticle'
+				],
+				[
+					'name'  => __( 'News: Ask The Public article', 'wordpress-seo-news' ),
+					'value' => 'AskPublicNewsArticle'
+				],
+				[
+					'name'  => __( 'News: Background article', 'wordpress-seo-news' ),
+					'value' => 'BackgroundNewsArticle'
+				],
+				[
+					'name'  => __( 'News: Opinion article', 'wordpress-seo-news' ),
+					'value' => 'OpinionNewsArticle'
+				],
+				[
+					'name'  => __( 'News: Reportage article', 'wordpress-seo-news' ),
+					'value' => 'ReportageNewsArticle'
+				],
+				[
+					'name'  => __( 'News: Review article', 'wordpress-seo-news' ),
+					'value' => 'ReviewNewsArticle'
+				],
+			]
+		);
 	}
 }

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -66,6 +66,7 @@ class WPSEO_News {
 		add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_pages' ] );
 		add_action( 'init', [ 'WPSEO_News_Option', 'register_option' ] );
 		add_action( 'init', [ 'WPSEO_News', 'read_options' ] );
+
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
 		add_filter( 'wpseo_helpscout_beacon_settings', [ $this, 'filter_helpscout_beacon' ] );

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -66,8 +66,6 @@ class WPSEO_News {
 		add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_pages' ] );
 		add_action( 'init', [ 'WPSEO_News_Option', 'register_option' ] );
 		add_action( 'init', [ 'WPSEO_News', 'read_options' ] );
-		add_filter( 'wpseo_schema_article_types', [ $this, 'schema_add_news_types' ] );
-		add_filter( 'wpseo_schema_article_types_labels', [ $this, 'schema_add_news_types_labels' ] );
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
 		add_filter( 'wpseo_helpscout_beacon_settings', [ $this, 'filter_helpscout_beacon' ] );
@@ -76,62 +74,6 @@ class WPSEO_News {
 
 		$editor_reactification_alert = new WPSEO_News_Settings_Genre_Removal_Alert();
 		$editor_reactification_alert->register_hooks();
-	}
-
-	/**
-	 * Add schema article types.
-	 *
-	 * @param array $schema_article_types Schema article types.
-	 *
-	 * @return array $schema_article_types Schema article types.
-	 */
-	public function schema_add_news_types( $schema_article_types ) {
-		return array_merge( $schema_article_types, [
-			'AnalysisNewsArticle'   => '',
-			'AskPublicNewsArticle'  => '',
-			'BackgroundNewsArticle' => '',
-			'OpinionNewsArticle'    => '',
-			'ReportageNewsArticle'  => '',
-			'ReviewNewsArticle'     => '',
-		] );
-	}
-
-	/**
-	 * Add schema article types with labels.
-	 *
-	 * @param array $schema_article_types_labels Schema article types with labels.
-	 *
-	 * @return array $schema_article_types_labels Schema article types with labels.
-	 */
-	public function schema_add_news_types_labels( $schema_article_types_labels ) {
-		return array_merge( $schema_article_types_labels,
-			[
-				[
-					'name'  => __( 'News: Analysis article', 'wordpress-seo-news' ),
-					'value' => 'AnalysisNewsArticle'
-				],
-				[
-					'name'  => __( 'News: Ask The Public article', 'wordpress-seo-news' ),
-					'value' => 'AskPublicNewsArticle'
-				],
-				[
-					'name'  => __( 'News: Background article', 'wordpress-seo-news' ),
-					'value' => 'BackgroundNewsArticle'
-				],
-				[
-					'name'  => __( 'News: Opinion article', 'wordpress-seo-news' ),
-					'value' => 'OpinionNewsArticle'
-				],
-				[
-					'name'  => __( 'News: Reportage article', 'wordpress-seo-news' ),
-					'value' => 'ReportageNewsArticle'
-				],
-				[
-					'name'  => __( 'News: Review article', 'wordpress-seo-news' ),
-					'value' => 'ReviewNewsArticle'
-				],
-			]
-		);
 	}
 
 	/**

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -66,7 +66,8 @@ class WPSEO_News {
 		add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_pages' ] );
 		add_action( 'init', [ 'WPSEO_News_Option', 'register_option' ] );
 		add_action( 'init', [ 'WPSEO_News', 'read_options' ] );
-
+		add_filter( 'wpseo_schema_article_types', [ $this, 'schema_add_news_types' ] );
+		add_filter( 'wpseo_schema_article_types_labels', [ $this, 'schema_add_news_types_labels' ] );
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
 		add_filter( 'wpseo_helpscout_beacon_settings', [ $this, 'filter_helpscout_beacon' ] );
@@ -75,6 +76,62 @@ class WPSEO_News {
 
 		$editor_reactification_alert = new WPSEO_News_Settings_Genre_Removal_Alert();
 		$editor_reactification_alert->register_hooks();
+	}
+
+	/**
+	 * Add schema article types.
+	 *
+	 * @param array $schema_article_types Schema article types.
+	 *
+	 * @return array $schema_article_types Schema article types.
+	 */
+	public function schema_add_news_types( $schema_article_types ) {
+		return array_merge( $schema_article_types, [
+			'AnalysisNewsArticle'   => '',
+			'AskPublicNewsArticle'  => '',
+			'BackgroundNewsArticle' => '',
+			'OpinionNewsArticle'    => '',
+			'ReportageNewsArticle'  => '',
+			'ReviewNewsArticle'     => '',
+		] );
+	}
+
+	/**
+	 * Add schema article types with labels.
+	 *
+	 * @param array $schema_article_types_labels Schema article types with labels.
+	 *
+	 * @return array $schema_article_types_labels Schema article types with labels.
+	 */
+	public function schema_add_news_types_labels( $schema_article_types_labels ) {
+		return array_merge( $schema_article_types_labels,
+			[
+				[
+					'name'  => __( 'News: Analysis article', 'wordpress-seo-news' ),
+					'value' => 'AnalysisNewsArticle'
+				],
+				[
+					'name'  => __( 'News: Ask The Public article', 'wordpress-seo-news' ),
+					'value' => 'AskPublicNewsArticle'
+				],
+				[
+					'name'  => __( 'News: Background article', 'wordpress-seo-news' ),
+					'value' => 'BackgroundNewsArticle'
+				],
+				[
+					'name'  => __( 'News: Opinion article', 'wordpress-seo-news' ),
+					'value' => 'OpinionNewsArticle'
+				],
+				[
+					'name'  => __( 'News: Reportage article', 'wordpress-seo-news' ),
+					'value' => 'ReportageNewsArticle'
+				],
+				[
+					'name'  => __( 'News: Review article', 'wordpress-seo-news' ),
+					'value' => 'ReviewNewsArticle'
+				],
+			]
+		);
 	}
 
 	/**
@@ -112,7 +169,7 @@ class WPSEO_News {
 
 		// Setting action for removing the transient on update options.
 		if ( class_exists( 'WPSEO_Sitemaps_Cache' )
-			&& method_exists( 'WPSEO_Sitemaps_Cache', 'register_clear_on_option_update' )
+			 && method_exists( 'WPSEO_Sitemaps_Cache', 'register_clear_on_option_update' )
 		) {
 			WPSEO_Sitemaps_Cache::register_clear_on_option_update(
 				'wpseo_news',
@@ -224,6 +281,7 @@ class WPSEO_News {
 	 */
 	protected function get_version() {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
+
 		return $asset_manager->flatten_version( self::VERSION );
 	}
 
@@ -263,7 +321,7 @@ class WPSEO_News {
 	public function error_missing_wpseo() {
 		echo '<div class="error"><p>';
 		printf(
-			/* translators: %1$s resolves to the link to search for Yoast SEO, %2$s resolves to the closing tag for this link, %3$s resolves to Yoast SEO, %4$s resolves to News SEO */
+		/* translators: %1$s resolves to the link to search for Yoast SEO, %2$s resolves to the closing tag for this link, %3$s resolves to Yoast SEO, %4$s resolves to News SEO */
 			esc_html__(
 				'Please %1$sinstall &amp; activate %3$s%2$s and then enable its XML sitemap functionality to allow the %4$s module to work.',
 				'wordpress-seo-news'
@@ -284,7 +342,7 @@ class WPSEO_News {
 	public function error_upgrade_wp() {
 		echo '<div class="error"><p>';
 		printf(
-			/* translators: %1$s resolves to News SEO */
+		/* translators: %1$s resolves to News SEO */
 			esc_html__(
 				'Please upgrade WordPress to the latest version to allow WordPress and the %1$s module to work properly.',
 				'wordpress-seo-news'
@@ -302,7 +360,7 @@ class WPSEO_News {
 	public function error_upgrade_wpseo() {
 		echo '<div class="error"><p>';
 		printf(
-			/* translators: %1$s resolves to Yoast SEO, %2$s resolves to News SEO */
+		/* translators: %1$s resolves to Yoast SEO, %2$s resolves to News SEO */
 			esc_html__(
 				'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.',
 				'wordpress-seo-news'
@@ -415,10 +473,10 @@ class WPSEO_News {
 	/**
 	 * Listing the genres.
 	 *
+	 * @return array
 	 * @deprecated 12.7 News genres are deprecated.
 	 * @codeCoverageIgnore
 	 *
-	 * @return array
 	 */
 	public static function list_genres() {
 		_deprecated_function( __METHOD__, 'WPSEO News 12.7' );

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -169,7 +169,7 @@ class WPSEO_News {
 
 		// Setting action for removing the transient on update options.
 		if ( class_exists( 'WPSEO_Sitemaps_Cache' )
-			 && method_exists( 'WPSEO_Sitemaps_Cache', 'register_clear_on_option_update' )
+			&& method_exists( 'WPSEO_Sitemaps_Cache', 'register_clear_on_option_update' )
 		) {
 			WPSEO_Sitemaps_Cache::register_clear_on_option_update(
 				'wpseo_news',
@@ -281,7 +281,6 @@ class WPSEO_News {
 	 */
 	protected function get_version() {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
-
 		return $asset_manager->flatten_version( self::VERSION );
 	}
 
@@ -321,7 +320,7 @@ class WPSEO_News {
 	public function error_missing_wpseo() {
 		echo '<div class="error"><p>';
 		printf(
-		/* translators: %1$s resolves to the link to search for Yoast SEO, %2$s resolves to the closing tag for this link, %3$s resolves to Yoast SEO, %4$s resolves to News SEO */
+			/* translators: %1$s resolves to the link to search for Yoast SEO, %2$s resolves to the closing tag for this link, %3$s resolves to Yoast SEO, %4$s resolves to News SEO */
 			esc_html__(
 				'Please %1$sinstall &amp; activate %3$s%2$s and then enable its XML sitemap functionality to allow the %4$s module to work.',
 				'wordpress-seo-news'
@@ -342,7 +341,7 @@ class WPSEO_News {
 	public function error_upgrade_wp() {
 		echo '<div class="error"><p>';
 		printf(
-		/* translators: %1$s resolves to News SEO */
+			/* translators: %1$s resolves to News SEO */
 			esc_html__(
 				'Please upgrade WordPress to the latest version to allow WordPress and the %1$s module to work properly.',
 				'wordpress-seo-news'
@@ -360,7 +359,7 @@ class WPSEO_News {
 	public function error_upgrade_wpseo() {
 		echo '<div class="error"><p>';
 		printf(
-		/* translators: %1$s resolves to Yoast SEO, %2$s resolves to News SEO */
+			/* translators: %1$s resolves to Yoast SEO, %2$s resolves to News SEO */
 			esc_html__(
 				'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.',
 				'wordpress-seo-news'
@@ -473,10 +472,10 @@ class WPSEO_News {
 	/**
 	 * Listing the genres.
 	 *
-	 * @return array
 	 * @deprecated 12.7 News genres are deprecated.
 	 * @codeCoverageIgnore
 	 *
+	 * @return array
 	 */
 	public static function list_genres() {
 		_deprecated_function( __METHOD__, 'WPSEO News 12.7' );

--- a/integration-tests/schema-test.php
+++ b/integration-tests/schema-test.php
@@ -119,116 +119,58 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	}
 
 	/**
-	 * Tests the news article type.
+	 * Tests the Schema news types.
 	 *
-	 * @covers WPSEO_News_Schema::add_news_article_type
-	 * @covers WPSEO_News_Schema::is_post_type_included
-	 * @covers WPSEO_News_Schema::is_post_excluded
+	 * @covers WPSEO_News_Schema::schema_add_news_types
 	 */
-	public function test_add_news_article_type() {
-		$this->set_post_mock();
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'get_post' );
-
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'is_post_excluded' )
-			->willReturn( false );
-
+	public function test_schema_add_news_types() {
 		$this->assertSame(
-			[ 'Article', 'NewsArticle' ],
-			$this->default_mock->add_news_article_type( [ 'Article' ] )
+			[
+				'AnalysisNewsArticle'   => '',
+				'AskPublicNewsArticle'  => '',
+				'BackgroundNewsArticle' => '',
+				'OpinionNewsArticle'    => '',
+				'ReportageNewsArticle'  => '',
+				'ReviewNewsArticle'     => '',
+			],
+			$this->default_mock->schema_add_news_types( [] )
 		);
 	}
 
 	/**
-	 * Tests that news article type changes None to Article.
+	 * Tests the Schema news types labels.
 	 *
-	 * @covers WPSEO_News_Schema::add_news_article_type
-	 * @covers WPSEO_News_Schema::is_post_type_included
-	 * @covers WPSEO_News_Schema::is_post_excluded
+	 * @covers WPSEO_News_Schema::schema_add_news_types_labels
 	 */
-	public function test_add_news_article_type_change_none() {
-		$this->set_post_mock();
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'get_post' );
-
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'is_post_excluded' )
-			->willReturn( false );
-
+	public function test_schema_add_news_types_labels() {
 		$this->assertSame(
-			[ 'Article', 'NewsArticle' ],
-			$this->default_mock->add_news_article_type( [ 'None' ] )
-		);
-	}
-
-	/**
-	 * Tests that news article type handling type as string.
-	 *
-	 * @covers WPSEO_News_Schema::add_news_article_type
-	 * @covers WPSEO_News_Schema::is_post_type_included
-	 * @covers WPSEO_News_Schema::is_post_excluded
-	 */
-	public function test_add_news_article_type_handle_string() {
-		$this->set_post_mock();
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'get_post' );
-
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'is_post_excluded' )
-			->willReturn( false );
-
-		$this->assertSame(
-			[ 'Article', 'NewsArticle' ],
-			$this->default_mock->add_news_article_type( 'None' )
-		);
-	}
-
-	/**
-	 * Tests that news article type is not changed when the post type is not included.
-	 *
-	 * @covers WPSEO_News_Schema::add_news_article_type
-	 * @covers WPSEO_News_Schema::is_post_type_included
-	 */
-	public function test_add_news_article_type_post_type_not_included() {
-		$this->set_post_mock( 'other_post_type' );
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'get_post' );
-
-		$this->assertSame(
-			'None',
-			$this->default_mock->add_news_article_type( 'None' )
-		);
-	}
-
-	/**
-	 * Tests that news article type is not changed when the post is excluded.
-	 *
-	 * @covers WPSEO_News_Schema::add_news_article_type
-	 * @covers WPSEO_News_Schema::is_post_type_included
-	 * @covers WPSEO_News_Schema::is_post_excluded
-	 */
-	public function test_add_news_article_type_post_excluded() {
-		$this->set_post_mock();
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'get_post' );
-
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'is_post_excluded' )
-			->willReturn( true );
-
-		$this->assertSame(
-			'None',
-			$this->default_mock->add_news_article_type( 'None' )
+			[
+				[
+					'name'  => 'News: Analysis article',
+					'value' => 'AnalysisNewsArticle',
+				],
+				[
+					'name'  => 'News: Ask The Public article',
+					'value' => 'AskPublicNewsArticle',
+				],
+				[
+					'name'  => 'News: Background article',
+					'value' => 'BackgroundNewsArticle',
+				],
+				[
+					'name'  => 'News: Opinion article',
+					'value' => 'OpinionNewsArticle',
+				],
+				[
+					'name'  => 'News: Reportage article',
+					'value' => 'ReportageNewsArticle',
+				],
+				[
+					'name'  => 'News: Review article',
+					'value' => 'ReviewNewsArticle',
+				],
+			],
+			$this->default_mock->schema_add_news_types_labels( [] )
 		);
 	}
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add Schema Article News subtypes (`ReviewNewsArticle`, `AnalysisNewsArticle`, `AskPublicNewsArticle`, `BackgroundNewsArticle`, `OpinionNewsArticle`, `ReportageNewsArticle`). 
  **Please note** that we no longer automatically add `NewsArticle` for every article automatically as you can now configure 
 all of that in the Content Types settings.

## Relevant technical choices:

* Needs https://github.com/Yoast/wordpress-seo/pull/17479 to work.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test in conjunction with https://github.com/Yoast/wordpress-seo/pull/17479
* The Schema article dropdown on post pages should have extra added `News:` article types, and this should propagate through to the frontend.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes PRODUCT-166
