### PR TITLE
Composer: allow plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,10 @@
         },
         "preferred-install": {
             "yoast/wordpress-seo": "source"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION


## Context

* Composer 2.2 compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Composer 2.2 compatibility

## Relevant technical choices:

The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.
The `composer/installers` Composer plugin is used to install the plugin in the correct directory in a WordPress context.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution
