### PR TITLE
Dupp 253 fix deprecation warnings news

### DIFF
--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -56,7 +56,8 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 		}
 
 		// Load the editor script when on an elementor edit page.
-		$get_action             = filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING );
+        $raw_input              = filter_input( INPUT_GET, 'action' );
+		$get_action             = $raw_input === null ? null : htmlspecialchars( $raw_input );
 		$is_elementor_edit_page = $pagenow === 'post.php' && $get_action === 'elementor';
 		if ( $is_elementor_edit_page ) {
 			add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_scripts' ] );

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -56,7 +56,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 		}
 
 		// Load the editor script when on an elementor edit page.
-        $raw_input              = filter_input( INPUT_GET, 'action' );
+		$raw_input              = filter_input( INPUT_GET, 'action' );
 		$get_action             = $raw_input === null ? null : htmlspecialchars( $raw_input );
 		$is_elementor_edit_page = $pagenow === 'post.php' && $get_action === 'elementor';
 		if ( $is_elementor_edit_page ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* php 8.* deprecates some of the features used to develop wpseo-news: this results in deprecation warnings in web server logs or other tool such as the Query Monitor plugin

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove deprecated FILTER_SANITIZE_STRING filter and call htmlspecialchars() instead

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Install and activate WordPress 5.9 with php 8.1.
2. Install and activate Query Monitor
3. Install and activate Yoast SEO Free and News 13.1
4. Open the Query Monitor bottom tab
5. Select "PHP errors" from the tab's sidebar and choose "Deprecated" from the "Message" drop-down
6. Verify no message such as _Constant FILTER_SANITIZE_STRING is deprecated_ is listed with Location set to _wp-content/plugins/wpseo-news/classes/meta-box.php_


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
