### PR TITLE
DUPP-65 Update minimum required Free version to 17.6

### DIFF
--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -145,8 +145,8 @@ class WPSEO_News {
 			return false;
 		}
 
-		// At least 17.4-RC3, which enables the filtering of the Schema Article types.
-		if ( version_compare( $wordpress_seo_version, '17.4-RC3', '<' ) ) {
+		// At least 17.6-RC1, which adds object timestamps to indexables.
+		if ( version_compare( $wordpress_seo_version, '17.6-RC1', '<' ) ) {
 			add_action( 'all_admin_notices', [ $this, 'error_upgrade_wpseo' ] );
 
 			return false;

--- a/integration-tests/wpseo-news-test.php
+++ b/integration-tests/wpseo-news-test.php
@@ -55,11 +55,11 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 			[ false, false, '5.3', 'WordPress SEO is not installed.' ],
 			[ false, '8.1', '5.6', 'WordPress SEO is below the minimal required version.' ],
 			[ false, '16.9', '5.7', 'WordPress SEO is below the minimal required version.' ],
-			[ false, '17.4-RC2', '5.7', 'WordPress SEO is below the minimal required version.' ],
-			[ true, '17.4-RC3', '5.8', 'WordPress and WordPress SEO have the minimal required versions.' ],
-			[ true, '17.4-RC3', '5.7', 'WordPress and WordPress SEO have the minimal required versions.' ],
-			[ true, '17.4-RC3', '5.6', 'WordPress and WordPress SEO have the minimal required versions.' ],
-			[ true, '17.4', '5.8', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ false, '17.5', '5.7', 'WordPress SEO is below the minimal required version.' ],
+			[ true, '17.6-RC1', '5.8', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '17.6-RC1', '5.7', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '17.6-RC1', '5.6', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '17.6', '5.8', 'WordPress and WordPress SEO have the minimal required versions.' ],
 		];
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to update the minimum Free update version to 17.6

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the minimum required Yoast SEO version to 17.6

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test against  Free >= 17.6-RC1 to see that News SEO is available in the Sidebar under `SEO`
* Test against  Free < 17.6-RC1 to see that News SEO is not available  in the Sidebar under `SEO` and you get and admin notice saying "Please upgrade the Yoast SEO plugin to the latest version to allow the News SEO module to work."

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-65]

[DUPP-65]: https://yoast.atlassian.net/browse/DUPP-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ