### PR TITLE
Set minimum WP version to 5.8 and tested up to to 5.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     - php: 7.2
       env: WP_VERSION=latest WP_MULTISITE=1 PHPCS=1 SECURITY=1 COVERAGE=1
     - php: 5.6
-      env: WP_VERSION=5.6 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
+      env: WP_VERSION=5.8 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
       dist: trusty
     - php: 7.4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Yoast News SEO for Yoast SEO
 ==========================
-Requires at least: 5.6
+Requires at least: 5.8
 Tested up to: 5.9
 Stable tag: 13.1
 Requires PHP: 5.6.20

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -130,7 +130,7 @@ class WPSEO_News {
 	 */
 	protected function check_dependencies( $wp_version ) {
 		// When WordPress function is too low.
-		if ( version_compare( $wp_version, '5.6', '<' ) ) {
+		if ( version_compare( $wp_version, '5.8', '<' ) ) {
 			add_action( 'all_admin_notices', [ $this, 'error_upgrade_wp' ] );
 
 			return false;

--- a/integration-tests/wpseo-news-test.php
+++ b/integration-tests/wpseo-news-test.php
@@ -53,12 +53,11 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 			[ false, '12.7', '3.0', 'WordPress is below the minimal required version.' ],
 			[ false, '12.7', '5.5', 'WordPress is below the minimal required version.' ],
 			[ false, false, '5.3', 'WordPress SEO is not installed.' ],
-			[ false, '8.1', '5.6', 'WordPress SEO is below the minimal required version.' ],
-			[ false, '16.9', '5.7', 'WordPress SEO is below the minimal required version.' ],
-			[ false, '17.5', '5.7', 'WordPress SEO is below the minimal required version.' ],
+			[ false, '8.1', '5.8', 'WordPress SEO is below the minimal required version.' ],
+			[ false, '16.9', '5.8', 'WordPress SEO is below the minimal required version.' ],
+			[ false, '17.5', '5.8', 'WordPress SEO is below the minimal required version.' ],
 			[ true, '17.6-RC1', '5.9', 'WordPress and WordPress SEO have the minimal required versions.' ],
-			[ true, '17.6-RC1', '5.7', 'WordPress and WordPress SEO have the minimal required versions.' ],
-			[ true, '17.6-RC1', '5.6', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '17.6-RC1', '5.8', 'WordPress and WordPress SEO have the minimal required versions.' ],
 			[ true, '17.6', '5.8', 'WordPress and WordPress SEO have the minimal required versions.' ],
 		];
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On January 25, 2022, WordPress 5.9 was released. We've decided to go back to supporting only the latest 2 WP versions.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets minimum required WordPress version to 5.8.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have WordPress 5.7 or lower installed. Be unable to update.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
