### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -58,7 +58,7 @@ jobs:
       # @link https://github.com/staabm/annotate-pull-request-from-checkstyle/
       - name: Check PHP code style
         id: phpcs
-        run: composer check-cs -- --report-full --report-checkstyle=./phpcs-report.xml
+        run: composer check-cs -- --no-cache --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       # Check the codestyle of the files.
       # The results of the CS check will be shown inline in the PR via the CS2PR tool.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Debug info: show directory layout"
         run: tree -dC .

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -105,8 +105,8 @@ jobs:
           dependency-versions: "highest"
           # But make it selective.
           composer-options: "yoast/wp-test-utils --with-dependencies"
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       # Update YoastSEO as a separate step so the caches will be reasonably stable.
       # This also prevents potentially updating dependencies of YoastSEO due to the above

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors
         run: composer lint -- --checkstyle | cs2pr

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -64,8 +64,8 @@ jobs:
           dependency-versions: "highest"
           # But make it selective.
           composer-options: "yoast/wp-test-utils --with-dependencies"
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Run unit tests
         run: composer test


### PR DESCRIPTION
## Context

* CI maintenance

## Summary

This PR can be summarized in the following changelog entry:

* CI maintenance

## Relevant technical choices:

### GH Actions: minor simplification

... of the bash `date` command in the earlier pulled cache busting.

### GH Actions: improve performance of the CS step

All the repos in the Yoast organisation contain a `<arg name="cache" value="./.cache/phpcs.cache"/>` directive in the PHPCS ruleset.
This directive makes running PHPCS faster by caching the run results in a file and only scanning changed files when running PHPCS again.

However, when there is no cache available, running with the `cache` option enabled will make PHPCS _slower_ as the cache needs to be created and the file read/write actions slow PHPCS down.

In GH Actions, we are not caching the PHPCS `cache` file, which means that there is cache file available and running with `cache` will be slower.

By adding the `--no-cache` option, the `cache` directive in the ruleset is ignored, which should result in a slightly faster runtime for the CS workflow.

Note: the alternative would be to _cache_ the cache file in GH Actions, but aside from the two very frequently changing repos, there's not much point doing that.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_