### PR TITLE
PHP 8.1 | Tests: minor fix to work round WP native issue

### DIFF
--- a/integration-tests/admin-page-test.php
+++ b/integration-tests/admin-page-test.php
@@ -18,19 +18,43 @@ class WPSEO_News_Admin_Page_Test extends WPSEO_News_UnitTestCase {
 	private $instance;
 
 	/**
+	 * Original value of the $plugin_page global.
+	 *
+	 * @var string|null
+	 */
+	private $original_plugin_page;
+
+	/**
 	 * Setting up the instance of WPSEO_News_Admin_Page.
 	 */
 	public function set_up() {
 		parent::set_up();
 
 		// Because is a global $wpseo_admin_pages we have to fill this one with an instance of WPSEO_Admin_Pages.
-		global $wpseo_admin_pages;
+		// Similar for the WP native $plugin_page global.
+		global $wpseo_admin_pages, $plugin_page;
 
 		if ( empty( $wpseo_admin_pages ) ) {
 			$wpseo_admin_pages = new WPSEO_Admin_Pages();
 		}
 
+		// The $plugin_page variable needs to be set, the value is actually not really relevant for our purposes.
+		$this->original_plugin_page = $plugin_page;
+		$plugin_page                = 'wpseo_news';
+
 		$this->instance = new WPSEO_News_Admin_Page();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		// Reset the value of $plugin_page.
+		global $plugin_page;
+		$plugin_page = $this->original_plugin_page;
+		unset( $this->original_plugin_page );
+
+		parent::tear_down();
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Compatibility with PHP 8.1/WP 5.9

## Summary

This PR can be summarized in the following changelog entry:

* Compatibility with PHP 8.1/WP 5.9

## Relevant technical choices:

Tests: minor fix to work round WP native issue with a not-as-yet-fixed PHP 8.1 deprecation notice.

If the `$plugin_page` is not set, WP will generate a `preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated` deprecation notice as of PHP 8.1.

By "mocking" the value of the `$plugin_page`, we get round that.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The issue (test errroing out) can be seen when running the integration tests against PHP 8.1 and will be gone with this fix in place.