### PR TITLE
DUPP-73 Remove not indexed post types from sitemap

### DIFF
--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -81,6 +81,8 @@ class WPSEO_News_Admin_Page {
 	 * Generates the HTML for the post types which should be included in the sitemap.
 	 */
 	private function include_post_types() {
+		$post_type_helper = YoastSEO()->helpers->post_type;
+
 		// Post Types to include in News Sitemap.
 		echo '<h2>' . esc_html__( 'Post Types to include in News Sitemap', 'wordpress-seo-news' ) . '</h2>';
 		echo '<fieldset><legend class="screen-reader-text">' . esc_html__( 'Post Types to include:', 'wordpress-seo-news' ) . '</legend>';
@@ -88,7 +90,9 @@ class WPSEO_News_Admin_Page {
 		$post_types      = get_post_types( [ 'public' => true ], 'objects' );
 		$post_types_list = [];
 		foreach ( $post_types as $post_type ) {
-			$post_types_list[ $post_type->name ] = $post_type->labels->name . ' (' . $post_type->name . ')';
+			if ( ! $post_type_helper->is_excluded( $post_type->name ) ) {
+				$post_types_list[ $post_type->name ] = $post_type->labels->name . ' (' . $post_type->name . ')';
+			}
 		}
 
 		Yoast_Form::get_instance()->checkbox_list( 'news_sitemap_include_post_types', $post_types_list );

--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -90,7 +90,7 @@ class WPSEO_News_Admin_Page {
 		$post_types      = get_post_types( [ 'public' => true ], 'objects' );
 		$post_types_list = [];
 		foreach ( $post_types as $post_type ) {
-			if ( ! $post_type_helper->is_excluded( $post_type->name ) ) {
+			if ( ! $post_type_helper->is_excluded( $post_type->name ) && $post_type->name !== 'attachment' ) {
 				$post_types_list[ $post_type->name ] = $post_type->labels->name . ' (' . $post_type->name . ')';
 			}
 		}

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -5,7 +5,6 @@
  * @package WPSEO_News\XML_Sitemaps
  */
 
-use Yoast\WP\Lib\Model;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove attachments and non-indexed post types from the settings page.
* [See slack for reference](https://yoast.slack.com/archives/CGUL0LDQS/p1636463831028500). 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Excludes attachments and non-indexed post types from the possible post types to include in the News Sitemap.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO 17.6
* install and activate this branch
* install and activate Elementor
* visit `SEO` > `News SEO`
* check that under "Post Types to include in News Sitemap":
  * you can't see `Media (attachement)` anymore
  * you can see `Landing Pages (e-landing-page)` but not `My Templates (elementor_library)` since the latter don't  get indexables.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-73]


[DUPP-73]: https://yoast.atlassian.net/browse/DUPP-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ