### PR TITLE
Travis: fix integration test build on PHP >= 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,7 +181,8 @@ script:
       travis_time_finish && travis_fold end "PHP.integration-tests"
     elif [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.integration-tests" && travis_time_start
-      travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      travis_retry composer remove --dev yoast/wp-test-utils --ignore-platform-reqs --no-interaction &&
+      travis_retry composer require --dev yoast/wp-test-utils:"^1.0.0" phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       composer integration-test
       travis_time_finish && travis_fold end "PHP.integration-tests"
     fi


### PR DESCRIPTION
## Context


* Improve/fix CI

## Summary

This PR can be summarized in the following changelog entry:

* Improve/fix CI

## Relevant technical choices:

Composer 2.2 contains a a bug/over-optimization, which causes the install with changed, but compatible requirements to error out on "conflicting" requirements.

This commit puts a work-around for this in place.

It is recommended to revert this commit if/when the Composer bug has been fixed and a new version has been released.

Ref:
* Bug report: https://github.com/composer/composer/issues/10394
* Probable cause: https://github.com/composer/composer/pull/9620
* Similar fix in YoastSEO: https://github.com/Yoast/wordpress-seo/commit/b3999428193d5cdcdd0758dcb7dc060e6992c507


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.
