### PR TITLE
Fix reserved keywords used as parameters names

### DIFF
--- a/integration-tests/framework/unittestcase.php
+++ b/integration-tests/framework/unittestcase.php
@@ -15,18 +15,18 @@ abstract class WPSEO_News_UnitTestCase extends TestCase {
 	/**
 	 * Call protected/private method of a class.
 	 *
-	 * @param object $object      Instantiated object that we will run method on.
-	 * @param string $method_name Method name to call.
-	 * @param array  $parameters  Array of parameters to pass into method.
+	 * @param object $target_object      Instantiated object that we will run method on.
+	 * @param string $method_name        Method name to call.
+	 * @param array  $parameters         Array of parameters to pass into method.
 	 *
 	 * @return mixed Method return.
 	 */
-	public function invoke_method( &$object, $method_name, array $parameters = [] ) {
-		$reflection = new ReflectionClass( get_class( $object ) );
+	public function invoke_method( &$target_object, $method_name, array $parameters = [] ) {
+		$reflection = new ReflectionClass( get_class( $target_object ) );
 		$method     = $reflection->getMethod( $method_name );
 
 		$method->setAccessible( true );
 
-		return $method->invokeArgs( $object, $parameters );
+		return $method->invokeArgs( $target_object, $parameters );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For php8 compatibility we should avoid using reserved parameter names.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids usage of the reserved keywords (_object_ in this case) as parameters names

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

The changes should all be internal to methods, so no behaviour should be affected. For clarity, the areas touched are:
    * Integration tests

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [DUPP-341]


[DUPP-341]: https://yoast.atlassian.net/browse/DUPP-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ