### PR TITLE
Set minimum WP version to 6.0

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - php_version: '5.6'
-            wp_version: '5.9'
+            wp_version: '6.0'
             multisite: true
 
           - php_version: '7.0'
@@ -39,12 +39,12 @@ jobs:
             multisite: true
 
           - php_version: '7.4'
-            wp_version: '5.9'
+            wp_version: '6.0'
             multisite: false
 
           # WP 5.6 is the earliest version which (sort of) supports PHP 8.0.
           - php_version: '8.0'
-            wp_version: '5.9'
+            wp_version: '6.0'
             multisite: false
 
           # WP 5.9 is the earliest version which (sort of) supports PHP 8.1.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Yoast News SEO for Yoast SEO
 ==========================
-Requires at least: 5.9
+Requires at least: 6.0
 Tested up to: 6.1
 Stable tag: 13.1
 Requires PHP: 5.6.20

--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -130,7 +130,7 @@ class WPSEO_News {
 	 */
 	protected function check_dependencies( $wp_version ) {
 		// When WordPress function is too low.
-		if ( version_compare( $wp_version, '5.9', '<' ) ) {
+		if ( version_compare( $wp_version, '6.0', '<' ) ) {
 			add_action( 'all_admin_notices', [ $this, 'error_upgrade_wp' ] );
 
 			return false;

--- a/integration-tests/wpseo-news-test.php
+++ b/integration-tests/wpseo-news-test.php
@@ -53,12 +53,12 @@ class WPSEO_News_Test extends WPSEO_News_UnitTestCase {
 			[ false, '12.7', '3.0', 'WordPress is below the minimal required version.' ],
 			[ false, '12.7', '5.8', 'WordPress is below the minimal required version.' ],
 			[ false, false, '5.3', 'WordPress SEO is not installed.' ],
-			[ false, '8.1', '5.9', 'WordPress SEO is below the minimal required version.' ],
-			[ false, '16.9', '5.9', 'WordPress SEO is below the minimal required version.' ],
-			[ false, '17.5', '5.9', 'WordPress SEO is below the minimal required version.' ],
+			[ false, '8.1', '6.0', 'WordPress SEO is below the minimal required version.' ],
+			[ false, '16.9', '6.0', 'WordPress SEO is below the minimal required version.' ],
+			[ false, '17.5', '6.0', 'WordPress SEO is below the minimal required version.' ],
 			[ true, '17.6-RC1', '6.1', 'WordPress and WordPress SEO have the minimal required versions.' ],
-			[ true, '17.6-RC1', '5.9', 'WordPress and WordPress SEO have the minimal required versions.' ],
-			[ true, '17.6', '5.9', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '17.6-RC1', '6.0', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '17.6', '6.0', 'WordPress and WordPress SEO have the minimal required versions.' ],
 		];
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Sets minimum WordPress version to 6.0.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets minimum WordPress version to 6.0.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
