### PR TITLE
Adding filter so custom entries can be added to the news sitemap.

### DIFF
--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -160,6 +160,13 @@ class WPSEO_News_Sitemap {
 			$output .= $this->build_items( $items );
 		}
 
+		/**
+		 * Filter to add extra entries to the news sitemap.
+		 *
+		 * @param string $content String content to add, defaults to empty.
+		 */
+		$output .= apply_filters( 'wpseo_news_sitemap_content', '' );
+
 		$output .= '</urlset>';
 
 		$total_time = ( \microtime( true ) - $start_time );


### PR DESCRIPTION
## Context

* We want to add a filter to allow users to append custom content to `Yoast SEO News` XML sitemap.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a `wpseo_news_sitemap_content` filter to append custom content to the XML sitemap. Props to @wccoder.

## Relevant technical choices:

* N/A

## Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
**Preliminary steps**
* In your theme's `functions.php` add the following lines:
  ```
   function add_sitemap_news_content($content = '') {
      return "<!-- Added by custom hook -->\n";
   }
   add_filter('wpseo_news_sitemap_content', 'add_sitemap_news_content');
  ```
* Go to `Yoast SEO` -> `Settings`
* In `Site features` make sure you have `XML sitemaps` feature active
* Go to `Yoast SEO` -> `News SEO`
* Make sure `Posts` checkbox is selected under `Post types to include in News sitemap`
* Create a new post and publish it

---

* Go to `Yoast SEO` -> `News SEO`
* Click on `View your News Sitemap` and verify that
  * the sitemaps renders correctly
  * no errors are displayed in the browser's console
* Inspect the sitemap page source code and verify the string `<!-- Added by custom hook -->` is present before `</urlset>` closing tag


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No additional plugin part should be tested.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
