### PR TITLE
Remove and deprecate sitemap caching logic

### DIFF
--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -35,10 +35,6 @@ class WPSEO_News_Sitemap {
 		$this->date = new WPSEO_Date_Helper();
 
 		add_action( 'init', [ $this, 'init' ], 10 );
-
-		add_action( 'save_post', [ $this, 'invalidate_sitemap' ] );
-
-		add_action( 'wpseo_news_schedule_sitemap_clear', 'yoast_wpseo_news_clear_sitemap_cache' );
 	}
 
 	/**
@@ -77,8 +73,6 @@ class WPSEO_News_Sitemap {
 		if ( isset( $GLOBALS['wpseo_sitemaps'] ) ) {
 			add_filter( 'wpseo_sitemap_index', [ $this, 'add_to_index' ] );
 
-			$this->yoast_wpseo_news_schedule_clear();
-
 			// We might consider deprecating/removing this, because we are using a static xsl file.
 			$GLOBALS['wpseo_sitemaps']->register_sitemap( $this->basename, [ $this, 'build' ] );
 			if ( method_exists( $GLOBALS['wpseo_sitemaps'], 'register_xsl' ) ) {
@@ -94,30 +88,6 @@ class WPSEO_News_Sitemap {
 				);
 			}
 		}
-	}
-
-	/**
-	 * Method to invalidate the sitemap.
-	 *
-	 * @param int $post_id Post ID to invalidate for.
-	 */
-	public function invalidate_sitemap( $post_id ) {
-		// If this is just a revision, don't invalidate the sitemap cache yet.
-		if ( wp_is_post_revision( $post_id ) ) {
-			return;
-		}
-
-		// Bail if this is a multisite installation and the site has been switched.
-		if ( is_multisite() && ms_is_switched() ) {
-			return;
-		}
-
-		// Only invalidate when we are in a News Post Type object.
-		if ( ! in_array( get_post_type( $post_id ), WPSEO_News::get_included_post_types(), true ) ) {
-			return;
-		}
-
-		WPSEO_Sitemaps_Cache::invalidate( $this->basename );
 	}
 
 	/**
@@ -197,19 +167,6 @@ class WPSEO_News_Sitemap {
 		// phpcs:enable
 
 		die();
-	}
-
-	/**
-	 * Clear the sitemap and sitemap index every hour to make sure the sitemap is hidden or shown when it needs to be.
-	 *
-	 * @return void
-	 */
-	private function yoast_wpseo_news_schedule_clear() {
-		$schedule = wp_get_schedule( 'wpseo_news_schedule_sitemap_clear' );
-
-		if ( empty( $schedule ) ) {
-			wp_schedule_event( time(), 'hourly', 'wpseo_news_schedule_sitemap_clear' );
-		}
 	}
 
 	/**

--- a/wpseo-news.php
+++ b/wpseo-news.php
@@ -67,6 +67,7 @@ add_action( 'plugins_loaded', '__wpseo_news_main' );
  * Clear the news sitemap.
  */
 function yoast_wpseo_news_clear_sitemap_cache() {
+	_deprecated_function( __METHOD__, "13.2" );
 	if ( class_exists( 'WPSEO_Sitemaps_Cache' ) && method_exists( 'WPSEO_Sitemaps_Cache', 'clear' ) ) {
 		WPSEO_Sitemaps_Cache::clear( [ WPSEO_News_Sitemap::get_sitemap_name() ] );
 	}
@@ -80,14 +81,4 @@ function yoast_wpseo_news_activate() {
 	if ( class_exists( 'WPSEO_Options' ) && method_exists( 'WPSEO_Options', 'set' ) ) {
 		WPSEO_Options::set( 'tracking', true );
 	}
-
-	yoast_wpseo_news_clear_sitemap_cache();
 }
-
-/**
- * Clear the news sitemap when we activate the plugin.
- */
-function yoast_wpseo_news_deactivate() {
-	yoast_wpseo_news_clear_sitemap_cache();
-}
-


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* With the indexable sitemaps in free, the sitemap caching, which was always disabled, deprecated removed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensure compatibility with Yoast SEO 18.1

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install the feature/indexable-sitemap branch of Yoast SEO free.
- Create and publish a new post
- This should not throw a fatal error nor should it show deprecation warnings.
- The post you updated is now visible in the sitemaps.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
