### PR TITLE
DUPP-78 Fix bug in query

### DIFF
--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -317,7 +317,7 @@ class WPSEO_News_Sitemap {
 					FROM $wpdb->term_relationships AS tr
 					LEFT OUTER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 				)",
-				"$term_query AND t.object_id = i.object_id",
+				"( $term_query ) AND t.object_id = i.object_id",
 				't',
 				$replacements
 			)


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an un released bug where a sitemap might not include all the expected items when filtering by many terms.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO 17.6 RC4.
* Install and activate Yoast News SEO 13.0
* Install and activate Yoast Local 14.2-RC1.
* Install and activate Yoast Test Helper
* Enable post types & taxonomies in Yoast Test Helper
* Create several different post types/taxonomies/CPT(locations/books) and custom taxonomies
* Mark them as types to include in News Sitemap
* Mark some terms to be excluded from News sitemap.
* Check News sitemap xml and make a screenshot 
* Upgrade News SEO to 13.1 -RC5
* Check News sitemap xml after upgrading and compare with previous, they should be the same.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-78]


[DUPP-78]: https://yoast.atlassian.net/browse/DUPP-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ