### PR TITLE
DUPP-61 Remove code hooking into the deprecated `wpseo_schema_article_post_types` filter

### DIFF
--- a/classes/schema.php
+++ b/classes/schema.php
@@ -30,25 +30,7 @@ class WPSEO_News_Schema {
 		add_filter( 'wpseo_schema_article_types', [ $this, 'schema_add_news_types' ] );
 		add_filter( 'wpseo_schema_article_types_labels', [ $this, 'schema_add_news_types_labels' ] );
 
-		add_filter( 'wpseo_schema_article_post_types', [ $this, 'article_post_types' ] );
 		add_filter( 'wpseo_schema_article', [ $this, 'add_copyright_information' ] );
-	}
-
-	/**
-	 * Make all News post types output Article schema.
-	 *
-	 * @param array $post_types Supported post types.
-	 *
-	 * @return array Supported post types.
-	 */
-	public function article_post_types( $post_types ) {
-		$post = $this->get_post();
-		// Alter the article post types only when the news article is not excluded.
-		if ( $post !== null && ! $this->is_post_excluded( $post ) ) {
-			$post_types = array_unique( array_merge( WPSEO_News::get_included_post_types(), $post_types ) );
-		}
-
-		return $post_types;
 	}
 
 	/**

--- a/integration-tests/schema-test.php
+++ b/integration-tests/schema-test.php
@@ -39,45 +39,6 @@ class WPSEO_News_Schema_Test extends WPSEO_News_UnitTestCase {
 	}
 
 	/**
-	 * Tests whether the article post types includes `post` by default.
-	 *
-	 * @covers WPSEO_News_Schema::article_post_types
-	 * @covers WPSEO_News_Schema::is_post_excluded
-	 */
-	public function test_article_post_types() {
-		$this->set_post_mock();
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'get_post' );
-
-		$actual = $this->default_mock->article_post_types( [] );
-
-		$this->assertSame( [ 'post' ], $actual );
-	}
-
-	/**
-	 * Tests whether the article post types does not add when the post is excluded through a term.
-	 *
-	 * @covers WPSEO_News_Schema::article_post_types
-	 * @covers WPSEO_News_Schema::is_post_excluded
-	 */
-	public function test_article_post_types_with_excluded_term() {
-		$this->set_post_mock();
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'get_post' );
-
-		$this->default_mock
-			->expects( $this->once() )
-			->method( 'is_post_excluded' )
-			->willReturn( true );
-
-		$actual = $this->default_mock->article_post_types( [] );
-
-		$this->assertSame( [], $actual );
-	}
-
-	/**
 	 * Tests the copyright information.
 	 *
 	 * @covers WPSEO_News_Schema::add_copyright_information


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* https://github.com/Yoast/wordpress-seo/pull/17549 has deprecated the `wpseo_schema_article_post_types` filter. We want to remove the code hooking into that to prevent any warning.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes function hooking into the deprecated `wpseo_schema_article_post_types` filter.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproduce the bug
* Install and activate Free 17.6-RC2
* Install and activate News SEO 13.1-RC1
* make sure you have `define( 'WP_DEBUG', true );` in your config
* visit `SEO` > `Search Appearance`, tab `Content types` and see that you can find such notice:
```
Deprecated: wpseo_schema_article_post_types is deprecated since version WPSEO 17.6 with no alternative available. Every post type supporting authors will automatically have the Article schema enabled. in /var/www/html/wp-includes/functions.php on line 5596 
```

#### Test the fix the bug
* Install and activate Free 17.6-RC2
* Install and activate this branch
* make sure you have `define( 'WP_DEBUG', true );` in your config
* visit `SEO` > `Search Appearance`, tab `Content types` and see that you can't find the above notice.
* visit `SEO` > `News` and enable some `Post Types to include in News Sitemap`.
   * make sure that you are choosing types supporting `author`, such as Posts, Pages, Web Stories...
* visit some item of the chosen types on the front end and inspect the schema
  * they should display the `Article` piece.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-61]


[DUPP-61]: https://yoast.atlassian.net/browse/DUPP-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ