### PR TITLE
[DUPP-67] Fix exclude join query

### DIFF
--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -312,15 +312,17 @@ class WPSEO_News_Sitemap {
 		$term_query = implode( ' OR ', $term_query );
 
 		return $query
-			->where_raw(
-				"NOT EXISTS (
-					SELECT *
+			->raw_join(
+				"LEFT OUTER JOIN (
+					SELECT tr.object_id, tt.term_id
 					FROM $wpdb->term_relationships AS tr
-					JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-					WHERE $term_query AND tr.object_id = i.object_id
+					LEFT OUTER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 				)",
+				"$term_query AND tr.object_id = i.object_id",
+				't',
 				$replacements
-			);
+			)
+			->where_null( 't.object_id' );
 	}
 
 	/**

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -293,7 +293,7 @@ class WPSEO_News_Sitemap {
 			if ( ! array_key_exists( $post_type, $excluded_terms_by_post_type ) ) {
 				$excluded_terms_by_post_type[ $post_type ] = [];
 			}
-			$excluded_terms_by_post_type[ $post_type ][] = $term_id;
+			$excluded_terms_by_post_type[ $post_type ][] = (int) $term_id;
 		}
 
 		$term_query = [];

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -307,7 +307,7 @@ class WPSEO_News_Sitemap {
 			$term_ids     = $excluded_terms_by_post_type[ $post_type ];
 			$replacements = array_merge( $replacements, [ $post_type ], $term_ids );
 			$placeholders = implode( ', ', array_fill( 0, count( $term_ids ), '%d' ) );
-			$term_query[] = "( object_sub_type = %s AND tt.term_id IN ( $placeholders ) )";
+			$term_query[] = "( object_sub_type = %s AND t.term_id IN ( $placeholders ) )";
 		}
 		$term_query = implode( ' OR ', $term_query );
 
@@ -318,7 +318,7 @@ class WPSEO_News_Sitemap {
 					FROM $wpdb->term_relationships AS tr
 					LEFT OUTER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 				)",
-				"$term_query AND tr.object_id = i.object_id",
+				"$term_query AND t.object_id = i.object_id",
 				't',
 				$replacements
 			)

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -297,13 +297,16 @@ class WPSEO_News_Sitemap {
 			$excluded_terms_by_post_type[ $post_type ][] = (int) $term_id;
 		}
 
-		$term_query = [];
+		$replacements = [];
+		$term_query   = [];
 		foreach ( $post_types as $post_type ) {
 			if ( ! array_key_exists( $post_type, $excluded_terms_by_post_type ) ) {
 				continue;
 			}
-			$term_ids_string = implode( ', ', $excluded_terms_by_post_type[ $post_type ] );
-			$term_query[]    = "( i.object_sub_type = '$post_type' AND tt.term_id IN ( $term_ids_string ) )";
+			$term_ids     = $excluded_terms_by_post_type[ $post_type ];
+			$replacements = array_merge( $replacements, [ $post_type ], $term_ids );
+			$placeholders = implode( ', ', array_fill( 0, count( $term_ids ), '%d' ) );
+			$term_query[] = "( object_sub_type = %s AND tt.term_id IN ( $placeholders ) )";
 		}
 		$term_query = implode( ' OR ', $term_query );
 
@@ -314,7 +317,8 @@ class WPSEO_News_Sitemap {
 					FROM $wpdb->term_relationships AS tr
 					JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 					WHERE $term_query
-				)"
+				)",
+				$replacements
 			);
 	}
 

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -265,6 +265,7 @@ class WPSEO_News_Sitemap {
 			->limit( $limit );
 
 		$query = $this->maybe_add_terms_query( $query, $post_types );
+
 		return $query->find_many();
 	}
 
@@ -312,11 +313,11 @@ class WPSEO_News_Sitemap {
 
 		return $query
 			->where_raw(
-				"i.object_id NOT IN (
-					SELECT DISTINCT tr.object_id
+				"NOT EXISTS (
+					SELECT *
 					FROM $wpdb->term_relationships AS tr
 					JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-					WHERE $term_query
+					WHERE $term_query AND tr.object_id = i.object_id
 				)",
 				$replacements
 			);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes DUPP-67 in a performant manner by joining on a virtual table composed of all excluded terms and then checking if that table has no matches.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where items with multiple terms would only be excluded if all terms were excluded rather than any term.

## Relevant technical choices:

* A join on a virtual table is used to avoid full table scans and dependent sub-queries.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See https://yoast.atlassian.net/browse/DUPP-67


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The news sitemaps

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/DUPP-67
