### PR TITLE
815 news seo php 81 improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ gettext.pot
 # Temp
 ############
 /.tmp 
+
+.vscode/

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -56,8 +56,8 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 		}
 
 		// Load the editor script when on an elementor edit page.
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
-		$get_action             = filter_input( INPUT_GET, 'action', @FILTER_SANITIZE_STRING );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, not form data.
+		$get_action = ( isset( $_GET['action'] ) ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null;
 		$is_elementor_edit_page = $pagenow === 'post.php' && $get_action === 'elementor';
 		if ( $is_elementor_edit_page ) {
 			add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_scripts' ] );

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -57,7 +57,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 
 		// Load the editor script when on an elementor edit page.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, not form data.
-		$get_action = ( isset( $_GET['action'] ) ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null;
+		$get_action             = ( isset( $_GET['action'] ) ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null;
 		$is_elementor_edit_page = $pagenow === 'post.php' && $get_action === 'elementor';
 		if ( $is_elementor_edit_page ) {
 			add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_scripts' ] );

--- a/classes/meta-box.php
+++ b/classes/meta-box.php
@@ -106,12 +106,7 @@ class WPSEO_News_Meta_Box extends WPSEO_Metabox {
 	 * @return array
 	 */
 	public function save( $meta_boxes ) {
-		// When action is inline-save there is nothing to save for seo news.
-		if ( filter_input( INPUT_POST, 'action' ) !== 'inline-save' ) {
-			$meta_boxes = array_merge( $meta_boxes, $this->get_meta_boxes() );
-		}
-
-		return $meta_boxes;
+		return array_merge( $meta_boxes, $this->get_meta_boxes() );
 	}
 
 	/**

--- a/classes/sitemap.php
+++ b/classes/sitemap.php
@@ -181,8 +181,9 @@ class WPSEO_News_Sitemap {
 	 */
 	public function build_news_sitemap_xsl() {
 		$protocol = 'HTTP/1.1';
-		if ( filter_input( INPUT_SERVER, 'SERVER_PROTOCOL' ) !== '' ) {
-			$protocol = sanitize_text_field( filter_input( INPUT_SERVER, 'SERVER_PROTOCOL' ) );
+		
+		if ( isset($_SERVER['SERVER_PROTOCOL']) && is_string( $_SERVER['SERVER_PROTOCOL'] && $_SERVER['SERVER_PROTOCOL'] !== '' ) ) {
+			$protocol = sanitize_text_field( wp_unslash( $_SERVER['SERVER_PROTOCOL'] ) );
 		}
 		// Force a 200 header and replace other status codes.
 		header( $protocol . ' 200 OK', true, 200 );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Replace usage of `filter_input`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replace usage of `filter_input`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
