### PR TITLE
Remove our yoast i18n composer dependency

### DIFF
--- a/classes/admin-page.php
+++ b/classes/admin-page.php
@@ -11,15 +11,6 @@
 class WPSEO_News_Admin_Page {
 
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		if ( $this->is_news_page( filter_input( INPUT_GET, 'page' ) ) ) {
-			$this->register_i18n_promo_class();
-		}
-	}
-
-	/**
 	 * Display admin page.
 	 */
 	public function display() {
@@ -55,26 +46,6 @@ class WPSEO_News_Admin_Page {
 
 		// Admin footer.
 		Yoast_Form::get_instance()->admin_footer( true, false );
-	}
-
-	/**
-	 * Register the promotion class for our GlotPress instance.
-	 *
-	 * @link https://github.com/Yoast/i18n-module
-	 */
-	protected function register_i18n_promo_class() {
-		new Yoast_I18n_v3(
-			[
-				'textdomain'     => 'wordpress_seo_news',
-				'project_slug'   => 'news-seo',
-				'plugin_name'    => 'WordPress SEO News',
-				'hook'           => 'wpseo_admin_promo_footer',
-				'glotpress_url'  => 'https://translate.yoast.com/gp/',
-				'glotpress_name' => 'Yoast Translate',
-				'glotpress_logo' => 'https://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',
-				'register_url'   => 'https://translate.yoast.com/register/#utm_source=plugin&utm_medium=promo-box&utm_campaign=wpseo-news-i18n-promo',
-			]
-		);
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
     },
     "require": {
         "php": ">=5.6",
-        "composer/installers": "^1.12.0",
-        "yoast/i18n-module": "^3.1.1"
+        "composer/installers": "^1.12.0"
     },
     "require-dev": {
         "yoast/yoastcs": "^2.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dccca502a4cab819c22530de9d11c258",
+    "content-hash": "7f779c1fd9d92112ea2bad165014b784",
     "packages": [
         {
             "name": "composer/installers",
@@ -2646,16 +2646,16 @@
         },
         {
             "name": "yoast/wp-test-utils",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wp-test-utils.git",
-                "reference": "f319edb9c074d2c23f83005e66a86c9441c5040f"
+                "reference": "f955f6a6bd8c625f3ae47b2c19fff1caa648896a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/f319edb9c074d2c23f83005e66a86c9441c5040f",
-                "reference": "f319edb9c074d2c23f83005e66a86c9441c5040f",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/f955f6a6bd8c625f3ae47b2c19fff1caa648896a",
+                "reference": "f955f6a6bd8c625f3ae47b2c19fff1caa648896a",
                 "shasum": ""
             },
             "require": {
@@ -2711,7 +2711,7 @@
                 "issues": "https://github.com/Yoast/wp-test-utils/issues",
                 "source": "https://github.com/Yoast/wp-test-utils"
             },
-            "time": "2022-11-16T23:23:15+00:00"
+            "time": "2022-11-17T14:06:19+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/composer.lock
+++ b/composer.lock
@@ -2495,12 +2495,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wordpress-seo.git",
-                "reference": "b5f80c647065bd4b59b870b4e8ed23d19176b97c"
+                "reference": "eaa7ba1bb5f45120ea395dfd1ecfd095d101c998"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wordpress-seo/zipball/b5f80c647065bd4b59b870b4e8ed23d19176b97c",
-                "reference": "b5f80c647065bd4b59b870b4e8ed23d19176b97c",
+                "url": "https://api.github.com/repos/Yoast/wordpress-seo/zipball/eaa7ba1bb5f45120ea395dfd1ecfd095d101c998",
+                "reference": "eaa7ba1bb5f45120ea395dfd1ecfd095d101c998",
                 "shasum": ""
             },
             "require": {
@@ -2521,8 +2521,7 @@
                 "symfony/polyfill-php70": "1.19.0",
                 "symfony/polyfill-php72": "1.19.0",
                 "wordproof/wordpress-sdk": "1.3.2",
-                "yoast/php-development-environment": "^1.0",
-                "yoast/wp-test-utils": "^1.0.0",
+                "yoast/wp-test-utils": "^1.1.1",
                 "yoast/yoastcs": "^2.2.1"
             },
             "default-branch": true,
@@ -2643,7 +2642,7 @@
                 "wiki": "https://github.com/Yoast/wordpress-seo/wiki",
                 "source": "https://github.com/Yoast/wordpress-seo"
             },
-            "time": "2022-11-17T14:23:00+00:00"
+            "time": "2022-11-21T17:35:58+00:00"
         },
         {
             "name": "yoast/wp-test-utils",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b77c911762678ab076ab36bcf5a43ba",
+    "content-hash": "dccca502a4cab819c22530de9d11c258",
     "packages": [
         {
             "name": "composer/installers",
@@ -156,55 +156,6 @@
                 }
             ],
             "time": "2021-09-13T08:19:44+00:00"
-        },
-        {
-            "name": "yoast/i18n-module",
-            "version": "3.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Yoast/i18n-module.git",
-                "reference": "9d0a2f6daea6fb42376b023e7778294d19edd85d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/i18n-module/zipball/9d0a2f6daea6fb42376b023e7778294d19edd85d",
-                "reference": "9d0a2f6daea6fb42376b023e7778294d19edd85d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "roave/security-advisories": "dev-master",
-                "yoast/yoastcs": "^1.2.2"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Team Yoast",
-                    "email": "support@yoast.com",
-                    "homepage": "https://yoast.com"
-                }
-            ],
-            "description": "Handle i18n for WordPress plugins.",
-            "homepage": "https://github.com/Yoast/i18n-module",
-            "keywords": [
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/Yoast/i18n-module/issues",
-                "source": "https://github.com/Yoast/i18n-module"
-            },
-            "time": "2019-05-07T06:45:05+00:00"
         }
     ],
     "packages-dev": [
@@ -2544,18 +2495,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wordpress-seo.git",
-                "reference": "865229f06cc04ca62e69629f7f8b5f000ef308c1"
+                "reference": "b5f80c647065bd4b59b870b4e8ed23d19176b97c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wordpress-seo/zipball/865229f06cc04ca62e69629f7f8b5f000ef308c1",
-                "reference": "865229f06cc04ca62e69629f7f8b5f000ef308c1",
+                "url": "https://api.github.com/repos/Yoast/wordpress-seo/zipball/b5f80c647065bd4b59b870b4e8ed23d19176b97c",
+                "reference": "b5f80c647065bd4b59b870b4e8ed23d19176b97c",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "^1.12 || ^2.0",
-                "php": "^5.6.20 || ^7.0 || ^8.0",
-                "yoast/i18n-module": "^3.1.1"
+                "php": "^5.6.20 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "6.5.8",
@@ -2693,7 +2643,7 @@
                 "wiki": "https://github.com/Yoast/wordpress-seo/wiki",
                 "source": "https://github.com/Yoast/wordpress-seo"
             },
-            "time": "2022-01-28T10:12:06+00:00"
+            "time": "2022-11-17T14:23:00+00:00"
         },
         {
             "name": "yoast/wp-test-utils",

--- a/tests/googlebot-news-presenter-test.php
+++ b/tests/googlebot-news-presenter-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\News\Tests;
 
 use Brain\Monkey;
+use Brain\Monkey\Functions;
 use Mockery;
 use Mockery\MockInterface;
 use WPSEO_News_Googlebot_News_Presenter;
@@ -134,6 +135,9 @@ class Googlebot_News_Presenter_Test extends TestCase {
 
 		Monkey\Filters\expectApplied( 'Yoast\WP\News\head_display_noindex' )
 			->andReturn( true );
+
+		Functions\expect( 'is_admin_bar_showing' )
+			->andReturn( false );
 
 		$this->assertSame( '<meta name="Googlebot-News" content="noindex" />', $this->instance->present() );
 	}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removed the Translation "nag" from the plugin.

