### PR TITLE
Fix activation warning

### DIFF
--- a/classes/wpseo-news.php
+++ b/classes/wpseo-news.php
@@ -52,10 +52,6 @@ class WPSEO_News {
 
 		// Schema.
 		new WPSEO_News_Schema();
-
-		if ( is_admin() ) {
-			$this->init_admin();
-		}
 	}
 
 	/**
@@ -66,6 +62,7 @@ class WPSEO_News {
 		add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_pages' ] );
 		add_action( 'init', [ 'WPSEO_News_Option', 'register_option' ] );
 		add_action( 'init', [ 'WPSEO_News', 'read_options' ] );
+		add_action( 'admin_init', [ $this, 'init_admin' ] );
 
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
@@ -105,7 +102,7 @@ class WPSEO_News {
 	/**
 	 * Initialize the admin page.
 	 */
-	private function init_admin() {
+	public function init_admin() {
 		// Upgrade Manager.
 		$upgrade_manager = new WPSEO_News_Upgrade_Manager();
 		$upgrade_manager->check_update();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,16 @@
 
 define( 'WPSEO_INDEXABLES', true );
 define( 'WPSEO_NEWS_VERSION', '12.6' );
+define( 'WPSEO_VERSION', '17.6' );
+define( 'YOAST_SEO_NEWS_WP_REQUIRED', '6.1' );
+
+if ( ! defined( 'WPSEO_PATH' ) ) {
+	define( 'WPSEO_PATH', dirname( dirname( __DIR__ ) ) . '/' );
+}
+
+if ( ! defined( 'WPSEO_FILE' ) ) {
+	define( 'WPSEO_FILE', WPSEO_PATH . 'wp-seo.php' );
+}
 
 if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;

--- a/tests/news-test.php
+++ b/tests/news-test.php
@@ -44,7 +44,7 @@ class News_Test extends TestCase {
 	public function test_construct() {
 		$this->assertNotFalse( Filters\has( 'plugin_action_links', [ $this->instance, 'plugin_links' ] ) );
 		$this->assertNotFalse( Filters\has( 'wpseo_submenu_pages', [ $this->instance, 'add_submenu_pages' ] ) );
-		$this->assertNotFalse( Actions\has('init', [ 'WPSEO_News_Option', 'register_option' ] ) );
+		$this->assertNotFalse( Actions\has( 'init', [ 'WPSEO_News_Option', 'register_option' ] ) );
 		$this->assertNotFalse( Actions\has( 'init', [ 'WPSEO_News', 'read_options' ] ) );
 		$this->assertNotFalse( Actions\has( 'admin_init', [ $this->instance, 'init_admin' ] ) );
 

--- a/tests/news-test.php
+++ b/tests/news-test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\News\Tests;
 
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
 use WPSEO_News;
@@ -11,6 +13,46 @@ use WPSEO_Options;
  * Test the WPSEO_News class.
  */
 class News_Test extends TestCase {
+
+	/**
+	 * The instance.
+	 *
+	 * @var WPSEO_News
+	 */
+	protected $instance;
+
+	/**
+	 * Sets the instance.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $wp_version;
+		$wp_version = YOAST_SEO_NEWS_WP_REQUIRED;
+
+		$this->instance = new WPSEO_News();
+	}
+
+	/**
+	 * Tests the retrieval of included post types.
+	 *
+	 * @covers WPSEO_News::__construct
+	 * @covers WPSEO_News::set_hooks
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_construct() {
+		$this->assertNotFalse( Filters\has( 'plugin_action_links', [ $this->instance, 'plugin_links' ] ) );
+		$this->assertNotFalse( Filters\has( 'wpseo_submenu_pages', [ $this->instance, 'add_submenu_pages' ] ) );
+		$this->assertNotFalse( Actions\has('init', [ 'WPSEO_News_Option', 'register_option' ] ) );
+		$this->assertNotFalse( Actions\has( 'init', [ 'WPSEO_News', 'read_options' ] ) );
+		$this->assertNotFalse( Actions\has( 'admin_init', [ $this->instance, 'init_admin' ] ) );
+
+		$this->assertNotFalse( Filters\has( 'wpseo_enable_tracking', '__return_true' ) );
+		$this->assertNotFalse( Filters\has( 'wpseo_helpscout_beacon_settings', [ $this->instance, 'filter_helpscout_beacon' ] ) );
+
+		$this->assertNotFalse( Filters\has( 'wpseo_frontend_presenters', [ $this->instance, 'add_frontend_presenter' ] ) );
+	}
 
 	/**
 	 * Tests the retrieval of included post types.

--- a/tests/news-test.php
+++ b/tests/news-test.php
@@ -28,6 +28,7 @@ class News_Test extends TestCase {
 		parent::set_up();
 
 		global $wp_version;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- intended, to be able to test the constructor.
 		$wp_version = YOAST_SEO_NEWS_WP_REQUIRED;
 
 		$this->instance = new WPSEO_News();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a warning would be thrown on activation.

## Relevant technical choices:

* The root cause of the problem was that we run the upgrade manager on the constructor of `WPSEO_News`, while the class initializes the options on the `init` hook. I moved the upgrade manager to the `admin_init` hook which fires after `init` so the options will be there when needed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* make sure you are in a clean environment where News have never been run. If not, deleting `wpseo_news` from the `wp_option` table should be enough.
* install and activate Query Monitor
* install and activate Yoast SEO
* install and activate News SEO
* without this patch:
  * you should see a couple of warnings in Query monitor `Trying to access array offset on value of type bool`
* with this patch:
  * you shouldn't see any such warning
  

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

Also test in case of an upgrade from a previous version, ideally:
* install the latest released version (you will see the warnings)
* set some options in Yoast SEO -> News SEO and save
* update to this RC (you should not get any warnings as above)
* check that the options are the same, and there are no regressions

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #805
