### PR TITLE
CS/QA: various tweaks

### DIFF
--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -354,10 +354,11 @@ class WPSEO_News_Sitemap {
 	private function build_publication_tag() {
 		$publication_name = WPSEO_Options::get( 'news_sitemap_name', get_bloginfo( 'name' ) );
 		$publication_lang = $this->get_publication_lang();
+		$charset          = get_bloginfo( 'charset' );
 
 		$publication_tag  = "\t\t<news:publication>\n";
-		$publication_tag .= "\t\t\t<news:name>" . \htmlspecialchars( $publication_name ) . '</news:name>' . "\n";
-		$publication_tag .= "\t\t\t<news:language>" . htmlspecialchars( $publication_lang, ENT_COMPAT, get_bloginfo( 'charset' ), false ) . '</news:language>' . "\n";
+		$publication_tag .= "\t\t\t<news:name>" . \htmlspecialchars( $publication_name, ENT_COMPAT, $charset, false ) . '</news:name>' . "\n";
+		$publication_tag .= "\t\t\t<news:language>" . htmlspecialchars( $publication_lang, ENT_COMPAT, $charset, false ) . '</news:language>' . "\n";
 		$publication_tag .= "\t\t</news:publication>\n";
 
 		return $publication_tag;

--- a/tests/news-test.php
+++ b/tests/news-test.php
@@ -4,8 +4,8 @@ namespace Yoast\WP\News\Tests;
 
 use Brain\Monkey\Functions;
 use Mockery;
-use WPSEO_Options;
 use WPSEO_News;
+use WPSEO_Options;
 
 /**
  * Test the WPSEO_News class.


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* [Sitemaps] Minor improvement for sites not using `utf-8` character encoding

## Relevant technical choices:

### CS: minor tweak

* Alphabetically sort `use` statements.

### PHP Compat: pass parameters for which the default value has changed

* The default value of the `$flags` parameter has changed in PHP 8.1. Passing the value explicitly will ensure that the resulting escaped value will be the same PHP cross-version.
* Passing the `$encoding` parameter is also important as not all WP sites use `utf-8` as the character encoding.
* Lastly, we want to prevent the value from being double encoded, so `$double_encode` should be set to `false`.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On a site not using `utf-8` char encoding, the site name in the sitemap will now have a smaller chance of getting mangled.