### PR TITLE
Travis: remove "fix integration test build on PHP >= 8.0"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,8 +181,7 @@ script:
       travis_time_finish && travis_fold end "PHP.integration-tests"
     elif [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.integration-tests" && travis_time_start
-      travis_retry composer remove --dev yoast/wp-test-utils --ignore-platform-reqs --no-interaction &&
-      travis_retry composer require --dev yoast/wp-test-utils:"^1.0.0" phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       composer integration-test
       travis_time_finish && travis_fold end "PHP.integration-tests"
     fi


### PR DESCRIPTION
## Context

* Simplify CI

## Summary

This PR can be summarized in the following changelog entry:

* Simplify CI

## Relevant technical choices:

Follow up on #731

This reverts commit 3a51b97ab6db8399c25da14c3ea18c2330a3d7ea.

Composer 2.2.3 has been released which contains a fix for the overly greedy optimization pass which was introduced in Composer 2.2.0.

With this fix in place, the previously introduced work-around for Composer 2.2 is no longer needed.

Refs:
* https://github.com/composer/composer/releases/tag/2.2.3
* https://github.com/composer/composer/issues/10394

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.
